### PR TITLE
Make dark/light UI theme switch work in rendered docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,11 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
   features:
     - navigation.tabs
     - navigation.tabs.sticky


### PR DESCRIPTION
Since the beginning the UI button to switch between the dark and light theme didn't seem to work: the displayed theme was always set to "dark" regardless of OS settings or how often the button was clicked (that was at least my experience on Mac OS).
![dark-light-ui-theme-button](https://github.com/user-attachments/assets/7389d8d5-b6b3-4808-a8ef-13eea0aeee09)

This PR fixes this: now the user's preferred setting is used when the page is displayed, and the button can be used to manually toggle between light and dark mode.
![let-there-be-light](https://github.com/user-attachments/assets/30f41f4b-4d0b-4cef-ac52-50154d42386b)
