### PR TITLE
Feat/ci docs link typo gate

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,15 @@
+# codespell configuration for the ARF docs typo gate.
+# Run locally with:  codespell docs/
+# CI runs it only on the files a PR changes (burn-down rollout).
+[codespell]
+# Allowlist: valid terminology / house style that codespell mis-flags. These
+# are NOT typos, so they must not block:
+#   re-use / re-using / re-uses / re-used / pre-selected
+#                 -> the ARF consistently uses the hyphenated spelling
+#   requestor(s)  -> spec terminology used throughout the document
+#   fulfilment    -> British spelling (the site language is en-IE)
+# Keep this list tight: only add words that are genuinely correct here, never
+# real misspellings, or the gate stops catching them.
+ignore-words-list = re-use,re-using,re-uses,re-used,pre-selected,requestor,requestors,fulfilment
+# Never spell-check binary or vector assets, or build output.
+skip = ./.git,./build,./site,./node_modules,*.svg,*.png,*.jpg,*.jpeg,*.gif,*.pdf,*.ico

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 # Validate documentation changes on pull requests, before they reach main.
-# Two checks run in parallel:
-#   build-docs : fast MkDocs --strict build (broken nav / dead links / bad markdown)
-#   build-pdf  : the full Pandoc/LaTeX PDF build, using the same pinned image as the
-#                deploy workflow, so a PR that breaks the PDF fails here instead of
-#                only surfacing on the post-merge release build.
+# Three checks run in parallel:
+#   build-docs    : fast MkDocs --strict build (broken nav / dead links / bad markdown)
+#   build-pdf     : the full Pandoc/LaTeX PDF build, using the same pinned image as the
+#                   deploy workflow, so a PR that breaks the PDF fails here instead of
+#                   only surfacing on the post-merge release build.
+#   docs-quality  : blocking link / reference / typo gate — internal links + section
+#                   anchors (MkDocs), external URLs (lychee) and typos (codespell),
+#                   scoped to the files a PR changes so the pre-existing backlog is
+#                   burned down incrementally instead of blocking unrelated PRs.
 name: CI
 
 on:
@@ -82,3 +86,68 @@ jobs:
 
       - name: Build pdf
         run: make pdfs
+
+  docs-quality:
+    # Link / reference / typo gate. PR-only: it diffs against the PR base to
+    # scope the checks to the Markdown a PR changes. New problems in touched
+    # files block the merge; the pre-existing backlog (broken section anchors,
+    # typos) is fixed incrementally as files are touched. See
+    # tools/check_doc_links.py, .codespellrc and lychee.toml.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0 # need history back to the PR base to compute the diff
+
+      - name: Setup python environment
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: 3.x
+          cache: pip
+
+      - name: Install docs toolchain (mkdocs + codespell)
+        # Pin codespell so a new release's dictionary can't change the gate's
+        # verdict without an intentional bump.
+        run: pip install -r requirements.txt codespell==2.4.2
+
+      # The link build resolves [shorthand] references from includes/references.md,
+      # so regenerate it first (same as build-docs).
+      - name: Generate reference link definitions
+        run: python3 tools/gen_references.py
+
+      - name: Determine changed Markdown files
+        id: changed
+        run: |
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          git diff --name-only --diff-filter=ACMR "$base_sha" HEAD \
+            | grep -E '^(docs|includes)/.*\.md$' > changed_md.txt || true
+          echo "Changed Markdown files:"; cat changed_md.txt || true
+          echo "count=$(wc -l < changed_md.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          echo "files=$(paste -sd' ' changed_md.txt)" >> "$GITHUB_OUTPUT"
+
+      # 1) Internal links + section anchors (MkDocs). not-found / unrecognized /
+      #    nav links block repo-wide; broken #anchors block only for changed files.
+      - name: Check internal links and anchors
+        if: ${{ !cancelled() }}
+        run: python3 tools/check_doc_links.py --changed-from changed_md.txt
+
+      # 2) Typos on the changed Markdown (allowlist of house terminology lives in
+      #    .codespellrc, which codespell picks up from the repo root).
+      - name: Check typos
+        if: ${{ !cancelled() && steps.changed.outputs.count != '0' }}
+        run: codespell $(cat changed_md.txt)
+
+      # 3) External http(s) URLs on the changed Markdown (config in lychee.toml,
+      #    skip-list in .lycheeignore). GITHUB_TOKEN avoids github.com rate limits.
+      - name: Check external links
+        if: ${{ !cancelled() && steps.changed.outputs.count != '0' }}
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          lycheeVersion: lychee-v0.24.2 # pin the checker binary too
+          args: "--config lychee.toml --no-progress ${{ steps.changed.outputs.files }}"
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/arf.pdf
 docs/arf.png
 .vscode
 .cache
+.lycheecache
 
 docs/annexes/annex-2/high-level-requirements.xlsx
 docs/annexes/annex-2/~$high-level-requirements.xlsx

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,10 @@
+# URLs the external-link gate should skip (one regex per line).
+#
+# Add a host here when it is known-good but blocks automated checkers
+# (persistent HTTP 403 / anti-bot challenge), so the gate stays green without
+# weakening checking for every other URL. Keep the list short and justified.
+
+# Local / placeholder / example hosts that are never meant to resolve.
+^https?://localhost
+^https?://127\.0\.0\.1
+^https?://example\.(com|org)

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,30 @@
+# lychee configuration for the external-URL half of the docs CI gate.
+#
+# Only http/https URLs are checked here; relative/internal links and section
+# anchors are validated by MkDocs (tools/check_doc_links.py), and the
+# [shorthand] reference style (e.g. [OpenID4VCI]) is resolved by MkDocs at
+# build time from includes/references.md, so lychee never sees it as a link.
+#
+# The gate runs lychee on the Markdown a PR changes (the same changed-files
+# burn-down model as the link and typo checks).
+
+# Restrict checking to real web URLs.
+scheme = ["https", "http"]
+
+# Tolerate transient failures so a momentarily slow or throttled host does not
+# turn the gate red for reasons unrelated to the change.
+max_retries = 3
+retry_wait_time = 2
+timeout = 20
+max_concurrency = 8
+
+# Many official sites reject non-browser clients; present a common user agent.
+user_agent = "Mozilla/5.0 (compatible; lychee/docs-ci; +https://github.com/lycheeverse/lychee)"
+
+# 429 = rate limited: the link is live, we are just being throttled -> not a
+# failure. 200-299 are the normal successes.
+accept = ["200..=299", "429"]
+
+# Cache results between runs to cut network load and flakiness.
+cache = true
+max_cache_age = "2d"

--- a/tools/check_doc_links.py
+++ b/tools/check_doc_links.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Validate internal documentation links and section anchors via MkDocs.
+
+This is the internal half of the docs CI gate (external URLs are handled by
+lychee, typos by codespell). It builds the site with MkDocs' own link
+validation turned up and decides pass/fail from the warnings, with two
+different policies because the two backlogs are in different states:
+
+  * not-found / unrecognized / nav links  -> FAIL repo-wide.
+        These are already clean across the whole site, so any new one --
+        including a cross-file break, e.g. renaming a heading that another
+        page links to -- must block, wherever it appears.
+
+  * broken '#anchor' (section) references  -> FAIL only for changed files.
+        There is a backlog of pre-existing broken anchors (mostly stale
+        links into the generated annex-2 topic pages). We gate these on the
+        files a PR actually touches and burn the backlog down over time,
+        rather than blocking every PR on debt it did not introduce. Once the
+        backlog reaches zero, move `anchors` to repo-wide by setting
+        `validation.links.anchors: warn` in mkdocs.yml directly and dropping
+        the changed-files filter here.
+
+MkDocs does not validate anchors by default, and its social/privacy plugins
+need native imaging libraries we don't want in this job, so we build from a
+derived config: the real mkdocs.yml with those plugins stripped and anchor
+validation enabled. Everything else (nav, the pymdownx.snippets reference
+machinery, markdown extensions) is inherited unchanged, so there is no risk
+of the gate and the published site drifting apart.
+
+Usage:
+    tools/check_doc_links.py [--changed-from FILE] [--changed PATH ...]
+
+`--changed-from` reads newline-separated paths (the CI passes the PR's
+changed files); `--changed` adds paths individually. With no changed files
+given, only the repo-wide policy can fail (anchors are reported but not
+enforced).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MKDOCS_CONFIG = os.path.join(REPO_ROOT, "mkdocs.yml")
+
+# Plugins that need native imaging libraries (social, privacy) or a versioned
+# deploy (mike); none affect link validation, all are dropped for this build.
+DROP_PLUGINS = {"social", "privacy", "mike"}
+
+# A warning is about a section anchor (vs. a missing page / nav entry) iff it
+# matches one of these. Both the cross-file and same-page phrasings are here.
+ANCHOR_MARKERS = (
+    "does not contain an anchor",
+    "there is no such anchor",
+)
+
+# Pull the owning page out of "Doc file 'PATH' contains a link ...".
+DOC_FILE_RE = re.compile(r"Doc file '([^']+)'")
+
+
+def derive_config() -> str:
+    """Write a temp config: real mkdocs.yml minus DROP_PLUGINS, anchors on.
+
+    Written into the repo root (not /tmp) so docs_dir, the snippets
+    auto_append path and other relative paths resolve exactly as in a normal
+    build. Returns the temp file path; caller removes it.
+    """
+    with open(MKDOCS_CONFIG, encoding="utf-8") as fh:
+        config = yaml.safe_load(fh)
+
+    plugins = config.get("plugins")
+    if isinstance(plugins, list):
+        config["plugins"] = [
+            p for p in plugins if not (isinstance(p, str) and p in DROP_PLUGINS)
+        ]
+    # The mike version provider is meaningless without the mike plugin.
+    if "mike" in DROP_PLUGINS:
+        config.get("extra", {}).pop("version", None)
+
+    validation = config.setdefault("validation", {})
+    links = validation.setdefault("links", {})
+    links.setdefault("not_found", "warn")
+    links.setdefault("unrecognized_links", "warn")
+    links["anchors"] = "warn"
+    links["absolute_links"] = "warn"
+
+    fd, path = tempfile.mkstemp(
+        prefix="mkdocs.linkcheck.", suffix=".yml", dir=REPO_ROOT
+    )
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(config, fh, sort_keys=False, allow_unicode=True)
+    return path
+
+
+def run_mkdocs(config_path: str) -> str:
+    """Build the site (non-strict) and return MkDocs' combined warning output.
+
+    Non-strict so we collect *every* warning and apply our own policy, rather
+    than aborting at the first one.
+    """
+    with tempfile.TemporaryDirectory() as site_dir:
+        proc = subprocess.run(
+            ["mkdocs", "build", "-f", config_path, "-d", site_dir],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+    return proc.stderr + proc.stdout
+
+
+def normalize(path: str) -> str:
+    """Normalize a doc path to be comparable with the git changed-file list.
+
+    MkDocs reports paths relative to docs_dir (e.g. 'discussion-topics/x.md');
+    git reports them from the repo root ('docs/discussion-topics/x.md').
+    """
+    path = path.strip().lstrip("./")
+    if not path.startswith("docs/"):
+        path = "docs/" + path
+    return path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changed", action="append", default=[], metavar="PATH")
+    parser.add_argument("--changed-from", metavar="FILE")
+    args = parser.parse_args()
+
+    changed = {normalize(p) for p in args.changed}
+    if args.changed_from:
+        with open(args.changed_from, encoding="utf-8") as fh:
+            changed.update(normalize(line) for line in fh if line.strip())
+
+    config_path = derive_config()
+    try:
+        output = run_mkdocs(config_path)
+    finally:
+        os.remove(config_path)
+
+    link_failures = []           # not-found / unrecognized / nav, repo-wide
+    anchor_changed = []          # broken anchors in changed files (blocking)
+    anchor_backlog = 0           # broken anchors elsewhere (reported only)
+
+    for line in output.splitlines():
+        if "WARNING" not in line:
+            continue
+        is_anchor = any(marker in line for marker in ANCHOR_MARKERS)
+        if not is_anchor:
+            link_failures.append(line.strip())
+            continue
+        match = DOC_FILE_RE.search(line)
+        owner = normalize(match.group(1)) if match else None
+        if owner in changed:
+            anchor_changed.append(line.strip())
+        else:
+            anchor_backlog += 1
+
+    print(f"Changed docs files considered: {len(changed)}")
+    print(
+        f"MkDocs warnings: {len(link_failures)} link/nav, "
+        f"{len(anchor_changed) + anchor_backlog} broken-anchor "
+        f"({anchor_backlog} pre-existing in unchanged files, not blocking)."
+    )
+
+    if link_failures:
+        print("\nBroken links / nav (must be fixed — these block repo-wide):")
+        for w in link_failures:
+            print(f"  - {w}")
+
+    if anchor_changed:
+        print("\nBroken section anchors in files this PR changed (must be fixed):")
+        for w in anchor_changed:
+            print(f"  - {w}")
+
+    if link_failures or anchor_changed:
+        print("\nFAIL: fix the links/anchors above before merging.")
+        return 1
+
+    print("\nOK: no blocking link or anchor problems.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a **`docs-quality`** CI job that validates documentation on every PR and **blocks merge** on link, reference and typo problems in the files a PR touches.

Rollout is **changed-files burn-down** (as agreed): a PR must be clean for the Markdown it changes; the existing backlog is fixed incrementally as files are edited, so it never blocks unrelated PRs.

## The three checks

| Check | Tool | Scope | Backlog today |
|---|---|---|---|
| Internal links / nav / unrecognized | MkDocs validation | **repo-wide** (already clean) | **0** |
| Broken `#anchor` (section) references | MkDocs `validation.links.anchors` | **changed files** | 128 |
| Typos | codespell (`.codespellrc` allowlist) | **changed files** | 33 genuine |
| External `http(s)` URLs | lychee (`lychee.toml` / `.lycheeignore`) | **changed files**, blocking | unmeasured |

Backlog was measured at this commit; everything is non-blocking until its file is touched.

## How it works

- **`tools/check_doc_links.py`** builds the site from a config *derived at runtime* from `mkdocs.yml` — social/privacy/mike plugins stripped (no imaging libs needed) and anchor validation enabled — so the gate and the published site can't drift. It fails repo-wide on not-found/unrecognized/nav links and only on changed files for broken anchors. Runs locally too: `python3 tools/check_doc_links.py --changed docs/foo.md`.
- **codespell** runs on the changed Markdown; `.codespellrc` allowlists house terminology (`re-use`, `requestor`, British `fulfilment`) so only real typos block. 33 genuine typos remain in the repo.
- **lychee** checks only `http(s)` URLs in changed files (relative links and `[shorthand]` references are left to MkDocs). Retries + browser UA + `429`-tolerance reduce flakiness from third-party sites; persistently bot-blocked hosts can be added to `.lycheeignore`.

All three steps run even if an earlier one fails (`!cancelled()`), so an author sees every problem at once.

## Validated locally (TeX-free, mkdocs 1.6.1 + lychee 0.24.2 + codespell 2.4.2)

- Clean file as the only change → **pass**.
- File with a broken anchor / typo / dead `.com` URL injected → each check **fails** as expected (lychee exit 2, codespell exit 65, link checker exit 1).
- Reserved example domains, relative links and anchors are correctly **excluded** by lychee.
- The 128 pre-existing anchors and 33 typos do **not** block when their files are untouched.