### PR TITLE
perf(pdf): build the per-document PDFs in parallel (make -j)

### DIFF
--- a/.github/workflows/build-pdf-image.yml
+++ b/.github/workflows/build-pdf-image.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Smoke test — build the ARF PDFs inside the image
         run: |
           docker run --rm -v "${{ github.workspace }}:/data" -w /data \
-            ${{ env.IMAGE }}:ci make pdfs
+            ${{ env.IMAGE }}:ci make -j"$(nproc)" pdfs
           test -s build/pdf/architecture-and-reference-framework-main-and-annexes.pdf
 
       - name: Log in to GHCR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build pdf
-        run: make pdfs
+        # -j"$(nproc)": the per-document and combined PDFs are independent
+        # LuaLaTeX compiles; build them in parallel (Makefile orders the zip last).
+        run: make -j"$(nproc)" pdfs

--- a/.github/workflows/release-pdf.yml
+++ b/.github/workflows/release-pdf.yml
@@ -49,7 +49,8 @@ jobs:
         run: |
           VER="${TAG#v}"
           echo "Building ARF PDFs for version $VER"
-          make pdfs VERSION="$VER"
+          # -j"$(nproc)": build the independent per-document PDFs in parallel.
+          make -j"$(nproc)" pdfs VERSION="$VER"
 
       - name: Attach PDFs to the release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,11 @@ all: $(EXPORTED_DOCS) epub pdf zip-pdfs mkdocs
 # PDF-only artifacts (per-document + combined + zip), without DOCX/EPUB or the
 # MkDocs site. Used by the CI PDF build, which runs in a pandoc/LaTeX container
 # that has no mkdocs and only needs build/pdf.
+#
+# Each PDF is an independent LuaLaTeX compile, so this is the slow part of the
+# build. It is safe to run with `make -j` (e.g. `make -j"$(nproc)" pdfs`): the
+# per-document PDFs and the combined PDF build concurrently, and the order-only
+# barrier on zip-pdfs (see below) holds the archive back until every PDF exists.
 pdfs: $(SOURCE_DOCS:.md=.pdf) pdf zip-pdfs
 
 # EPUB combined main text + annexes
@@ -117,7 +122,11 @@ copy-pdfs:
 	@echo "PDF files have been copied."
 
 # Create a zip archive of all files in the build/pdf folder.
-zip-pdfs: copy-pdfs
+# copy-pdfs (a normal prerequisite) brings in the committed annex-4/annex-6
+# PDFs; the order-only prerequisites after | force every *generated* PDF to be
+# built first. Together they guarantee a complete build/pdf/ before we archive
+# it, so `make -j pdfs` can never zip a partial build.
+zip-pdfs: copy-pdfs | $(SOURCE_DOCS:.md=.pdf) pdf
 	@echo "Creating zip archive of PDFs in $(BUILD_DIR)/pdf..."
 	@cd $(BUILD_DIR) && zip -r arf-pdfs-v$(VERSION).zip pdf/*
 	@echo "Zip archive created at $(BUILD_DIR)/arf-pdfs-v$(VERSION).zip."


### PR DESCRIPTION
`make pdfs` compiles 10 independent documents (9 per-source PDFs + the combined main-and-annexes PDF), each its own LuaLaTeX run, and CI ran them serially. They have no data dependencies, so build them concurrently.

- Makefile: add an order-only barrier to zip-pdfs (`zip-pdfs: copy-pdfs | $(SOURCE_DOCS:.md=.pdf) pdf`) so the archive is only created once every generated PDF exists. Without it, `make -j` could zip a partial build/pdf/. copy-pdfs (the committed annex-4/annex-6 PDFs) stays a normal prerequisite.
- ci.yml / release-pdf.yml / build-pdf-image.yml: invoke `make -j"$(nproc)" pdfs` so the PDF jobs actually run in parallel on the runner's cores.

No change to the produced PDFs or the zip contents (23 PDFs); only the wall-clock to build them. The Pandoc lua-filter was ruled out as the bottleneck (~0.1s); the cost is the LuaLaTeX engine, run once per document.