### PR TITLE
fix(ci): correct lychee version pin in the docs-quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         if: ${{ !cancelled() && steps.changed.outputs.count != '0' }}
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
-          lycheeVersion: lychee-v0.24.2 # pin the checker binary too
+          lycheeVersion: v0.24.2 # pinned; the action prepends the 'lychee-' tag prefix
           args: "--config lychee.toml --no-progress ${{ steps.changed.outputs.files }}"
           fail: true
         env:


### PR DESCRIPTION
The external-link check pinned `lycheeVersion: lychee-v0.24.2`, but lychee-action forms the download URL as `lychee-${lycheeVersion}`, so it requested the tag `lychee-lychee-v0.24.2` (doubled prefix) -> 404 -> the step failed on every PR. Pin `v0.24.2`; the action adds the `lychee-` prefix, resolving to the real tag `lychee-v0.24.2` (asset confirmed reachable).