### PR TITLE
docs: re-sync l+m clause-6 anchor after the typo fix

### DIFF
--- a/docs/discussion-topics/l+m-data-deletion-and-reporting-of-wrp-to-dpa.md
+++ b/docs/discussion-topics/l+m-data-deletion-and-reporting-of-wrp-to-dpa.md
@@ -17,7 +17,7 @@ the existing high level requirements from [**Topic 48** (Blueprint for requestin
 and [**Topic 50** (Blueprint to report unlawful or suspicious request of data)](https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-2/annex-2.02-high-level-requirements-by-topic.md#a2350-topic-50---blueprint-to-report-unlawful-or-suspicious-request-of-data), before it 
 discusses these topics in [clause 4](#4-erasure-of-personal-data-at-a-wallet-relying-party) and [clause 5](#5-reporting-a-wallet-relying-party-to-the-competent-data-protection-supervisory-authority). 
 
-The result of the discussions documented in the present paper is the updated set of high level requirements as laid down in [clause 6](#6-updated-set-of-high-level-requriements).
+The result of the discussions documented in the present paper is the updated set of high level requirements as laid down in [clause 6](#6-updated-set-of-high-level-requirements).
 
 ### 1.2 Related risks in the Risk Register
 


### PR DESCRIPTION
The typo PR corrected the section-6 heading "Requriements" -> "Requirements", which changed its slug, while the anchor PR had pointed the in-page "clause 6" link at the old (typo'd) slug. They landed in separate PRs, so the link broke once both merged. Point it at the current slug
(#6-updated-set-of-high-level-requirements).

This clears the last of the 128 broken section anchors: an MkDocs build with anchor validation now reports 0.