### PR TITLE
[Editorial Typo] remove duplicate section on 4.3.2

### DIFF
--- a/docs/architecture-and-reference-framework-main.md
+++ b/docs/architecture-and-reference-framework-main.md
@@ -871,11 +871,6 @@ independently.
 
 The following have been identified as the core components of a Wallet Unit:
 
-- **User device (UD)**: A User Device comprises the hardware, operating system,
-and software environment required to host and execute the Wallet Instance. The
-minimum hardware and software requirements for the User device will be
-determined by the Wallet Provider.
-
 - **Wallet Instance (WI)**: The app or application installed on a User device,
 which is an instance of a Wallet Solution and belongs to and is controlled by a
 User. This component implements the core business logic and interfaces as


### PR DESCRIPTION
Hi, maintainers of EUDI ARF.

I found duplicate section in 4.3.2 and remove it.
The deleted changes are duplicated with line 885

Feel free to provide any feedback or suggestions for improvements. Thank you.