### PR TITLE
Feat/md and csv linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,13 @@ jobs:
         run: make -j"$(nproc)" pdfs
 
   docs-quality:
-    # Link / reference / typo gate (PR-only). Internal links and section anchors
-    # are validated repo-wide (the backlog is cleared). Typos and external URLs
-    # are scoped to the Markdown a PR changes — typos because the allowlist is
-    # young, external URLs because pre-existing link rot must not block unrelated
-    # PRs. See tools/check_doc_links.py, .codespellrc and lychee.toml.
+    # Link / reference / typo / lint gate (PR-only). Internal links and section
+    # anchors are validated repo-wide (backlog cleared), as is the HLR CSV
+    # structure. Typos, external URLs and markdown lint are scoped to the
+    # Markdown a PR changes, so their pre-existing backlogs burn down
+    # incrementally instead of blocking unrelated PRs. See
+    # tools/check_doc_links.py, tools/check_hltr_csv.py, .codespellrc,
+    # lychee.toml and .markdownlint.jsonc.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -134,6 +136,11 @@ jobs:
           echo "Changed Markdown files:"; cat changed_md.txt || true
           echo "count=$(wc -l < changed_md.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
           echo "files=$(paste -sd' ' changed_md.txt)" >> "$GITHUB_OUTPUT"
+          # markdownlint target: changed Markdown minus the generated annex-2
+          # pages (their lint issues live in the CSV/template, not the .md).
+          grep -vE 'docs/annexes/annex-2/annex-2\.0[23]' changed_md.txt > md_lint.txt || true
+          echo "md_lint=$(paste -sd' ' md_lint.txt)" >> "$GITHUB_OUTPUT"
+          echo "md_lint_count=$(wc -l < md_lint.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
       # 1) Internal links + section anchors (MkDocs), repo-wide: not-found /
       #    unrecognized / nav / anchors / absolute links all block, anywhere.
@@ -162,6 +169,22 @@ jobs:
           fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # 4) Markdown lint on the changed files (rules in .markdownlint.jsonc — a
+      #    curated, correctness-only set; stylistic rules are off). Changed-files
+      #    scoped so the existing backlog is burned down incrementally.
+      - name: Lint markdown
+        if: ${{ !cancelled() && steps.changed.outputs.md_lint_count != '0' }}
+        uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
+        with:
+          globs: ${{ steps.changed.outputs.md_lint }}
+
+      # 5) Structural check of the HLR CSV that generates annex-2.02 / 2.03.
+      #    Malformed rows (field count / header) fail; data-quality issues
+      #    (duplicate IDs, empties) are reported as warnings.
+      - name: Check the HLR CSV
+        if: ${{ !cancelled() }}
+        run: python3 tools/check_hltr_csv.py
 
   regenerate-hltr:
     # The Annex 2 high-level-requirements pages (annex-2.02 / annex-2.03) are

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,21 @@
+// Markdown lint rules for the ARF docs.
+// Most stylistic rules are off — these prose-heavy documents legitimately use
+// long lines, inline HTML and varied table/emphasis styles. Only correctness
+// and structural rules that catch real defects are enabled.
+{
+  "default": false,
+  "MD001": true, // heading levels increment by one (no skipped levels)
+  "MD005": true, // consistent list indentation
+  "MD011": true, // no reversed link syntax (text)(url)
+  "MD018": true, // space after # in ATX headings
+  "MD019": true, // no multiple spaces after # in ATX headings
+  "MD023": true, // headings start at the line beginning
+  "MD034": true, // no bare URLs (wrap in <> or a link)
+  "MD037": true, // no spaces inside emphasis markers
+  "MD038": true, // no spaces inside code span markers
+  "MD039": true, // no spaces inside link text
+  "MD042": true, // no empty links
+  "MD045": true, // images have alt text
+  "MD051": true, // link fragments point at an existing heading
+  "MD056": true  // tables have a consistent column count
+}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -16,6 +16,10 @@
   "MD039": true, // no spaces inside link text
   "MD042": true, // no empty links
   "MD045": true, // images have alt text
-  "MD051": true, // link fragments point at an existing heading
+  // MD051 (link-fragments) is off: it slugifies headings the GitHub way
+  // (triple-dash around " - "), but this is an MkDocs site (single-dash), so it
+  // false-positives. Section anchors are validated correctly by
+  // tools/check_doc_links.py instead.
+  "MD051": false,
   "MD056": true  // tables have a consistent column count
 }

--- a/tools/check_hltr_csv.py
+++ b/tools/check_hltr_csv.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Structural checker for hltr/high-level-requirements.csv.
+
+The Annex 2 high-level-requirements pages are generated from this CSV, so a
+malformed row (an unescaped delimiter, a stray newline, a missing column) would
+silently corrupt the generated markdown. This validates the structure before
+that can happen; it does not judge the requirement text.
+
+Structural problems FAIL the build (they break generation):
+  * the file parses as semicolon-delimited CSV (UTF-8, BOM tolerated);
+  * the header is exactly the expected columns;
+  * every data row has exactly that many fields.
+
+Data-quality problems are reported as warnings (they don't corrupt the
+structure, and a pre-existing one shouldn't block an unrelated change):
+  * the key columns (Harmonized_ID, Index) are non-empty;
+  * Harmonized_ID values are unique;
+  * Topic_Number is an integer where present.
+"""
+from __future__ import annotations
+
+import csv
+import sys
+
+CSV_PATH = "hltr/high-level-requirements.csv"
+DELIM = ";"
+EXPECTED = [
+    "Harmonized_ID", "Part", "Category", "Topic", "Topic_Number",
+    "Topic_Title", "Subsection", "Index", "Requirement_specification", "Notes",
+]
+
+
+def main() -> int:
+    errors: list[str] = []
+    # utf-8-sig strips the BOM; newline="" lets csv handle quoted newlines.
+    with open(CSV_PATH, newline="", encoding="utf-8-sig") as fh:
+        rows = list(csv.reader(fh, delimiter=DELIM))
+
+    if not rows:
+        print(f"{CSV_PATH}: file is empty"); return 1
+
+    header = rows[0]
+    if header != EXPECTED:
+        print(f"{CSV_PATH}:1: header mismatch")
+        print(f"  expected: {EXPECTED}")
+        print(f"  found:    {header}")
+        return 1
+
+    ncol = len(EXPECTED)
+    idx = {name: i for i, name in enumerate(EXPECTED)}
+    seen_ids: dict[str, int] = {}
+    warnings: list[str] = []
+
+    for n, row in enumerate(rows[1:], start=2):  # 1-based, header is line 1
+        if len(row) != ncol:
+            errors.append(f"line {n}: {len(row)} fields, expected {ncol} "
+                          f"(likely an unescaped '{DELIM}' or a stray newline)")
+            continue
+        hid = row[idx["Harmonized_ID"]].strip()
+        if not hid:
+            warnings.append(f"line {n}: empty Harmonized_ID")
+        elif hid in seen_ids:
+            warnings.append(f"line {n}: duplicate Harmonized_ID '{hid}' "
+                            f"(first seen line {seen_ids[hid]})")
+        else:
+            seen_ids[hid] = n
+        if not row[idx["Index"]].strip():
+            warnings.append(f"line {n}: empty Index")
+        tn = row[idx["Topic_Number"]].strip()
+        if tn and not tn.isdigit():
+            warnings.append(f"line {n}: Topic_Number '{tn}' is not an integer")
+
+    if warnings:
+        print(f"{CSV_PATH}: {len(warnings)} data-quality warning(s):")
+        for w in warnings:
+            print(f"  - {w}")
+        print()
+
+    if errors:
+        print(f"{CSV_PATH}: {len(errors)} structural problem(s):")
+        for e in errors:
+            print(f"  - {e}")
+        print("\nFAIL")
+        return 1
+
+    print(f"OK: {len(rows) - 1} rows, {ncol} columns, structurally well-formed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Two new checks in the `docs-quality` gate.

### 1. Markdown lint (markdownlint-cli2)
Rules in `.markdownlint.jsonc`. The default ruleset flags **~11,600** issues on these prose-heavy docs — almost all stylistic noise (line length 4.4k, table style 4.7k, inline HTML, trailing spaces…). The config turns those **off** and enables only **correctness/structure** rules: heading increment, link fragments, **table column count**, bare URLs, empty links, reversed links, spaces in emphasis/code/links, alt text, list indent.

That leaves **35** real issues across 15 hand-authored pages — burned down **per changed file** (changed-files scoped, like typos). The generated `annex-2.02/2.03` pages are excluded (their lint originates in the CSV/template, not the `.md`).

### 2. HLR CSV checker (`tools/check_hltr_csv.py`)
The semicolon-delimited CSV that generates annex-2 must stay well-formed, or a stray delimiter/newline silently corrupts the generated markdown. The check **fails** on structural problems (unexpected header, wrong field count per row) and **warns** on data-quality ones (duplicate `Harmonized_ID`, empty keys, non-integer `Topic_Number`). Runs repo-wide (one file).

## Findings to act on (reported, not blocking)

- **35 markdown issues** in hand-authored pages (bare URLs ×8, link fragments ×7, heading-increment ×6, table-column-count ×5, …). I can clear the mechanical ones (bare URLs, emphasis/heading spacing, list indent) in a follow-up; the heading-level and table-column ones need a light editorial touch. Clearing them lets markdown lint go repo-wide.
- **1 CSV duplicate ID** — `EW-DM-38-018` is on two *different* requirements (Index `WURevocation_07a` and `WURevocation_17`). Looks like a real data error; one needs the correct Harmonized_ID (domain call). Surfaced as a warning for now.

## This PR's own gate
Changes only CI/config/tool files (no docs `.md`), so markdown lint is skipped and the CSV check passes structurally — green.

