### PR TITLE
Trust Model reference fixes

### DIFF
--- a/docs/annexes/annex-06-pid-rulebook.md
+++ b/docs/annexes/annex-06-pid-rulebook.md
@@ -508,9 +508,8 @@ section 2.2.2) MAY be released in either a VP Token or an ID Token.
 
 ### 3.1 Introduction
 
-The Trust Model \[TrustModel\] introduces the concept of a Wallet
-Instance Attestation issued by the Wallet Provider for each Wallet
-Instance.
+\[ARF\] introduces the concept of a Wallet Instance Attestation issued 
+by the Wallet Provider for each Wallet Instance.
 
 ### 3.2 Document type and namespace
 
@@ -616,7 +615,7 @@ Notes:
 
 #### 4.2.2 Trusted Issuer List
 
-Section 4.2.2. of \[TrustModel\] describes the concept of a trusted list
+Section 6.3.2.2 of \[ARF\] describes the concept of a trusted list
 of Issuers. This document specifies that for PID attestations, such a
 trusted list SHALL be used. Relying Parties SHALL only trust PID issuers
 that are included in a trusted list of PID Providers. Additionally,

--- a/docs/arf.md
+++ b/docs/arf.md
@@ -1522,7 +1522,7 @@ Attestation revocation is a process whereby the Provider of an
 attestation declares that Relying Parties SHOULD no longer trust a
 particular attestation, even though the attestation is still valid
 temporally and contains a valid Provider signature. As described in
-section 4.2.4 of \[TrustModel\], during the process of releasing an
+section 6.3.2.3, during the process of releasing an
 attestation, a Relying Party SHOULD verify that the Provider has not
 revoked the attestation. Revocation checking is a process that takes
 place after the Relying Party has validated that the validity period of
@@ -2543,7 +2543,7 @@ apply. If this is not the case, then the person handling the Wallet
 Instance is legally not allowed to approve to release the attributes.
 
 Note that this requirement is slightly different from the requirement of
-User binding discussed in section 6.3.2.5 of \[TrustModel\]. In some use
+User binding discussed in section 6.3.2.5. In some use
 cases, for example in attended proximity use cases, the Relying Party can
 use a portrait of the User to do User binding, if that portrait is issued
 as an attribute in an attestation. Obviously, this is not a possibility


### PR DESCRIPTION
Fixed Trust Model references in the ARF.

Fixed some of the Trust Model references in the PID Rule Book. I left two references in place because I think an editor needs to resolve those.

### Unresolved reference 1

```
The value of all data elements (both PID attributes and PID metadata) SHALL be valid at the value of the timestamp in the validFrom element in the MSO from ISO/IEC 18013-5 clause 9.1.2.4[^6].
```

```
[^6]: As explained in \[TrustModel\], server retrieval, as specified in ISO/IEC 18013-5, SHALL NOT be used for EUDI Wallets.
```

I did not fix this reference because I did not understand how the footnote relates to the paragraph it is attached to. Additionally, the footnote is outdated because the ARF does not say anything about server retrieval.

### Unresolved reference 2

```
| [TrustModel] | Trust Model for the EUDI Wallet Ecosystem – generic for all use cases, version 0.8.1, 2023-05-25  |
```

I left the Trust Model reference in chapter 5 References intact because the footnote mentioned above references it.