### PR TITLE
Fix for a potential typo in Reg_22b

### DIFF
--- a/docs/annexes/annex-2/annex-2-high-level-requirements.md
+++ b/docs/annexes/annex-2/annex-2-high-level-requirements.md
@@ -1078,7 +1078,7 @@ D. *Requirements for the registration of Attestation Providers*
 | Reg_21 | A Member State SHALL approve an Attestation Provider according to a well-defined policy before including it in its Attestation Provider Registry. To that end, a Member State SHALL define specific vetting processes and rules of acceptance for inclusion of Attestation Providers in its Registry. These processes and rules SHOULD consider any relevant differences between QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers. |
 | Reg_22 | A Member State SHALL identify Attestation Providers (i.e., QEAA Providers, PuB-EAA Providers and non-qualified EAA Providers) at a level of confidence proportionate to the risk arising from the potential harm a fraudulent Attestation Provider could cause to Users and other stakeholders in the EUDI Wallet ecosystem. |
 | Reg_22a | A Registrar SHALL provide a method to suspend or cancel a registered Attestation Provider. |
-| Reg_22b | A Registrar SHALL have a policy for the suspension or cancellation of a registered Attestation Provider, which SHALL specify that an Attestation Provider is suspended or cancelled at least on request of the PID Provider or of a competent national authority. |
+| Reg_22b | A Registrar SHALL have a policy for the suspension or cancellation of a registered Attestation Provider, which SHALL specify that an Attestation Provider is suspended or cancelled at least on request of the Attestation Provider or of a competent national authority. |
 
 E. *Requirements for the registration of Relying Parties*
 


### PR DESCRIPTION
Replaced ‘on request of the PID Provider’ with ‘on request of the Attestation Provider’ in Reg_22b. I believe this is a copypaste error from Reg_20b. Reg_20 is about suspension or cancellation of a registered PID Provider while Reg_22b is about suspension or cancellation of a registered Attestation Provider. It would be quite strange for a PID Provider to be able to request suspension or cancellation of an Attestation Provider.