### PR TITLE
fix(ci): drop lychee version pin so the binary installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,12 @@ jobs:
       - name: Check external links
         if: ${{ !cancelled() && steps.changed.outputs.count != '0' }}
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        # Don't set lycheeVersion: this action's installer untars without
+        # --strip-components and expects the binary at the archive root, which
+        # only holds for the version it ships (v0.23.0). lychee >= v0.24 nests
+        # the binary in a platform subdir, so a newer pin fails to install. The
+        # pinned action SHA keeps the default lychee version reproducible.
         with:
-          lycheeVersion: v0.24.2 # pinned; the action prepends the 'lychee-' tag prefix
           args: "--config lychee.toml --no-progress ${{ steps.changed.outputs.files }}"
           fail: true
         env:


### PR DESCRIPTION
The previous pin (lychee v0.24.2) downloaded but failed to install:
  install: cannot stat '.../lychee-download/lychee': No such file or directory
lychee-action@v2.8.0 untars without --strip-components and installs the binary from the archive root, which only holds for older lychee tarballs. lychee
>= v0.24 nests the binary under lychee-x86_64-unknown-linux-gnu/, so the
install step can't find it.

Drop lycheeVersion entirely and use the action's default (v0.23.0, flat tarball). Reproducibility is preserved by the pinned action SHA.