### PR TITLE
Typo fixes 2024-03-18

### DIFF
--- a/docs/arf.md
+++ b/docs/arf.md
@@ -2422,7 +2422,7 @@ with the requirements for Issuing Authority CA certificates in Appendix
 B.1.2 of \[ISO/IEC18013-5\], with the following exceptions:
 
 * The validity period of this certificate SHALL be 5 years maximum.
-* For the certificates subject field, the requirements regarding the issuing_country
+* For the certificate's issuer field, the requirements regarding the issuing_country
   data element (for countryName) and the issuing_jurisdiction data
   element (for stateOrProvinceName) SHALL be disregarded. Where the
   issuing country is mentioned, this SHALL be taken to refer to the


### PR DESCRIPTION
I realised I made an error in commit 41a3dd0711b23838f1b9d2b0099fe80aab675896. In the commit ‘For the Provider field’ should have been replaced with ‘For the certificate's issuer field’, not ‘For the certificate's subject field’.