### PR TITLE
chore(ci): bump all GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build-pdf-image.yml
+++ b/.github/workflows/build-pdf-image.yml
@@ -31,13 +31,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build image (load locally for smoke test)
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./docker
           load: true
@@ -52,7 +52,7 @@ jobs:
           test -s build/pdf/architecture-and-reference-framework-main-and-annexes.pdf
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Push image (only reached if the smoke test passed)
         id: push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./docker
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup python environment
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x
           cache: pip
@@ -78,7 +78,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build pdf
         run: make pdfs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,17 +29,17 @@ jobs:
       contents: write
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: 'main'
           fetch-depth: 0 # full history + tags required by mike and get-previous-tag
 
       - name: Get latest tag
         id: latest_tag
-        uses: WyriHaximus/github-action-get-previous-tag@04e8485ecb6487243907e330d522ff60f02283ce # v1
+        uses: WyriHaximus/github-action-get-previous-tag@61819f33034117e6c686e6a31dba995a85afc9de # v2.0.0
 
       - name: Setup python environment
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x
           cache: pip
@@ -47,7 +47,7 @@ jobs:
       - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
 
       - name: Setup mkdocs-material cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/release-pdf.yml
+++ b/.github/workflows/release-pdf.yml
@@ -41,7 +41,7 @@ jobs:
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
       - name: Checkout the release tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.TAG }}
 
@@ -52,7 +52,7 @@ jobs:
           make pdfs VERSION="$VER"
 
       - name: Attach PDFs to the release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ env.TAG }}
           files: |


### PR DESCRIPTION
Every action was pinned (correctly, by full commit SHA) but at least one major version behind. Re-pin each to the latest release SHA, refreshing the trailing version comment:

  actions/checkout                            v4 -> v7.0.0
  actions/setup-python                        v5 -> v6.2.0
  actions/cache                               v4 -> v5.0.5
  WyriHaximus/github-action-get-previous-tag  v1 -> v2.0.0
  softprops/action-gh-release                 v2 -> v3.0.1
  docker/setup-buildx-action                  v3 -> v4.1.0
  docker/build-push-action                    v6 -> v7.2.0
  docker/login-action                         v3 -> v4.2.0

These majors move the actions onto the Node 24 runtime, supported by ubuntu-latest. The container image digests are unchanged.