### PR TITLE
feat: EUDI Wallet brand theme restyle (homepage, PDF button, CI alignment)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # full history for git-revision-date-localized; --strict fails on a shallow clone
 
       - name: Setup python environment
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+template: home.html
+---
+
 # European Digital Identity Wallet
 
 ![Digital Identity for all Europeans - A personal digital wallet for EU citizens and residents](./media/top-banner-arf.png)

--- a/docs/media/extra.css
+++ b/docs/media/extra.css
@@ -1,8 +1,171 @@
-.md-header__button.md-logo {
-    margin: 0;
-    padding: 0;
+/* ============================================================
+   EUDI Wallet — shared documentation theme
+   Material for MkDocs · official EC brand colours (Europa Component Library)
+   Canonical file: copy verbatim into each repo (see README).
+   Primary blue  #004494  · Accent/EU yellow  #ffd617
+   ============================================================ */
+
+:root {
+  --eudi-blue:       #004494;  /* EC primary (ECL) */
+  --eudi-blue-700:   #003776;
+  --eudi-blue-dark:  #002554;
+  --eudi-blue-vivid: #1f5fd1;
+  --eudi-link:       #0e63c4;
+  --eudi-yellow:     #ffd617;  /* EC yellow */
+  --eudi-yellow-ink: #3a3000;
 }
 
-.md-header__button.md-logo img, .md-header__button.md-logo svg {
-    height: 2.7rem;
+/* ---- Brand palette wiring (mkdocs: palette primary/accent = custom) ---- */
+[data-md-color-primary="custom"] {
+  --md-primary-fg-color:        var(--eudi-blue);
+  --md-primary-fg-color--light: var(--eudi-blue-vivid);
+  --md-primary-fg-color--dark:  var(--eudi-blue-dark);
+  --md-primary-bg-color:        #ffffff;
+  --md-primary-bg-color--light: rgba(255, 255, 255, .72);
 }
+[data-md-color-accent="custom"] {
+  --md-accent-fg-color: var(--eudi-link);
+}
+
+/* Link colour, per scheme */
+[data-md-color-scheme="default"] { --md-typeset-a-color: var(--eudi-link); }
+[data-md-color-scheme="slate"]   { --md-typeset-a-color: #71a8ff; }
+
+/* ---- Logo sizing (preserved from existing theme) ---- */
+.md-header__button.md-logo { margin: 0; padding: 0; }
+.md-header__button.md-logo img,
+.md-header__button.md-logo svg { height: 2.7rem; }
+
+/* ============================================================
+   Tabs — yellow EU accent on the active/hovered tab
+   ============================================================ */
+.md-tabs { border-bottom: 3px solid var(--eudi-yellow); }
+.md-tabs__link {
+  border-bottom: 3px solid transparent;
+  margin-bottom: -3px;
+  padding-bottom: .4rem;
+  opacity: .85;
+  transition: border-color .15s, opacity .15s;
+}
+.md-tabs__item--active .md-tabs__link,
+.md-tabs__link:hover {
+  opacity: 1;
+  border-bottom-color: var(--eudi-yellow);
+}
+.md-tabs__item--active .md-tabs__link { font-weight: 700; }
+
+/* ============================================================
+   Tables — branded header, zebra rows, soft corners
+   ============================================================ */
+.md-typeset table:not([class]) {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.md-typeset table:not([class]) th {
+  background: var(--eudi-blue);
+  color: #fff;
+  font-weight: 600;
+}
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) th { background: var(--eudi-blue-dark); }
+.md-typeset table:not([class]) tr:nth-child(even) { background: var(--md-default-fg-color--lightest); }
+
+/* Helper for very wide tables (kept from docs-site) */
+.responsive-table { width: 100%; display: block; overflow-x: auto; white-space: nowrap; }
+.responsive-table th:nth-child(1), .responsive-table td:nth-child(1) { width: 20%; }
+.responsive-table th:nth-child(2), .responsive-table td:nth-child(2) { width: 15%; }
+.responsive-table th:nth-child(3), .responsive-table td:nth-child(3) { width: 65%; }
+
+/* ============================================================
+   Code blocks & admonitions — softer corners, brand "note"
+   ============================================================ */
+.md-typeset pre > code { border-radius: 8px; }
+.md-typeset .admonition,
+.md-typeset details { border-radius: 8px; }
+
+.md-typeset .admonition.note,
+.md-typeset details.note { border-color: var(--eudi-link); }
+.md-typeset .note > .admonition-title,
+.md-typeset .note > summary { background-color: rgba(14, 99, 196, .1); }
+.md-typeset .note > .admonition-title::before,
+.md-typeset .note > summary::before { background-color: var(--eudi-link); }
+
+/* ============================================================
+   HERO  (homepage) — "Hero A": solid blue, left aligned
+   Rendered by overrides/home.html (index page only)
+   ============================================================ */
+.eudi-hero { background: var(--eudi-blue); color: #fff; padding: 3.4rem 1.2rem 3.8rem; }
+[data-md-color-scheme="slate"] .eudi-hero { background: var(--eudi-blue-dark); }
+.eudi-hero__inner { max-width: 61rem; margin: 0 auto; padding: 0 .8rem; }
+.eudi-hero__eyebrow {
+  display: inline-flex; gap: .4rem; align-items: center;
+  background: rgba(255, 255, 255, .12); border: 1px solid rgba(255, 255, 255, .25);
+  border-radius: 999px; padding: .25rem .85rem; font-size: .72rem; font-weight: 600; margin-bottom: 1rem;
+}
+.eudi-hero h1 { color: #fff; font-weight: 800; font-size: 2.3rem; line-height: 1.12; margin: 0 0 .7rem; max-width: 20ch; }
+.eudi-hero p  { color: rgba(255, 255, 255, .85); font-size: 1rem; max-width: 60ch; margin: 0 0 1.4rem; }
+.eudi-hero .md-button { margin: .2rem .6rem .2rem 0; }
+.eudi-hero .md-button--primary {
+  background: var(--eudi-yellow); color: var(--eudi-yellow-ink); border-color: var(--eudi-yellow);
+}
+.eudi-hero .md-button--primary:hover { filter: brightness(1.06); }
+.eudi-hero .md-button:not(.md-button--primary) { color: #fff; border-color: rgba(255, 255, 255, .5); }
+.eudi-hero .md-button:not(.md-button--primary):hover { background: rgba(255, 255, 255, .12); border-color: #fff; }
+
+/* ============================================================
+   Navigation cards (Material ".grid.cards")
+   "Card 4": add class .eudi-feature to a card for the filled-blue variant
+   ============================================================ */
+.eudi-home-cards { margin-top: 2.2rem; }
+.md-typeset .grid.cards > ul > li {
+  border-radius: 12px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  transition: transform .18s, border-color .18s;
+}
+.md-typeset .grid.cards > ul > li:hover { transform: translateY(-3px); border-color: var(--eudi-blue); }
+
+.md-typeset .grid.cards > ul > li.eudi-feature {
+  background: var(--eudi-blue); border-color: var(--eudi-blue); color: #fff;
+}
+.md-typeset .grid.cards > ul > li.eudi-feature:hover { background: var(--eudi-blue-700); }
+.md-typeset .grid.cards > ul > li.eudi-feature :is(p, strong, h1, h2, h3, h4) { color: #fff; }
+.md-typeset .grid.cards > ul > li.eudi-feature a { color: var(--eudi-yellow); }
+
+/* ============================================================
+   HLR — high-level requirement callout (custom component)
+   Needs markdown_extensions: attr_list + md_in_html
+   Usage:
+     <div class="eudi-hlr" markdown>
+     <div class="eudi-hlr__id">PID_01<span>MUST</span></div>
+     <div class="eudi-hlr__body" markdown>
+     The PID Provider **shall** issue PID only at level of assurance high.
+     </div>
+     </div>
+   ============================================================ */
+.md-typeset .eudi-hlr {
+  display: grid; grid-template-columns: auto 1fr; gap: 0 1rem; align-items: stretch;
+  border: 1px solid var(--md-default-fg-color--lightest); border-radius: 10px; overflow: hidden; margin: 1rem 0;
+}
+.md-typeset .eudi-hlr__id {
+  background: var(--eudi-blue); color: #fff; font-weight: 700; padding: .8rem;
+  display: flex; flex-direction: column; gap: .3rem; align-items: center; justify-content: center;
+  min-width: 5.4rem; text-align: center;
+}
+/* Keyword badge — colour by RFC 2119 strength.
+   .kw-shall  = mandatory (SHALL / SHALL NOT / MUST)      → yellow
+   .kw-should = recommended (SHOULD / SHOULD NOT)         → white
+   .kw-may    = optional (MAY)                            → outline
+   A bare <span> (no class) defaults to the SHALL style. */
+.md-typeset .eudi-hlr__id span {
+  background: var(--eudi-yellow); color: var(--eudi-yellow-ink);
+  border-radius: 5px; padding: 0 .4rem; font-size: .6rem; font-weight: 700; letter-spacing: .02em;
+}
+.md-typeset .eudi-hlr__id span.kw-should {
+  background: #ffffff; color: var(--eudi-blue);
+}
+.md-typeset .eudi-hlr__id span.kw-may {
+  background: transparent; color: #fff; box-shadow: inset 0 0 0 1px rgba(255, 255, 255, .6);
+}
+.md-typeset .eudi-hlr__body { padding: .7rem 0; }
+.md-typeset .eudi-hlr__body > :first-child { margin-top: 0; }
+.md-typeset .eudi-hlr__body > :last-child  { margin-bottom: 0; }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,12 @@
-# European Digital Identity - Architecture and Reference Framework
-# Compatible with both MkDocs Material 9.7.x and Zensical (>= 0.0.45).
+# ============================================================
+# CANONICAL config — eudi-doc-architecture-and-reference-framework
+# (eudi.dev). The theme / markdown / plugins blocks below are the
+# shared baseline; docs.eudi.dev and conformance.eudi.dev mirror them.
+# Compatible with MkDocs Material 9.7.x and Zensical (>= 0.0.45).
+# ============================================================
 
 site_name: European Digital Identity
+site_author: European Commission - DG CNECT
 site_description: >-
   Architecture and Reference Framework (ARF) of the European Digital
   Identity Wallet: main narrative, annexes with normative high-level
@@ -12,18 +17,24 @@ repo_name: eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framew
 edit_uri: edit/main/docs/
 copyright: European Union, 2025 - Licensed under the EUPL-1.2 or later
 
+# ---------------- SHARED THEME BLOCK (keep identical across repos) ----------------
 theme:
   name: material
+  custom_dir: overrides          # holds home.html (ARF) + any future partials
   icon:
     repo: fontawesome/brands/github
   palette:
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
+      primary: custom            # EC blue #004494 — defined in extra.css
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to dark mode
@@ -31,6 +42,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.path
+    - navigation.indexes
     - navigation.top
     - navigation.footer
     - navigation.tracking
@@ -41,12 +53,16 @@ theme:
     - search.share
     - content.action.edit
     - content.action.view
+    - content.code.copy
+    - content.code.annotate     # quick win: annotated code blocks
+    - content.tabs.link         # quick win: linked content tabs
   logo: media/logo_eudi_white.svg
   favicon: media/favicon.ico
 
 extra_css:
-  - media/extra.css
+  - media/extra.css              # site-specific path; same file contents everywhere
 
+# ---------------- SHARED MARKDOWN BLOCK (keep identical) ----------------
 markdown_extensions:
   - footnotes
   - sane_lists
@@ -55,28 +71,46 @@ markdown_extensions:
   - md_in_html
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.tilde
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:           # quick win: content tabs (e.g. Android / iOS)
+      alternate_style: true
   - toc:
       permalink: true
       permalink_title: Link to this section
+  # --- ARF-specific: shared snippet of references appended to every page ---
   - pymdownx.snippets:
       auto_append:
         - includes/references.md
       check_paths: true
 
-watch:
-  - includes
-
+# ---------------- SHARED PLUGINS BLOCK (keep identical) ----------------
 plugins:
   - search
+  - tags
   - privacy
   - social
   - mike
+  - git-revision-date-localized:   # quick win: "last updated" (pip: mkdocs-git-revision-date-localized-plugin; CI needs full git history, fetch-depth: 0)
+      enable_creation_date: true
+      type: timeago
 
 extra:
+  # PDF button in the header (rendered by overrides/partials/header.html).
+  # Stable URL: always resolves to the asset of the latest GitHub release.
+  pdf_url: https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/releases/latest/download/architecture-and-reference-framework-main-and-annexes.pdf
+  pdf_title: Download the ARF as PDF
   version:
     provider: mike
     alias: true
+
+# ---------------- ARF-specific ----------------
+watch:
+  - includes
 
 validation:
   nav:
@@ -84,9 +118,6 @@ validation:
   links:
     not_found: warn
     unrecognized_links: warn
-    # Broken section anchors and absolute links are validated repo-wide. The
-    # backlog was cleared (see tools/check_doc_links.py history), so any new
-    # one fails `mkdocs build --strict` and the docs-quality gate.
     anchors: warn
     absolute_links: warn
 

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -1,0 +1,60 @@
+{#-
+  EUDI Wallet — homepage template (Hero A + navigation cards)
+  Apply only to the landing page by adding to its front matter:
+
+      ---
+      template: home.html
+      ---
+
+  Requires in mkdocs.yml:
+      theme:
+        custom_dir: overrides
+  Card links below are relative to the ARF site root (eudi.dev/latest/).
+  Adjust the hrefs if you reuse this template in another repo.
+-#}
+{% extends "main.html" %}
+
+{% block tabs %}
+  {{ super() }}
+  <section class="eudi-hero">
+    <div class="eudi-hero__inner">
+      <span class="eudi-hero__eyebrow">★ eIDAS 2.0 · Regulation (EU) 2024/1183</span>
+      <h1>Architecture and Reference Framework for the EU Digital Identity Wallet</h1>
+      <p>The single source of truth: main narrative, normative high-level
+         requirements, technical specifications and open discussion topics.</p>
+      <a href="architecture-and-reference-framework-main/" class="md-button md-button--primary">Read the Main Document</a>
+      <a href="annexes/" class="md-button">Browse the Annexes</a>
+      <a href="https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/releases/latest/download/architecture-and-reference-framework-main-and-annexes.pdf" class="md-button">Download PDF</a>
+    </div>
+  </section>
+{% endblock %}
+
+{% block content %}
+  <div class="md-typeset eudi-home-cards">
+    <div class="grid cards">
+      <ul>
+        <li class="eudi-feature">
+          <p><strong>Main Document</strong></p>
+          <p>Start here — the narrative description of the architecture, roles and trust model.</p>
+          <p><a href="architecture-and-reference-framework-main/">Open →</a></p>
+        </li>
+        <li>
+          <p><strong>Annexes &amp; HLRs</strong></p>
+          <p>Definitions, high-level requirements by topic and category, rulebooks and design guides.</p>
+          <p><a href="annexes/">Open →</a></p>
+        </li>
+        <li>
+          <p><strong>Discussion Topics</strong></p>
+          <p>Open questions: privacy risks, zero-knowledge proof, wallet-to-wallet and more.</p>
+          <p><a href="discussion-topics/">Open →</a></p>
+        </li>
+        <li>
+          <p><strong>Technical Specifications</strong></p>
+          <p>TS1–TS12 — the normative technical specifications for interoperability.</p>
+          <p><a href="technical-specifications/">Open →</a></p>
+        </li>
+      </ul>
+    </div>
+  </div>
+  {{ super() }}
+{% endblock %}

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -1,0 +1,105 @@
+{#-
+  EUDI Wallet — header override.
+  Adapted from Material for MkDocs 9.7.x partials/header.html (MIT, © squidfunk).
+  Only change vs upstream: the "Download PDF" button, rendered when
+  `extra.pdf_url` is set in mkdocs.yml. Re-sync with upstream if you bump
+  Material to a major new version.
+-#}
+
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
+{% endif %}
+
+<header class="{{ class }}" data-md-component="header">
+  <nav
+    class="md-header__inner md-grid"
+    aria-label="{{ lang.t('header') }}"
+  >
+
+    <a
+      href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"
+      title="{{ config.site_name | e }}"
+      class="md-header__button md-logo"
+      aria-label="{{ config.site_name }}"
+      data-md-component="logo"
+    >
+      {% include "partials/logo.html" %}
+    </a>
+
+    <label class="md-header__button md-icon" for="__drawer">
+      {% set icon = config.theme.icon.menu or "material/menu" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
+    </label>
+
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            {{ config.site_name }}
+          </span>
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
+            {% endif %}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        {% include "partials/palette.html" %}
+      {% endif %}
+    {% endif %}
+
+    {% if not config.theme.palette is mapping %}
+      {% include "partials/javascripts/palette.html" %}
+    {% endif %}
+
+    {% if config.extra.alternate %}
+      {% include "partials/alternate.html" %}
+    {% endif %}
+
+    {% if "material/search" in config.plugins %}
+      {% set search = config.plugins["material/search"] | attr("config") %}
+      {% if search.enabled %}
+        <label class="md-header__button md-icon" for="__search">
+          {% set icon = config.theme.icon.search or "material/magnify" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </label>
+        {% include "partials/search.html" %}
+      {% endif %}
+    {% endif %}
+
+    {#- Download PDF button (custom): rendered only when extra.pdf_url is set -#}
+    {% if config.extra.pdf_url %}
+      <a
+        href="{{ config.extra.pdf_url }}"
+        title="{{ config.extra.pdf_title | d('Download as PDF', true) }}"
+        class="md-header__button md-icon"
+        aria-label="{{ config.extra.pdf_title | d('Download as PDF', true) }}"
+      >
+        {% include ".icons/material/file-download-outline.svg" %}
+      </a>
+    {% endif %}
+
+    {% if config.repo_url %}
+      <div class="md-header__source">
+        {% include "partials/source.html" %}
+      </div>
+    {% endif %}
+  </nav>
+
+  {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+      {% include "partials/tabs.html" %}
+    {% endif %}
+  {% endif %}
+</header>

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ mike==2.1.3
 # (hltr/scripts/, run via `make hltr`). Also an mkdocs dependency, pinned
 # here explicitly because the generator depends on it directly.
 jinja2==3.1.6
+mkdocs-git-revision-date-localized-plugin==1.3.0

--- a/tools/check_doc_links.py
+++ b/tools/check_doc_links.py
@@ -34,6 +34,34 @@ MKDOCS_CONFIG = os.path.join(REPO_ROOT, "mkdocs.yml")
 # deploy (mike); none affect link validation, all are dropped for this build.
 DROP_PLUGINS = {"social", "privacy", "mike"}
 
+# mkdocs.yml uses Python-specific YAML tags (e.g. the superfences custom fence
+# `format: !!python/name:pymdownx.superfences.fence_code_format`). MkDocs' own
+# loader resolves them to live objects, but yaml.safe_load can't construct them
+# and yaml.safe_dump can't re-serialize them. We don't need their values here —
+# only to round-trip them verbatim into the derived config so the MkDocs build
+# below parses them exactly as the real site does. Carry each as an opaque tag.
+_PY_TAG_PREFIX = "tag:yaml.org,2002:python/"
+
+
+class _OpaqueTag:
+    """A YAML node with a Python-specific tag, preserved tag-and-value as-is."""
+
+    def __init__(self, tag: str, value: str) -> None:
+        self.tag = tag
+        self.value = value
+
+
+def _construct_opaque_tag(loader, tag_suffix, node):
+    return _OpaqueTag(_PY_TAG_PREFIX + tag_suffix, loader.construct_scalar(node))
+
+
+def _represent_opaque_tag(dumper, data):
+    return dumper.represent_scalar(data.tag, data.value)
+
+
+yaml.SafeLoader.add_multi_constructor(_PY_TAG_PREFIX, _construct_opaque_tag)
+yaml.SafeDumper.add_representer(_OpaqueTag, _represent_opaque_tag)
+
 
 def derive_config() -> str:
     """Write a temp config: real mkdocs.yml minus DROP_PLUGINS, validation forced on.


### PR DESCRIPTION
## Summary

Restyle the documentation site with the canonical **EUDI Wallet brand theme** on top of Material for MkDocs, add a custom homepage and a header *Download PDF* button, and align CI so the new "last updated" plugin works under `mkdocs build --strict`.

## Changes

### Theme & branding
- **`mkdocs.yml`** — wire the EC brand palette (`primary`/`accent = custom`), register `custom_dir: overrides`, and enable Material quick-wins: `navigation.indexes`, `content.code.copy`, `content.code.annotate`, `content.tabs.link`, `pymdownx.tabbed`, `pymdownx.tilde`. Add the `tags`, `social` and `git-revision-date-localized` plugins, and expose `extra.pdf_url` / `extra.pdf_title` for the header button.
- **`docs/media/extra.css`** — full brand restyle using the official EC colours (primary blue `#004494`, EU yellow `#ffd617`): tabs, tables (branded header + zebra rows), code blocks & admonitions, the homepage hero, navigation cards, and a reusable `eudi-hlr` high-level-requirement callout component.

### Homepage & header
- **`overrides/home.html`** — homepage template (hero section + navigation cards), applied to the landing page via `template: home.html` front matter.
- **`docs/index.md`** — opt the landing page into the new template.
- **`overrides/partials/header.html`** — fork of Material 9.7.x `partials/header.html` adding a *Download PDF* button, rendered only when `extra.pdf_url` is set. Re-sync with upstream on major Material bumps.

### Dependencies
- **`requirements.txt`** — pin `mkdocs-git-revision-date-localized-plugin==1.3.0`.

### CI alignment
- **`.github/workflows/ci.yml`** — set `fetch-depth: 0` on the `build-docs` checkout. The job runs `mkdocs build --strict`, and `git-revision-date-localized` needs the full commit history to resolve each page's last-updated date; on a shallow checkout it emits a "no git logs" warning that `--strict` promotes to a hard failure. This matches the checkout already used in `pages.yml`.

## Notes
- The `mkdocs.yml` theme / markdown / plugins blocks are kept as a shared baseline so other EUDI repos can mirror them verbatim.
- The header partial is a deliberate fork of upstream — only the PDF button differs.

## Commits
- `feat: restyle the docs site with the EUDI Wallet brand theme`
- `ci: fetch full git history for the strict docs build`
