### PR TITLE
Gender pronoun fixes

### DIFF
--- a/docs/annexes/annex-2/annex-2-high-level-requirements.md
+++ b/docs/annexes/annex-2/annex-2-high-level-requirements.md
@@ -1450,7 +1450,7 @@ relies mostly on the approval of the User. It may happen that a User
 will not be able to correctly understand the request, that the Relying
 Party was confused with another one due to a similar name or a phishing
 attempt, and so forth. The User may realize only after presenting the
-attributes that it was taken from him unlawfully by over-asking, or even
+attributes that it was taken from them unlawfully by over-asking, or even
 by fraud.
 
 This topic explores high-level requirements related to the function of

--- a/docs/annexes/annex-3/annex-3.01-pid-rulebook.md
+++ b/docs/annexes/annex-3/annex-3.01-pid-rulebook.md
@@ -317,7 +317,7 @@ primarily to assist in, for example, automated form filling.
 
 The nationality or citizenship of the PID User is potentially a
 multi-valued attribute, because a citizen can have more than one
-nationality. However, his document defines an attribute nationality
+nationality. However, their document defines an attribute nationality
 taking as its value a single Alpha-2 country code. This implies that any
 additional nationality of the PID User must be added by the respective
 Member State as a domestic attribute, see [section 2.2.2](#222-domestic-pid-namespaces-for-national-attributes).


### PR DESCRIPTION
Consistent usage of ‘he/she’, ‘his/her’ and ‘him/her’.

Another option is to replace gendered pronouns with ‘they’, ‘their’ and ‘them’.