### PR TITLE
Fix formatting of continued list

### DIFF
--- a/docs/architecture-and-reference-framework-main.md
+++ b/docs/architecture-and-reference-framework-main.md
@@ -2541,6 +2541,7 @@ Subsequently, after the Wallet Unit presents the selected attributes from the
 PID or attestation to the Relying Party Instance by sending a response to the
 request, the Relying Party validates the response. The following trust
 relationships are established:
+
 5. The Relying Party Instance verifies the signature of the PID or attestation.
 This ensures that the Relying Party can trust that the PID or attestation it
 receives is issued by an authentic Provider and has not been changed. This is
@@ -2890,17 +2891,17 @@ the PID Provider or Attestation Provider:
 authentication mechanisms implemented by the WSCD (see [Topic 9]). This means
 that the Relying Party trusts that the the WSCD has properly authenticated the
 User before allowing the User to present the attributes. Note that:
-   - This trust is not based on the outcome of any verification by the Relying
-   Party but is a-priori trust in (in particular) the certified WSCD that is
-   part of the Wallet Unit.
-   - Using this method implies that Relying Parties also trust device binding,
-   as described in [Section 6.5.3](#653-wallet-unit-activation). The Relying
-   Party Instance in fact first verifies that the PID or attestation is bound to
-   a WSCD trusted by the PID Provider or Attestation Provider, and then trusts
-   that the WSCD has properly authenticated the User.
-   - As a matter of fact, this User binding method will always be carried out,
-   since the WSCD must authenticate its User when asking for User approval for
-   presenting any attributes, and since device binding is also mandatory.
+    - This trust is not based on the outcome of any verification by the Relying
+    Party but is a-priori trust in (in particular) the certified WSCD that is
+    part of the Wallet Unit.
+    - Using this method implies that Relying Parties also trust device binding,
+    as described in [Section 6.5.3](#653-wallet-unit-activation). The Relying
+    Party Instance in fact first verifies that the PID or attestation is bound to
+    a WSCD trusted by the PID Provider or Attestation Provider, and then trusts
+    that the WSCD has properly authenticated the User.
+    - As a matter of fact, this User binding method will always be carried out,
+    since the WSCD must authenticate its User when asking for User approval for
+    presenting any attributes, and since device binding is also mandatory.
 2. In addition, in some cases, if a Relying Party does not want to only trust
 the above mechanism, it may be able to use User attributes to carry out an
 additional User binding process. For example, if the PID or attestation contains

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ theme:
 
 markdown_extensions:
   - footnotes
+  - sane_lists
   - tables
 repo_url: https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework
 repo_name: eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework


### PR DESCRIPTION
The continued list in section 6.6.3.1 was not being rendered as a list but as a continuation of the preceding paragraph. Adding the blank line makes it render as a list, but instead breaks the continued item numbering in MkDocs. Pandoc respects the starting number of the continued list, but MkDocs does not by default. This therefore requires the [`sane_lists`][1] MkDocs extension.

Enabling the `sane_lists` extension could have unintended consequences, so I compared the "main" ARF page of the rendered MkDocs sites side by side to check. I found only one place affected apart from the intended one in 6.6.3.1, namely a nested bullet point list in section 6.6.3.9 which was being rendered as numbered items of the parent list. This list formatting was broken by enabling the `sane_lists` extension, but fixed by indenting the nested lists to 4 spaces instead of 3.

[1]: https://python-markdown.github.io/extensions/sane_lists/