### PR TITLE
ci(docs): enforce internal links and anchors repo-wide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,10 @@ jobs:
             exit 1
           }
 
-      # Report-only: --strict surfaces every broken link / nav / markdown issue in
-      # the log, but continue-on-error keeps it from blocking PRs while the large
-      # backlog of pre-existing broken internal links is worked down separately.
-      # Drop continue-on-error once the site builds clean under --strict.
-      - name: Build site (strict, report-only)
-        continue-on-error: true
+      # --strict fails on any broken link / nav / section anchor / markdown
+      # issue. The backlog is cleared and mkdocs.yml now validates anchors and
+      # absolute links, so this is a hard gate (blocking) on the real site config.
+      - name: Build site (strict)
         run: mkdocs build --strict
 
   build-pdf:
@@ -90,11 +88,11 @@ jobs:
         run: make -j"$(nproc)" pdfs
 
   docs-quality:
-    # Link / reference / typo gate. PR-only: it diffs against the PR base to
-    # scope the checks to the Markdown a PR changes. New problems in touched
-    # files block the merge; the pre-existing backlog (broken section anchors,
-    # typos) is fixed incrementally as files are touched. See
-    # tools/check_doc_links.py, .codespellrc and lychee.toml.
+    # Link / reference / typo gate (PR-only). Internal links and section anchors
+    # are validated repo-wide (the backlog is cleared). Typos and external URLs
+    # are scoped to the Markdown a PR changes — typos because the allowlist is
+    # young, external URLs because pre-existing link rot must not block unrelated
+    # PRs. See tools/check_doc_links.py, .codespellrc and lychee.toml.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -130,11 +128,11 @@ jobs:
           echo "count=$(wc -l < changed_md.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
           echo "files=$(paste -sd' ' changed_md.txt)" >> "$GITHUB_OUTPUT"
 
-      # 1) Internal links + section anchors (MkDocs). not-found / unrecognized /
-      #    nav links block repo-wide; broken #anchors block only for changed files.
+      # 1) Internal links + section anchors (MkDocs), repo-wide: not-found /
+      #    unrecognized / nav / anchors / absolute links all block, anywhere.
       - name: Check internal links and anchors
         if: ${{ !cancelled() }}
-        run: python3 tools/check_doc_links.py --changed-from changed_md.txt
+        run: python3 tools/check_doc_links.py
 
       # 2) Typos on the changed Markdown (allowlist of house terminology lives in
       #    .codespellrc, which codespell picks up from the repo root).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,11 @@ validation:
   links:
     not_found: warn
     unrecognized_links: warn
+    # Broken section anchors and absolute links are validated repo-wide. The
+    # backlog was cleared (see tools/check_doc_links.py history), so any new
+    # one fails `mkdocs build --strict` and the docs-quality gate.
+    anchors: warn
+    absolute_links: warn
 
 nav:
   - European Digital Identity Wallet: index.md

--- a/tools/check_doc_links.py
+++ b/tools/check_doc_links.py
@@ -1,46 +1,26 @@
 #!/usr/bin/env python3
 """Validate internal documentation links and section anchors via MkDocs.
 
-This is the internal half of the docs CI gate (external URLs are handled by
-lychee, typos by codespell). It builds the site with MkDocs' own link
-validation turned up and decides pass/fail from the warnings, with two
-different policies because the two backlogs are in different states:
+The internal half of the docs CI gate (external URLs are handled by lychee,
+typos by codespell). It builds the site with MkDocs' link validation turned up
+and fails on any broken internal link, nav entry, section anchor or absolute
+link, **repo-wide** — the backlog has been cleared, so any new breakage blocks,
+wherever it appears (including cross-file breaks, e.g. renaming a heading that
+another page links to).
 
-  * not-found / unrecognized / nav links  -> FAIL repo-wide.
-        These are already clean across the whole site, so any new one --
-        including a cross-file break, e.g. renaming a heading that another
-        page links to -- must block, wherever it appears.
+MkDocs' social/privacy plugins need native imaging libraries we don't want in
+this job, so we build from a derived config: the real mkdocs.yml with those
+plugins stripped. Link validation levels are taken from mkdocs.yml (and forced
+on here as a safeguard), and everything else — nav, the pymdownx.snippets
+reference machinery, markdown extensions — is inherited unchanged, so the gate
+and the published site can't drift apart.
 
-  * broken '#anchor' (section) references  -> FAIL only for changed files.
-        There is a backlog of pre-existing broken anchors (mostly stale
-        links into the generated annex-2 topic pages). We gate these on the
-        files a PR actually touches and burn the backlog down over time,
-        rather than blocking every PR on debt it did not introduce. Once the
-        backlog reaches zero, move `anchors` to repo-wide by setting
-        `validation.links.anchors: warn` in mkdocs.yml directly and dropping
-        the changed-files filter here.
-
-MkDocs does not validate anchors by default, and its social/privacy plugins
-need native imaging libraries we don't want in this job, so we build from a
-derived config: the real mkdocs.yml with those plugins stripped and anchor
-validation enabled. Everything else (nav, the pymdownx.snippets reference
-machinery, markdown extensions) is inherited unchanged, so there is no risk
-of the gate and the published site drifting apart.
-
-Usage:
-    tools/check_doc_links.py [--changed-from FILE] [--changed PATH ...]
-
-`--changed-from` reads newline-separated paths (the CI passes the PR's
-changed files); `--changed` adds paths individually. With no changed files
-given, only the repo-wide policy can fail (anchors are reported but not
-enforced).
+Usage: tools/check_doc_links.py
 """
 
 from __future__ import annotations
 
-import argparse
 import os
-import re
 import subprocess
 import sys
 import tempfile
@@ -54,23 +34,13 @@ MKDOCS_CONFIG = os.path.join(REPO_ROOT, "mkdocs.yml")
 # deploy (mike); none affect link validation, all are dropped for this build.
 DROP_PLUGINS = {"social", "privacy", "mike"}
 
-# A warning is about a section anchor (vs. a missing page / nav entry) iff it
-# matches one of these. Both the cross-file and same-page phrasings are here.
-ANCHOR_MARKERS = (
-    "does not contain an anchor",
-    "there is no such anchor",
-)
-
-# Pull the owning page out of "Doc file 'PATH' contains a link ...".
-DOC_FILE_RE = re.compile(r"Doc file '([^']+)'")
-
 
 def derive_config() -> str:
-    """Write a temp config: real mkdocs.yml minus DROP_PLUGINS, anchors on.
+    """Write a temp config: real mkdocs.yml minus DROP_PLUGINS, validation forced on.
 
-    Written into the repo root (not /tmp) so docs_dir, the snippets
-    auto_append path and other relative paths resolve exactly as in a normal
-    build. Returns the temp file path; caller removes it.
+    Written into the repo root (not /tmp) so docs_dir, the snippets auto_append
+    path and other relative paths resolve exactly as in a normal build. Returns
+    the temp file path; caller removes it.
     """
     with open(MKDOCS_CONFIG, encoding="utf-8") as fh:
         config = yaml.safe_load(fh)
@@ -84,12 +54,10 @@ def derive_config() -> str:
     if "mike" in DROP_PLUGINS:
         config.get("extra", {}).pop("version", None)
 
-    validation = config.setdefault("validation", {})
-    links = validation.setdefault("links", {})
-    links.setdefault("not_found", "warn")
-    links.setdefault("unrecognized_links", "warn")
-    links["anchors"] = "warn"
-    links["absolute_links"] = "warn"
+    # Safeguard: enforce link validation even if mkdocs.yml is later weakened.
+    links = config.setdefault("validation", {}).setdefault("links", {})
+    for key in ("not_found", "unrecognized_links", "anchors", "absolute_links"):
+        links[key] = "warn"
 
     fd, path = tempfile.mkstemp(
         prefix="mkdocs.linkcheck.", suffix=".yml", dir=REPO_ROOT
@@ -102,7 +70,7 @@ def derive_config() -> str:
 def run_mkdocs(config_path: str) -> str:
     """Build the site (non-strict) and return MkDocs' combined warning output.
 
-    Non-strict so we collect *every* warning and apply our own policy, rather
+    Non-strict so we collect *every* warning and report them together, rather
     than aborting at the first one.
     """
     with tempfile.TemporaryDirectory() as site_dir:
@@ -115,75 +83,24 @@ def run_mkdocs(config_path: str) -> str:
     return proc.stderr + proc.stdout
 
 
-def normalize(path: str) -> str:
-    """Normalize a doc path to be comparable with the git changed-file list.
-
-    MkDocs reports paths relative to docs_dir (e.g. 'discussion-topics/x.md');
-    git reports them from the repo root ('docs/discussion-topics/x.md').
-    """
-    path = path.strip().lstrip("./")
-    if not path.startswith("docs/"):
-        path = "docs/" + path
-    return path
-
-
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--changed", action="append", default=[], metavar="PATH")
-    parser.add_argument("--changed-from", metavar="FILE")
-    args = parser.parse_args()
-
-    changed = {normalize(p) for p in args.changed}
-    if args.changed_from:
-        with open(args.changed_from, encoding="utf-8") as fh:
-            changed.update(normalize(line) for line in fh if line.strip())
-
     config_path = derive_config()
     try:
         output = run_mkdocs(config_path)
     finally:
         os.remove(config_path)
 
-    link_failures = []           # not-found / unrecognized / nav, repo-wide
-    anchor_changed = []          # broken anchors in changed files (blocking)
-    anchor_backlog = 0           # broken anchors elsewhere (reported only)
+    warnings = [ln.strip() for ln in output.splitlines() if "WARNING" in ln]
 
-    for line in output.splitlines():
-        if "WARNING" not in line:
-            continue
-        is_anchor = any(marker in line for marker in ANCHOR_MARKERS)
-        if not is_anchor:
-            link_failures.append(line.strip())
-            continue
-        match = DOC_FILE_RE.search(line)
-        owner = normalize(match.group(1)) if match else None
-        if owner in changed:
-            anchor_changed.append(line.strip())
-        else:
-            anchor_backlog += 1
-
-    print(f"Changed docs files considered: {len(changed)}")
-    print(
-        f"MkDocs warnings: {len(link_failures)} link/nav, "
-        f"{len(anchor_changed) + anchor_backlog} broken-anchor "
-        f"({anchor_backlog} pre-existing in unchanged files, not blocking)."
-    )
-
-    if link_failures:
-        print("\nBroken links / nav (must be fixed — these block repo-wide):")
-        for w in link_failures:
+    print(f"MkDocs link/anchor/nav warnings: {len(warnings)}")
+    if warnings:
+        print("\nFix these before merging (broken links / nav / section anchors):")
+        for w in warnings:
             print(f"  - {w}")
-
-    if anchor_changed:
-        print("\nBroken section anchors in files this PR changed (must be fixed):")
-        for w in anchor_changed:
-            print(f"  - {w}")
-
-    if link_failures or anchor_changed:
-        print("\nFAIL: fix the links/anchors above before merging.")
+        print("\nFAIL")
         return 1
 
-    print("\nOK: no blocking link or anchor problems.")
+    print("OK: no broken internal links, nav entries or section anchors.")
     return 0
 
 


### PR DESCRIPTION
The anchor backlog is cleared, so internal-link validation no longer needs the changed-files burndown scoping:

- mkdocs.yml: add `validation.links.anchors: warn` and `absolute_links: warn` as the source of truth (also benefits local `mkdocs build --strict`).
- build-docs: drop `continue-on-error` on the strict build — it's now a hard, repo-wide gate on the real site config (nav / links / anchors / markdown).
- check_doc_links.py: drop the changed-files anchor filter; fail on any broken internal link, nav entry, section anchor or absolute link, anywhere. This catches cross-file breaks (e.g. renaming a heading other pages link to) that changed-files scoping missed. Simplified accordingly.
- ci.yml: the docs-quality link check no longer takes --changed-from. Typos (codespell) and external URLs (lychee) stay changed-files scoped.