### PR TITLE
Bump topic J RR to version 1.0 (#2434)

### DIFF
--- a/docs/discussion-topics/j-rr-wallet-to-wallet-interactions.md
+++ b/docs/discussion-topics/j-rr-wallet-to-wallet-interactions.md
@@ -1,4 +1,4 @@
-Version 0.2, updated 23 April 2026
+Version 1.0, updated 28 May 2026
 
 # Topic J - Wallet to Wallet Interactions (Revision Round)
 


### PR DESCRIPTION
Update - proper version number for the final version (1.0) that was released at end of May.