### PR TITLE
feat(annex-2): render HLRs as anchorable cards with RFC 2119 badges

### DIFF
--- a/docs/annexes/annex-2/annex-2.02-high-level-requirements-by-topic.md
+++ b/docs/annexes/annex-2/annex-2.02-high-level-requirements-by-topic.md
@@ -36,1122 +36,6904 @@ a Topic number.
 Each Topic includes a short description, followed by the High-Level
 Requirements (HLRs), identified by a unique identifier. The identifier
 includes a prefix which signifies the context of the HLRs (e.g. ISSU
-for issuance), an underscore and a numerator, e.g. ISSU_10.
+for issuance), an underscore and a numerator, e.g. ISSU_10. Each requirement
+is anchorable: link directly to it with `#<identifier>`, e.g. `#ISSU_10`.
 
 ### A.2.3 High-Level Requirements
 
 #### A.2.3.1 Topic 1 - Accessing Online Services with a Wallet Unit
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| OIA_01 | A Wallet Unit SHALL support [OpenID4VP] for remote presentation flows and [ISO/IEC 18013-5] for proximity presentation flows, to receive and respond to presentation requests for person identification data (PID) and attestations by Relying Parties. |
-| OIA_02 | A Wallet Unit SHALL support proving cryptographic device binding between the WSCA/WSCD or a keystore included in the Wallet Unit and a PID or attestation, in accordance with [SD-JWT VC] or [ISO/IEC 18013-5]. *Note: Such a mechanism is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT VC].* |
-| OIA_03 | When issuing, presenting, or verifying an attestation, Wallet Units, PID Providers, Attestation Providers, and Relying Parties SHALL only use cryptographic algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0]. |
-| OIA_03a | Wallet Providers SHALL ensure that their Wallet Solution supports the protocol specified in 'OpenID for Verifiable Presentations', see [OpenID4VP], with additions and changes as documented in this Annex and in technical specifications referenced in this Annex. |
-| OIA_03b | For remote presentation flows using redirects, when the format of the requested attestation complies with [ISO/IEC 18013-5], Relying Parties and Wallet Units SHALL comply with the requirements in [HAIP] Sections 5, 5.1 and 5.3.1, as well as with the 'ISO mdocs' profile in Section 6. *Note: a) '[HAIP] Section 5' refers only to the requirements directly under the Section 5 heading. This does not include sections 5.1, 5.2, and 5.3. b) For clarity: in [HAIP] v1.0, the 'ISO mdocs profile' implies that Relying Parties and Wallet Units must comply with the applicable requirements in [OpenID4VP] Annex B.2.* |
-| OIA_03c |  For remote presentation flows using redirects, when the format of the requested attestation complies with [SD-JWT VC], Relying Parties and Wallet Units SHALL comply with the requirements in [HAIP] Sections 5, 5.1, and 5.3.2, as well as with the 'IETF SD-JWT VCs' profile in Section 6. *Note: a) '[HAIP] Section 5' refers only to the requirements directly under the Section 5 heading. This does not include sections 5.1, 5.2, and 5.3. b) For clarity: in [HAIP] v1.0 Section 6, the 'IETF SD-JWT VCs profile' implies that Relying Parties and Wallet Units must comply with the requirements in [OpenID4VP] Annex B.3, as well as with the requirements in Section 6.1.* |
-| OIA_04 | A Wallet Unit SHALL verify and process PID or attestation presentation requests from Relying Parties in accordance with the protocols and interfaces specified in [OpenID4VP] for remote flows. |
-| OIA_05 | After verifying and processing a PID or attestation request, the Wallet Unit SHALL display to the User the identity of the requesting Relying Party and the requested attributes. |
-| OIA_06 | A Wallet Unit SHALL present the requested attributes only after having received the User's approval. *Note: See also OIA_07.* |
-| OIA_07 | A Wallet Unit SHALL support selective disclosure of attributes from PIDs and attestations to be presented to the requesting Relying Parties. |
-| OIA_08 | Wallet Units and Relying Party Instances SHALL support the [W3C Digital Credentials API]](<https://wicg.github.io/digital-credentials/>) for remote presentation flows, provided that a) this API is a W3C Recommendation, b) this API complies with the expectations outlined in [Chapter 3](../../discussion-topics/f-digital-credential-api.md#3-expectations-from-the-digital-credentials-api) of the Topic F discussion paper, and c) this API is broadly supported by relevant browsers and operating systems. |
-| OIA_08a | If Wallet Units and Relying Party Instances do not support the [W3C Digital Credentials API], they SHALL implement adequate mitigations for the challenges described in [Section 4.4.3.1](../../architecture-and-reference-framework-main.md#4431-introduction) of the ARF main document. |
-| OIA_08b | If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL, by default (see OIA_08d), disclose the presence of all stored attestations (meaning their attestation type) to the Digital Credentials API framework, but it SHALL NOT disclose the presence of attributes in these attestations, nor their values. *Note: The latter restriction applies even if such disclosure would enhance the services provided by the operating system to the Wallet Unit, for example, attestation selection in the context of the Digital Credentials API.* |
-| OIA_08c | If a Relying Party supports the [W3C Digital Credentials API], the Relying Party's presentation request MAY be processed by the browser and/or the operating system for searching available attestations, for preventing fraud targeting the User, or for troubleshooting purposes. Moreover, the request SHOULD be processed by the browser and/or the Operating System for User security purposes. However, the request SHALL NOT be processed by the browser and/or the operating system for market analysis purposes (including as a secondary purpose) or for the browser's and/or the operating system's own purposes. |
-| OIA_08d | If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL provide a global User setting to disable the disclosure of stored attestations to the Digital Credentials API framework, as described in OIA_08b. When this setting is set to disable disclosure, the Wallet Unit SHOULD subsequently enable the User to select individual attestations to be disclosed to the DC API. *Note: If this setting is set to disable disclosure and the User does not subsequently select any individual attestations to be disclosed, the Wallet Unit will not disclose any attributes at all. As a result, presentation requests sent using the DC API will likely fail.* |
-| OIA_08e | If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL use the CTAP-Hybrid flow only if the expectations outlined in Chapter 4 of the [Topic F discussion paper](../../discussion-topics/f-digital-credential-api.md) are met. |
-| OIA_09 | For remote presentation flows the Wallet Unit SHALL ensure that the attributes included in the presented attestation are accessible only to the Relying Party Instance, by encrypting the presentation response. |
-| OIA_10 | For both proximity and remote presentation flows, if a Wallet Unit contains multiple PIDs having the same encoding (e.g. ISO/IEC 18013-5 or SD-JWT VC-compliant) and a Relying Party requests a PID having that encoding, the Wallet Unit SHALL ask the User which of these PIDs they want to present, unless the Wallet Unit can decide from context. *Note: This requirement is not about multiple technical PIDs corresponding to a single logical PID, but to different logical PIDs whose technical PIDs have the same encoding. Probably, these logical PIDs are issued by different PID Providers.* |
-| OIA_11 | For both proximity and remote presentation flows, if a Wallet Unit contains multiple attestations having the same encoding (e.g. ISO/IEC 18013-5 or SD-JWT VC-compliant) and the same attestation type, and a Relying Party requests an attestation having that type and encoding, the Wallet Unit SHALL ask the User which of these attestations they want to present, unless the Wallet Unit can decide from context. *Note: a) Attestation types are explained in [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)]. b) See note to OIA_10, which applies mutatis mutandis.* |
-| OIA_12 | For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a PID using a trust anchor provided in a PID Provider LoTE made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)]. |
-| OIA_13 | For both proximity and remote presentation flows, a Relying Party SHALL validate the qualified signature of a QEAA in accordance with Art.32 of the [European Digital Identity Regulation]. For the verification, the Relying Party SHALL use a trust anchor provided in a QEAA Provider Trusted List made available in accordance with [Art. 22](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ.L_.2014.257.01.0073.01.ENG#d1e2162-73-1) of the [European Digital Identity Regulation]. |
-| OIA_14 | For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a PuB-EAA using a trust anchor provided in a PUB-EAA Provider Trusted List made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)]. |
-| OIA_15 | For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a non-qualified EAA using a trust anchor provided according to the mechanism(s) specified in the applicable Rulebook, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)]. *Note: a) OIA_12 - OIA_15 imply that a Relying Party Instance must know if the attestation it is requesting from a Wallet Instance is a PID, a QEAA, a PuB-EAA, or a non-qualified EAA. These requirements also imply that the Relying Party Instance must store trust anchors in such a way that, at the time of verification, it is able to distinguish between trust anchors usable either for PIDs, for QEAAs, for PuB-EAAs, or for non-qualified EAAs.* |
-| OIA_16 | When receiving a PID or attestation, a Relying Party Instance SHALL discard the values of all unique elements, including at least the ones mentioned in requirement ISSU_35 in [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), as well as any timestamps, as soon as they are no longer needed. The Relying Party Instance SHALL NOT communicate these values to the Relying Party or to any other party inside or outside the EUDI Wallet ecosystem. |
-| OIA_17 | A Relying Party Instance SHOULD verify the device-binding signature or Message Authentication Code provided in the presentation response of the Wallet Unit during the presentation of a PID or device-bound attestation, following the steps specified per [ISO/IEC 18013-5] or [SD-JWT VC], as applicable. |
+<div class="eudi-hlr" id="OIA_01" markdown>
+<div class="eudi-hlr__id">OIA_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL support [OpenID4VP] for remote presentation flows and [ISO/IEC 18013-5] for proximity presentation flows, to receive and respond to presentation requests for person identification data (PID) and attestations by Relying Parties.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_02" markdown>
+<div class="eudi-hlr__id">OIA_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL support proving cryptographic device binding between the WSCA/WSCD or a keystore included in the Wallet Unit and a PID or attestation, in accordance with [SD-JWT VC] or [ISO/IEC 18013-5].
+
+*Note: Such a mechanism is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT VC].*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_03" markdown>
+<div class="eudi-hlr__id">OIA_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing, presenting, or verifying an attestation, Wallet Units, PID Providers, Attestation Providers, and Relying Parties SHALL only use cryptographic algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_03a" markdown>
+<div class="eudi-hlr__id">OIA_03a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that their Wallet Solution supports the protocol specified in 'OpenID for Verifiable Presentations', see [OpenID4VP], with additions and changes as documented in this Annex and in technical specifications referenced in this Annex.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_03b" markdown>
+<div class="eudi-hlr__id">OIA_03b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For remote presentation flows using redirects, when the format of the requested attestation complies with [ISO/IEC 18013-5], Relying Parties and Wallet Units SHALL comply with the requirements in [HAIP] Sections 5, 5.1 and 5.3.1, as well as with the 'ISO mdocs' profile in Section 6.
+
+*Note: a) '[HAIP] Section 5' refers only to the requirements directly under the Section 5 heading. This does not include sections 5.1, 5.2, and 5.3. b) For clarity: in [HAIP] v1.0, the 'ISO mdocs profile' implies that Relying Parties and Wallet Units must comply with the applicable requirements in [OpenID4VP] Annex B.2.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_03c" markdown>
+<div class="eudi-hlr__id">OIA_03c<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+ For remote presentation flows using redirects, when the format of the requested attestation complies with [SD-JWT VC], Relying Parties and Wallet Units SHALL comply with the requirements in [HAIP] Sections 5, 5.1, and 5.3.2, as well as with the 'IETF SD-JWT VCs' profile in Section 6.
+
+*Note: a) '[HAIP] Section 5' refers only to the requirements directly under the Section 5 heading. This does not include sections 5.1, 5.2, and 5.3. b) For clarity: in [HAIP] v1.0 Section 6, the 'IETF SD-JWT VCs profile' implies that Relying Parties and Wallet Units must comply with the requirements in [OpenID4VP] Annex B.3, as well as with the requirements in Section 6.1.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_04" markdown>
+<div class="eudi-hlr__id">OIA_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL verify and process PID or attestation presentation requests from Relying Parties in accordance with the protocols and interfaces specified in [OpenID4VP] for remote flows.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_05" markdown>
+<div class="eudi-hlr__id">OIA_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+After verifying and processing a PID or attestation request, the Wallet Unit SHALL display to the User the identity of the requesting Relying Party and the requested attributes.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_06" markdown>
+<div class="eudi-hlr__id">OIA_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL present the requested attributes only after having received the User's approval.
+
+*Note: See also OIA_07.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_07" markdown>
+<div class="eudi-hlr__id">OIA_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL support selective disclosure of attributes from PIDs and attestations to be presented to the requesting Relying Parties.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_08" markdown>
+<div class="eudi-hlr__id">OIA_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Units and Relying Party Instances SHALL support the [W3C Digital Credentials API]](<https://wicg.github.io/digital-credentials/>) for remote presentation flows, provided that a) this API is a W3C Recommendation, b) this API complies with the expectations outlined in [Chapter 3](../../discussion-topics/f-digital-credential-api.md#3-expectations-from-the-digital-credentials-api) of the Topic F discussion paper, and c) this API is broadly supported by relevant browsers and operating systems.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_08a" markdown>
+<div class="eudi-hlr__id">OIA_08a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Wallet Units and Relying Party Instances do not support the [W3C Digital Credentials API], they SHALL implement adequate mitigations for the challenges described in [Section 4.4.3.1](../../architecture-and-reference-framework-main.md#4431-introduction) of the ARF main document.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_08b" markdown>
+<div class="eudi-hlr__id">OIA_08b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL, by default (see OIA_08d), disclose the presence of all stored attestations (meaning their attestation type) to the Digital Credentials API framework, but it SHALL NOT disclose the presence of attributes in these attestations, nor their values.
+
+*Note: The latter restriction applies even if such disclosure would enhance the services provided by the operating system to the Wallet Unit, for example, attestation selection in the context of the Digital Credentials API.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_08c" markdown>
+<div class="eudi-hlr__id">OIA_08c<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Relying Party supports the [W3C Digital Credentials API], the Relying Party's presentation request MAY be processed by the browser and/or the operating system for searching available attestations, for preventing fraud targeting the User, or for troubleshooting purposes. Moreover, the request SHOULD be processed by the browser and/or the Operating System for User security purposes. However, the request SHALL NOT be processed by the browser and/or the operating system for market analysis purposes (including as a secondary purpose) or for the browser's and/or the operating system's own purposes.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_08d" markdown>
+<div class="eudi-hlr__id">OIA_08d<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL provide a global User setting to disable the disclosure of stored attestations to the Digital Credentials API framework, as described in OIA_08b. When this setting is set to disable disclosure, the Wallet Unit SHOULD subsequently enable the User to select individual attestations to be disclosed to the DC API.
+
+*Note: If this setting is set to disable disclosure and the User does not subsequently select any individual attestations to be disclosed, the Wallet Unit will not disclose any attributes at all. As a result, presentation requests sent using the DC API will likely fail.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_08e" markdown>
+<div class="eudi-hlr__id">OIA_08e<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL use the CTAP-Hybrid flow only if the expectations outlined in Chapter 4 of the [Topic F discussion paper](../../discussion-topics/f-digital-credential-api.md) are met.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_09" markdown>
+<div class="eudi-hlr__id">OIA_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For remote presentation flows the Wallet Unit SHALL ensure that the attributes included in the presented attestation are accessible only to the Relying Party Instance, by encrypting the presentation response.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_10" markdown>
+<div class="eudi-hlr__id">OIA_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For both proximity and remote presentation flows, if a Wallet Unit contains multiple PIDs having the same encoding (e.g. ISO/IEC 18013-5 or SD-JWT VC-compliant) and a Relying Party requests a PID having that encoding, the Wallet Unit SHALL ask the User which of these PIDs they want to present, unless the Wallet Unit can decide from context.
+
+*Note: This requirement is not about multiple technical PIDs corresponding to a single logical PID, but to different logical PIDs whose technical PIDs have the same encoding. Probably, these logical PIDs are issued by different PID Providers.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_11" markdown>
+<div class="eudi-hlr__id">OIA_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For both proximity and remote presentation flows, if a Wallet Unit contains multiple attestations having the same encoding (e.g. ISO/IEC 18013-5 or SD-JWT VC-compliant) and the same attestation type, and a Relying Party requests an attestation having that type and encoding, the Wallet Unit SHALL ask the User which of these attestations they want to present, unless the Wallet Unit can decide from context.
+
+*Note: a) Attestation types are explained in [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)]. b) See note to OIA_10, which applies mutatis mutandis.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_12" markdown>
+<div class="eudi-hlr__id">OIA_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a PID using a trust anchor provided in a PID Provider LoTE made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_13" markdown>
+<div class="eudi-hlr__id">OIA_13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For both proximity and remote presentation flows, a Relying Party SHALL validate the qualified signature of a QEAA in accordance with Art.32 of the [European Digital Identity Regulation]. For the verification, the Relying Party SHALL use a trust anchor provided in a QEAA Provider Trusted List made available in accordance with [Art. 22](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ.L_.2014.257.01.0073.01.ENG#d1e2162-73-1) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_14" markdown>
+<div class="eudi-hlr__id">OIA_14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a PuB-EAA using a trust anchor provided in a PUB-EAA Provider Trusted List made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_15" markdown>
+<div class="eudi-hlr__id">OIA_15<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a non-qualified EAA using a trust anchor provided according to the mechanism(s) specified in the applicable Rulebook, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)].
+
+*Note: a) OIA_12 - OIA_15 imply that a Relying Party Instance must know if the attestation it is requesting from a Wallet Instance is a PID, a QEAA, a PuB-EAA, or a non-qualified EAA. These requirements also imply that the Relying Party Instance must store trust anchors in such a way that, at the time of verification, it is able to distinguish between trust anchors usable either for PIDs, for QEAAs, for PuB-EAAs, or for non-qualified EAAs.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_16" markdown>
+<div class="eudi-hlr__id">OIA_16<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When receiving a PID or attestation, a Relying Party Instance SHALL discard the values of all unique elements, including at least the ones mentioned in requirement ISSU_35 in [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), as well as any timestamps, as soon as they are no longer needed. The Relying Party Instance SHALL NOT communicate these values to the Relying Party or to any other party inside or outside the EUDI Wallet ecosystem.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="OIA_17" markdown>
+<div class="eudi-hlr__id">OIA_17<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Relying Party Instance SHOULD verify the device-binding signature or Message Authentication Code provided in the presentation response of the Wallet Unit during the presentation of a PID or device-bound attestation, following the steps specified per [ISO/IEC 18013-5] or [SD-JWT VC], as applicable.
+
+</div>
+</div>
+
 
 #### A.2.3.2 Topic 3 - PID Rulebook
 
 ##### A. Generic HLRs <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| PID_01 | PIDs and PID Providers SHALL comply with all requirements in [PID Rulebook]. |
-| PID_02 | A PID Provider SHALL issue any PID in both the format specified in ISO/IEC 18013-5 [ISO/IEC 18013-5] and the format specified in [SD-JWT VC]. *Note: [CIR 2024/2977] mentions the W3C Verifiable Credentials Data Model v1.1 instead of [SD-JWT VC]. The latest stable version of this standard is [W3C VCDM 2.0]. However, W3C VCDM is not a complete specification of an attestation format. In particular, it does not specify a specific proof method to be used. Without additional specification, such as those in [W3C VC-JOSE-COSE] or [W3C VC Data Integrity], and making further choices, it is impossible to implement a PID based on W3C VCDM. This Rulebook considers [SD-JWT VC] to essentially be such an additional specification. See also [Section 5.4.4](../../architecture-and-reference-framework-main.md#544-w3c-verifiable-credentials) of the ARF main document.* |
-| PID_03 | The portrait in a PID SHALL consist of a single portrait image in JPEG format. The portrait image SHALL comply with the quality requirements for a Full Frontal Image Type in ISO/IEC 19794-5 clauses 8.2, 8.3, and 8.4. However, the attribute portrait SHALL NOT comply with the format requirements in ISO/IEC 19794-5 clauses 8.1 and 8.5, meaning it SHALL NOT contain any of the headers or blocks specified in clause 5 except for the image data itself (a JPEG). |
+<div class="eudi-hlr" id="PID_01" markdown>
+<div class="eudi-hlr__id">PID_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+PIDs and PID Providers SHALL comply with all requirements in [PID Rulebook].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_02" markdown>
+<div class="eudi-hlr__id">PID_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider SHALL issue any PID in both the format specified in ISO/IEC 18013-5 [ISO/IEC 18013-5] and the format specified in [SD-JWT VC].
+
+*Note: [CIR 2024/2977] mentions the W3C Verifiable Credentials Data Model v1.1 instead of [SD-JWT VC]. The latest stable version of this standard is [W3C VCDM 2.0]. However, W3C VCDM is not a complete specification of an attestation format. In particular, it does not specify a specific proof method to be used. Without additional specification, such as those in [W3C VC-JOSE-COSE] or [W3C VC Data Integrity], and making further choices, it is impossible to implement a PID based on W3C VCDM. This Rulebook considers [SD-JWT VC] to essentially be such an additional specification. See also [Section 5.4.4](../../architecture-and-reference-framework-main.md#544-w3c-verifiable-credentials) of the ARF main document.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_03" markdown>
+<div class="eudi-hlr__id">PID_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The portrait in a PID SHALL consist of a single portrait image in JPEG format. The portrait image SHALL comply with the quality requirements for a Full Frontal Image Type in ISO/IEC 19794-5 clauses 8.2, 8.3, and 8.4. However, the attribute portrait SHALL NOT comply with the format requirements in ISO/IEC 19794-5 clauses 8.1 and 8.5, meaning it SHALL NOT contain any of the headers or blocks specified in clause 5 except for the image data itself (a JPEG).
+
+</div>
+</div>
+
 
 ##### B. HLRs for ISO/IEC 18013-5-compliant PIDs <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| PID_04 | PID Providers SHALL use "eu.europa.ec.eudi.pid.1" as the attestation type for ISO/IEC 18013-5-compliant PIDs. *Note: a) This identifier uses the general format [Reverse Domain].[Domain Specific Extension]. Since the European Commission controls the domain ec.europa.eu, this attestation type identifier will not collide with any attestation type identifiers defined by other organisations in other Attestation Rulebooks. b) The version number 1 in this identifier is used to distinguish between the first version of the PID, defined in the [PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md), and any future version, which will then have an incremented version number.* |
-| PID_05 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL use the value "eu.europa.ec.eudi.pid.1" for the identifier of the namespace for the PID attributes specified in [Section 4.2 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md). *Note: a) The version number 1 allows for future extension(s) or change(s) of the ISO/IEC 18013-5-compliant PID attributes. b) This namespace has the same value as the attestation type specified in requirement PID_04. This is allowed according to ISO/IEC 18013-5.* |
-| PID_06 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider MAY include attributes that are not defined in the [PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md). If so, these attributes SHALL be defined within a domestic PID namespace as meant in requirement ARB_10 in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks). The PID Provider SHALL generate the identifier for this domestic PID namespace by appending the applicable ISO 3166-1 alpha-2 country code or the ISO 3166-2 region code, separated by a period, to the PID namespace identifier specified in PID_05, excluding the version number. The PID Provider MAY include a version number in the domestic PID namespace identifier. *Note: For example, the identifier of the first domestic PID namespace for Germany could be "eu.europa.ec.eudi.pid.de.1".* |
-| PID_07 | A PID Provider that defines a domestic namespace SHALL publish the namespace, including all attribute identifiers, their definition, presence and encoding format, in an Attestation Rulebook complying with all applicable requirements in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks). |
-| PID_08 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL include both the attributes and the metadata specified in [CIR 2024/2977] in the PID as issuer-signed data elements. *Note: This implies that technically speaking, there is no difference between these attributes and metadata.* |
-| PID_09 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL encode each attribute or metadata in the PID as specified in the third column of the tables in [Section 4.2.1 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md). |
-| PID_10 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL encode each attribute or metadata in the PID in Concise Binary Object Representation (CBOR) according to [RFC 8949]. |
-| PID_11 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL ensure that each PID contains at most one attribute with the same attribute identifier. |
-| PID_12 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL ensure that the value of all attributes and metadata in the PID is valid at the value of the timestamp in the validFrom element in the MSO, see [ISO/IEC 18013-5] clause 9.1.2.4. *Note: The value of the age_over_18, age_over_NN, or age_in_years attributes, if present, changes whenever the User to whom the person identification data relates has a relevant birthday. The value of many other attributes will also change over time.* |
-| PID_13 | If a PID Provider issues PIDs compliant with [ISO/IEC 18013-5] and containing the `issuance_date` or `expiry_date` attributes, the PID Provider SHALL have a policy for determining the value of these attributes relative to the `validFrom` and `validUntil` elements in the MSO, see [ISO/IEC 18013-5] clause 9.1.2.4. *Note: See the notes to the `issuance_date` and `expiry_date` attributes in [PID Rulebook]. Examples of aspects to be considered in the policy may include (but are not limited to) the following:  1)  If an `issuance_date` or `expiry_date` is encoded as a `full-date` (rather than a `tdate`), it has no time element. However, `validFrom` and `validUntil` contain a time element, which is expressed in UTC. Therefore, comparing `expiry_date` to `validUntil`, for instance, may give ambiguous results in case the local time is not equal to UTC. The policy should ensure that situations are avoided where the User can legitimately expect (based on the values of `issuance_date` and `expiry_date` shown by the Wallet Unit when displaying the PID) that they can use their PID, while in reality its technical validity period (as determined by `validFrom` and `validUntil`) has not yet begun or has ended. 2) The exact meaning of `issuance_date` and `expiry_date` depends on local law and regulations. For example, in some jurisdictions an identity document whose `expiry_date` is in the past may by law still be used for identification for some purposes. However, this requires that the PID is still valid according to the `validFrom` and `validUntil` timestamps in the MSO. 3) A local requirement may exist stating that `issuance_date` and `expiry_date` must be identical to the dates on an existing physical document of the User.* |
+<div class="eudi-hlr" id="PID_04" markdown>
+<div class="eudi-hlr__id">PID_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+PID Providers SHALL use "eu.europa.ec.eudi.pid.1" as the attestation type for ISO/IEC 18013-5-compliant PIDs.
+
+*Note: a) This identifier uses the general format [Reverse Domain].[Domain Specific Extension]. Since the European Commission controls the domain ec.europa.eu, this attestation type identifier will not collide with any attestation type identifiers defined by other organisations in other Attestation Rulebooks. b) The version number 1 in this identifier is used to distinguish between the first version of the PID, defined in the [PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md), and any future version, which will then have an incremented version number.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_05" markdown>
+<div class="eudi-hlr__id">PID_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL use the value "eu.europa.ec.eudi.pid.1" for the identifier of the namespace for the PID attributes specified in [Section 4.2 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md).
+
+*Note: a) The version number 1 allows for future extension(s) or change(s) of the ISO/IEC 18013-5-compliant PID attributes. b) This namespace has the same value as the attestation type specified in requirement PID_04. This is allowed according to ISO/IEC 18013-5.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_06" markdown>
+<div class="eudi-hlr__id">PID_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider MAY include attributes that are not defined in the [PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md). If so, these attributes SHALL be defined within a domestic PID namespace as meant in requirement ARB_10 in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks). The PID Provider SHALL generate the identifier for this domestic PID namespace by appending the applicable ISO 3166-1 alpha-2 country code or the ISO 3166-2 region code, separated by a period, to the PID namespace identifier specified in PID_05, excluding the version number. The PID Provider MAY include a version number in the domestic PID namespace identifier.
+
+*Note: For example, the identifier of the first domestic PID namespace for Germany could be "eu.europa.ec.eudi.pid.de.1".*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_07" markdown>
+<div class="eudi-hlr__id">PID_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider that defines a domestic namespace SHALL publish the namespace, including all attribute identifiers, their definition, presence and encoding format, in an Attestation Rulebook complying with all applicable requirements in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_08" markdown>
+<div class="eudi-hlr__id">PID_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL include both the attributes and the metadata specified in [CIR 2024/2977] in the PID as issuer-signed data elements.
+
+*Note: This implies that technically speaking, there is no difference between these attributes and metadata.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_09" markdown>
+<div class="eudi-hlr__id">PID_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL encode each attribute or metadata in the PID as specified in the third column of the tables in [Section 4.2.1 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_10" markdown>
+<div class="eudi-hlr__id">PID_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL encode each attribute or metadata in the PID in Concise Binary Object Representation (CBOR) according to [RFC 8949].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_11" markdown>
+<div class="eudi-hlr__id">PID_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL ensure that each PID contains at most one attribute with the same attribute identifier.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_12" markdown>
+<div class="eudi-hlr__id">PID_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL ensure that the value of all attributes and metadata in the PID is valid at the value of the timestamp in the validFrom element in the MSO, see [ISO/IEC 18013-5] clause 9.1.2.4.
+
+*Note: The value of the age_over_18, age_over_NN, or age_in_years attributes, if present, changes whenever the User to whom the person identification data relates has a relevant birthday. The value of many other attributes will also change over time.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_13" markdown>
+<div class="eudi-hlr__id">PID_13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a PID Provider issues PIDs compliant with [ISO/IEC 18013-5] and containing the `issuance_date` or `expiry_date` attributes, the PID Provider SHALL have a policy for determining the value of these attributes relative to the `validFrom` and `validUntil` elements in the MSO, see [ISO/IEC 18013-5] clause 9.1.2.4.
+
+*Note: See the notes to the `issuance_date` and `expiry_date` attributes in [PID Rulebook]. Examples of aspects to be considered in the policy may include (but are not limited to) the following:  1)  If an `issuance_date` or `expiry_date` is encoded as a `full-date` (rather than a `tdate`), it has no time element. However, `validFrom` and `validUntil` contain a time element, which is expressed in UTC. Therefore, comparing `expiry_date` to `validUntil`, for instance, may give ambiguous results in case the local time is not equal to UTC. The policy should ensure that situations are avoided where the User can legitimately expect (based on the values of `issuance_date` and `expiry_date` shown by the Wallet Unit when displaying the PID) that they can use their PID, while in reality its technical validity period (as determined by `validFrom` and `validUntil`) has not yet begun or has ended. 2) The exact meaning of `issuance_date` and `expiry_date` depends on local law and regulations. For example, in some jurisdictions an identity document whose `expiry_date` is in the past may by law still be used for identification for some purposes. However, this requires that the PID is still valid according to the `validFrom` and `validUntil` timestamps in the MSO. 3) A local requirement may exist stating that `issuance_date` and `expiry_date` must be identical to the dates on an existing physical document of the User.*
+
+</div>
+</div>
+
 
 ##### C. HLRs for SD-JWT VC-compliant PIDs <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| PID_14 | A PID Provider issuing [SD-JWT VC]-compliant PIDs SHALL include the vct claim in their PIDs, where the vct claim SHALL be a URN within the `urn:eudi:pid:` namespace. The type indicated by the vct claim SHALL be `urn:eudi:pid:1` for the type defined in this document or a domestic type that extends it. |
-| PID_15 | Empty |
-| PID_16 | A PID Provider that defines a domestic type SHALL publish information about the type, including all claim identifiers, their definition, presence and encoding format, in an Attestation Rulebook complying with all applicable requirements in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks). |
-| PID_17 | When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL include both the attributes and the metadata specified in [CIR 2024/2977] in the PID as claims. *Note: This implies that technically speaking, there is no difference between these attributes and metadata.* |
-| PID_18 | When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL encode each attribute or metadata in the PID as specified in the tables in [Section 5.2 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md). |
-| PID_19 | When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL ensure that the value of all attributes and metadata in the PID is valid at the value of the timestamp in the nbf claim, if present. *Note: The value of the age-related claims, if present, changes whenever the User to whom the person identification data relates has a relevant birthday. The value of many other attributes will also change over time.* |
-| PID_20 | If a PID Provider issues PIDs compliant with [SD-JWT VC] and containing the `date_of_issuance` or `date_of_expiry` claims, the PID Provider SHALL have a policy for determining the value of these claims relative to the `nbf` and `exp` claims in the SD-JWT VC, see [SD-JWT VC] section 3.2.2.2. *Note: See the notes to the `date_of_issuance` and `date_of_expiry` attributes in [PID Rulebook]. Examples of aspects to be considered in the policy may include (but are not limited to) the following: 1) `date_of_issuance` and `date_of_expiry` claims do not have a time element. However, `nbf` and `exp` express a time relative to UTC. Therefore, comparing `date_of_expiry` to `exp`, for instance, may give ambiguous results in case the local time is not equal to UTC. The policy should ensure that situations are avoided where the User can legitimately expect (based on the value of `date_of_issuance` and `date_of_expiry` shown by the Wallet Unit when displaying the PID) that they can use their PID, while in reality its technical validity period (as determined by `nbf` and `exp`) has not yet begun or has ended. 2) The exact meaning of `date_of_issuance` and `date_of_expiry` depends on local law and regulations. For example, in some jurisdictions an identity document whose `date_of_expiry` is in the past may by law still be used for identification for some purposes. However, this requires that the PID is still valid according to the `nbf` and `exp` timestamps in the SD_JWT VC. 3) A local requirement may exist stating that `date_of_issuance` and `date_of_expiry` must be identical to the dates on an existing physical document of the User.* |
-| PID_21 | When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL make all claims (i.e., all top-level properties, all nested properties, and all array entries) selectively disclosable individually, except those claims defined as non-selectively disclosable in [SD-JWT VC]. |
+<div class="eudi-hlr" id="PID_14" markdown>
+<div class="eudi-hlr__id">PID_14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider issuing [SD-JWT VC]-compliant PIDs SHALL include the vct claim in their PIDs, where the vct claim SHALL be a URN within the `urn:eudi:pid:` namespace. The type indicated by the vct claim SHALL be `urn:eudi:pid:1` for the type defined in this document or a domestic type that extends it.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_15" markdown>
+<div class="eudi-hlr__id">PID_15</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_16" markdown>
+<div class="eudi-hlr__id">PID_16<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider that defines a domestic type SHALL publish information about the type, including all claim identifiers, their definition, presence and encoding format, in an Attestation Rulebook complying with all applicable requirements in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_17" markdown>
+<div class="eudi-hlr__id">PID_17<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL include both the attributes and the metadata specified in [CIR 2024/2977] in the PID as claims.
+
+*Note: This implies that technically speaking, there is no difference between these attributes and metadata.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_18" markdown>
+<div class="eudi-hlr__id">PID_18<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL encode each attribute or metadata in the PID as specified in the tables in [Section 5.2 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_19" markdown>
+<div class="eudi-hlr__id">PID_19<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL ensure that the value of all attributes and metadata in the PID is valid at the value of the timestamp in the nbf claim, if present.
+
+*Note: The value of the age-related claims, if present, changes whenever the User to whom the person identification data relates has a relevant birthday. The value of many other attributes will also change over time.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_20" markdown>
+<div class="eudi-hlr__id">PID_20<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a PID Provider issues PIDs compliant with [SD-JWT VC] and containing the `date_of_issuance` or `date_of_expiry` claims, the PID Provider SHALL have a policy for determining the value of these claims relative to the `nbf` and `exp` claims in the SD-JWT VC, see [SD-JWT VC] section 3.2.2.2.
+
+*Note: See the notes to the `date_of_issuance` and `date_of_expiry` attributes in [PID Rulebook]. Examples of aspects to be considered in the policy may include (but are not limited to) the following: 1) `date_of_issuance` and `date_of_expiry` claims do not have a time element. However, `nbf` and `exp` express a time relative to UTC. Therefore, comparing `date_of_expiry` to `exp`, for instance, may give ambiguous results in case the local time is not equal to UTC. The policy should ensure that situations are avoided where the User can legitimately expect (based on the value of `date_of_issuance` and `date_of_expiry` shown by the Wallet Unit when displaying the PID) that they can use their PID, while in reality its technical validity period (as determined by `nbf` and `exp`) has not yet begun or has ended. 2) The exact meaning of `date_of_issuance` and `date_of_expiry` depends on local law and regulations. For example, in some jurisdictions an identity document whose `date_of_expiry` is in the past may by law still be used for identification for some purposes. However, this requires that the PID is still valid according to the `nbf` and `exp` timestamps in the SD_JWT VC. 3) A local requirement may exist stating that `date_of_issuance` and `date_of_expiry` must be identical to the dates on an existing physical document of the User.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PID_21" markdown>
+<div class="eudi-hlr__id">PID_21<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL make all claims (i.e., all top-level properties, all nested properties, and all array entries) selectively disclosable individually, except those claims defined as non-selectively disclosable in [SD-JWT VC].
+
+</div>
+</div>
+
 
 #### A.2.3.3 Topic 4 - mDL Rulebook
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| mDL_01 | mDLs and mDL Providers SHALL comply with all requirements in [mDL Rulebook]. |
+<div class="eudi-hlr" id="mDL_01" markdown>
+<div class="eudi-hlr__id">mDL_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+mDLs and mDL Providers SHALL comply with all requirements in [mDL Rulebook].
+
+</div>
+</div>
+
 
 #### A.2.3.4 Topic 6 - Relying Party authentication and User approval
 
 ##### A. Relying Party authentication <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| RPA_01 | The Wallet Unit used by a User, as well as the Relying Party Instance used by the Relying Party, SHALL implement a mechanism for Relying Party authentication in PID or attestation presentation transactions. This mechanism SHALL: - enable the Wallet Unit to identify and authenticate the Relying Party, - enable the Wallet Unit to verify that the request from the Relying Party was not copied and replayed, - use an access certificate issued in accordance with [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)]. *Note: Wallet Units and Relying Parties comply with this requirement if they comply with the requirements in this Topic.* |
-| RPA_01a | If a Wallet Unit supports the [W3C Digital Credentials API] for remote presentation flows, it SHALL retain full authority over the process meant in RPA_01. In particular, this process SHALL NOT be handled by a third party, including the browser and the operating system. |
-| RPA_02 | For performing Relying Party authentication, Wallet Units and Relying Party Instances SHALL support access certificates as specified in [ETSI TS 119 475] and [ETSI TS 119 411-8]. *Note: In [ISO/IEC 18013-5], the Relying Party authentication mechanism is called mdoc reader authentication and uses an X.509 certificate. For [OpenID4VP], [HAIP] specifies that Client Identifier Prefix ``x509_hash`` must be used to authenticate the Relying Party; this also uses an X.509 certificate.* |
-| RPA_02a | Empty |
-| RPA_03 | A Wallet Unit and a Relying Party Instance SHALL perform Relying Party authentication in all PID or attestation presentation transactions to Relying Parties, whether proximity or remote, using an access certificate. *Note: The actions both entities perform differ. For example, while the Relying Party creates a signature over some data in the request, the Wallet Unit validates that signature.* |
-| RPA_04 | For the verification of access certificates, a Wallet Unit SHALL accept only the trust anchors in the LoTE(s) of all Access Certificate Authorities notified by Member States. *Note: For more information about Access Certificate Authorities, please see [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].* |
-| RPA_05 | If Relying Party authentication fails for any reason, the Wallet Instance SHALL inform the User that the identity of the Relying Party could not be verified and that therefore the request is not trustworthy. |
-| RPA_06 | If Relying Party authentication succeeds, the Wallet Instance SHALL display to the User the trade names of the Relying Party and its Service, as included in the access certificate received from the Relying Party Instance, together with the attributes requested by the Relying Party. The Wallet Instance SHALL do so when asking the User for approval according to RPA_07. *Note: a) A Relying Party Instance may be used for multiple Relying Party services, provided it has received a separate access certificate for each, see Reg_10b. b) If the Relying Party is an intermediary acting on behalf of an intermediated Relying Party, the Wallet Instance displays the trade names of both the intermediary and the intermediated Relying Party to the User, see RPI_07.* |
-| RPA_06a | If Relying Party authentication fails for any reason, the Wallet Unit SHALL notify the User. In addition, the Wallet Unit SHALL either not present the requested attributes to the Relying Party, or give the User the choice to present the requested attributes or not. *Note: It is up to the Wallet Provider to make a choice for one of these two options.* |
+<div class="eudi-hlr" id="RPA_01" markdown>
+<div class="eudi-hlr__id">RPA_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit used by a User, as well as the Relying Party Instance used by the Relying Party, SHALL implement a mechanism for Relying Party authentication in PID or attestation presentation transactions. This mechanism SHALL: - enable the Wallet Unit to identify and authenticate the Relying Party, - enable the Wallet Unit to verify that the request from the Relying Party was not copied and replayed, - use an access certificate issued in accordance with [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].
+
+*Note: Wallet Units and Relying Parties comply with this requirement if they comply with the requirements in this Topic.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_01a" markdown>
+<div class="eudi-hlr__id">RPA_01a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Unit supports the [W3C Digital Credentials API] for remote presentation flows, it SHALL retain full authority over the process meant in RPA_01. In particular, this process SHALL NOT be handled by a third party, including the browser and the operating system.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_02" markdown>
+<div class="eudi-hlr__id">RPA_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For performing Relying Party authentication, Wallet Units and Relying Party Instances SHALL support access certificates as specified in [ETSI TS 119 475] and [ETSI TS 119 411-8].
+
+*Note: In [ISO/IEC 18013-5], the Relying Party authentication mechanism is called mdoc reader authentication and uses an X.509 certificate. For [OpenID4VP], [HAIP] specifies that Client Identifier Prefix ``x509_hash`` must be used to authenticate the Relying Party; this also uses an X.509 certificate.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_02a" markdown>
+<div class="eudi-hlr__id">RPA_02a</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_03" markdown>
+<div class="eudi-hlr__id">RPA_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit and a Relying Party Instance SHALL perform Relying Party authentication in all PID or attestation presentation transactions to Relying Parties, whether proximity or remote, using an access certificate.
+
+*Note: The actions both entities perform differ. For example, while the Relying Party creates a signature over some data in the request, the Wallet Unit validates that signature.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_04" markdown>
+<div class="eudi-hlr__id">RPA_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the verification of access certificates, a Wallet Unit SHALL accept only the trust anchors in the LoTE(s) of all Access Certificate Authorities notified by Member States.
+
+*Note: For more information about Access Certificate Authorities, please see [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_05" markdown>
+<div class="eudi-hlr__id">RPA_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Relying Party authentication fails for any reason, the Wallet Instance SHALL inform the User that the identity of the Relying Party could not be verified and that therefore the request is not trustworthy.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_06" markdown>
+<div class="eudi-hlr__id">RPA_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Relying Party authentication succeeds, the Wallet Instance SHALL display to the User the trade names of the Relying Party and its Service, as included in the access certificate received from the Relying Party Instance, together with the attributes requested by the Relying Party. The Wallet Instance SHALL do so when asking the User for approval according to RPA_07.
+
+*Note: a) A Relying Party Instance may be used for multiple Relying Party services, provided it has received a separate access certificate for each, see Reg_10b. b) If the Relying Party is an intermediary acting on behalf of an intermediated Relying Party, the Wallet Instance displays the trade names of both the intermediary and the intermediated Relying Party to the User, see RPI_07.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_06a" markdown>
+<div class="eudi-hlr__id">RPA_06a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Relying Party authentication fails for any reason, the Wallet Unit SHALL notify the User. In addition, the Wallet Unit SHALL either not present the requested attributes to the Relying Party, or give the User the choice to present the requested attributes or not.
+
+*Note: It is up to the Wallet Provider to make a choice for one of these two options.*
+
+</div>
+</div>
+
 
 ##### B. User approval <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| RPA_07 | A Wallet Unit SHALL ensure the User approved the presentation of any attribute(s) in the Wallet Unit to a Relying Party or Verifier Wallet Unit, prior to presenting these attributes. A Wallet Unit SHALL always allow the User to refuse presenting an attribute requested by the Relying Party or Verifier Wallet Unit. |
-| RPA_07a | If a Wallet Unit supports the [W3C Digital Credentials API] for remote presentation flows, it SHALL retain full authority over the process meant in RPA_07. In particular, this process SHALL NOT be handled by a third party, including the browser and the operating system. |
-| RPA_08 | A Wallet Unit SHALL authenticate the User before allowing the User to give or refuse approval for releasing any attributes, in accordance with WIAM_14 or WIAM_15, as applicable. |
-| RPA_09 | Empty |
-| RPA_10 | When asking for User approval, the Wallet Unit SHALL show to the User the User-friendly description of the Relying Party's intended use and, if available, the link to the applicable privacy policy. *Note: The User-friendly description of the Relying Party's intended use is included in the presentation request and also in the registration certificate, if available. The link to the privacy policy is included in the registration certificate, or in the absence of a registration certificate, the Wallet Unit obtained the link from the Registrar's online service, if the User requested this. See RPRC_19a and other requirements in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties) for details.* |
-| RPA_10a | The Wallet Unit SHOULD ensure that the User gives approval either to present all attributes requested in a presentation request, or none of them. *Note: This means that a User should be asked either to approve the presentation of all requested attributes or to deny all of them. The Wallet Unit should not allow partial approval, since this would mean that the Relying Party cannot deliver the service, but nevertheless receives some User attributes. This would be a violation of the User's privacy. Note that a Relying Party is not allowed to request more data than is justified for the intended use. So if the User feels that the Relying Party is actually requesting more data than needed, that implies that the Relying Party is not trustworthy and should not receive any data.* |
-| RPA_11 | When the presentation of an attestation or a PID is denied by the User, the Wallet Unit SHALL behave towards the Relying Party as if the attestation or PID did not exist. |
-| RPA_12 | When asking for User approval, the Wallet Unit MAY indicate to the User whether the attestation requested by a Relying Party is device-bound or not. *Note: The intent of this indication is to warn the User that a non-device-bound attestation may be copied by the Relying Party and presented to a third party.* |
+<div class="eudi-hlr" id="RPA_07" markdown>
+<div class="eudi-hlr__id">RPA_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL ensure the User approved the presentation of any attribute(s) in the Wallet Unit to a Relying Party or Verifier Wallet Unit, prior to presenting these attributes. A Wallet Unit SHALL always allow the User to refuse presenting an attribute requested by the Relying Party or Verifier Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_07a" markdown>
+<div class="eudi-hlr__id">RPA_07a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Unit supports the [W3C Digital Credentials API] for remote presentation flows, it SHALL retain full authority over the process meant in RPA_07. In particular, this process SHALL NOT be handled by a third party, including the browser and the operating system.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_08" markdown>
+<div class="eudi-hlr__id">RPA_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL authenticate the User before allowing the User to give or refuse approval for releasing any attributes, in accordance with WIAM_14 or WIAM_15, as applicable.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_09" markdown>
+<div class="eudi-hlr__id">RPA_09</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_10" markdown>
+<div class="eudi-hlr__id">RPA_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When asking for User approval, the Wallet Unit SHALL show to the User the User-friendly description of the Relying Party's intended use and, if available, the link to the applicable privacy policy.
+
+*Note: The User-friendly description of the Relying Party's intended use is included in the presentation request and also in the registration certificate, if available. The link to the privacy policy is included in the registration certificate, or in the absence of a registration certificate, the Wallet Unit obtained the link from the Registrar's online service, if the User requested this. See RPRC_19a and other requirements in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties) for details.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_10a" markdown>
+<div class="eudi-hlr__id">RPA_10a<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHOULD ensure that the User gives approval either to present all attributes requested in a presentation request, or none of them.
+
+*Note: This means that a User should be asked either to approve the presentation of all requested attributes or to deny all of them. The Wallet Unit should not allow partial approval, since this would mean that the Relying Party cannot deliver the service, but nevertheless receives some User attributes. This would be a violation of the User's privacy. Note that a Relying Party is not allowed to request more data than is justified for the intended use. So if the User feels that the Relying Party is actually requesting more data than needed, that implies that the Relying Party is not trustworthy and should not receive any data.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_11" markdown>
+<div class="eudi-hlr__id">RPA_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When the presentation of an attestation or a PID is denied by the User, the Wallet Unit SHALL behave towards the Relying Party as if the attestation or PID did not exist.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPA_12" markdown>
+<div class="eudi-hlr__id">RPA_12<span class="kw-may">MAY</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When asking for User approval, the Wallet Unit MAY indicate to the User whether the attestation requested by a Relying Party is device-bound or not.
+
+*Note: The intent of this indication is to warn the User that a non-device-bound attestation may be copied by the Relying Party and presented to a third party.*
+
+</div>
+</div>
+
 
 #### A.2.3.5 Topic 7 - Attestation revocation and revocation checking
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| VCR_01 | A PID Provider, QEAA Provider, or PuB-EAA Provider SHALL use one of the following methods for revocation of a PID, QEAA, or PuB-EAA: - Only issue short-lived attestations having a validity period of 24 hours or less, such that revocation will never be necessary, - Use an Attestation Status List mechanism specified per VCR_11, or - Use an Attestation Revocation List mechanism specified per VCR_11. *Note: The 24-hour period originates from [ETSI EN 319 411-1] V1.4.1, requirement REV-6.2.4-03A. This requires that the process of revocation must take at most 24 hours. Consequently, revocation may make no sense if the attestation is valid for less than 24 hours, because it may reach the end of its validity period before it is revoked.* |
-| VCR_01a | A Wallet Provider SHALL use the method specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) for maintaining the revocation status of the underlying objects referenced in a WIA or key attestation. *Note: The 'underlying object' is the object that is actually revoked by revoking the WIA or key attestation, i.e., the Wallet Instance in case of a WIA and a WSCA/WSCD or keystore in case of a key attestation.* |
-| VCR_02 | For non-qualified EAAs, the relevant Rulebook SHALL specify whether that type of EAA must be revocable. If a non-qualified EAA type must be revocable, the relevant Rulebook SHALL determine which of the methods mentioned in VCR_01 must be implemented by the relevant EAA Providers for the revocation of such an EAA. |
-| VCR_03 | If a PID or attestation is revocable, the PID Provider of a given PID, or the Attestation Provider of a given attestation, SHALL be the only party in the EUDI Wallet ecosystem responsible for executing the revocation of that PID or attestation. *Note: A PID Provider or Attestation Provider MAY outsource the operation of the revocation process to a third party.* |
-| VCR_03a | The Wallet Provider of a given WIA or KA SHALL be the only party in the EUDI Wallet ecosystem responsible for maintaining the revocation status of the underlying object attested in that WIA or KA. *Note: A Wallet Provider MAY outsource the operation of the revocation process to a third party.* |
-| VCR_04 | A PID Provider, Attestation Provider or Wallet Provider that revoked a PID, attestation, WIA, or KA SHALL NOT reverse the revocation. |
-| VCR_05 | If a PID, attestation, WIA, or KA is revocable, the PID Provider, Attestation Provider, or Wallet Provider SHALL have a policy specifying under which conditions a PID, attestation, WIA, or KA it issued will be revoked. |
-| VCR_06 | If a PID or attestation is revocable, the PID Provider or Attestation Provider SHALL revoke a PID or attestation when its security has been compromised. |
-| VCR_07 | A Wallet Provider SHALL revoke the Wallet Instance upon the explicit request of the User to revoke their Wallet Unit. *Note: See also WURevocation_07 and _10.* |
-| VCR_07a | If a PID is revocable, the PID Provider SHALL revoke that PID upon the explicit request of the User to whom the PID was issued. |
-| VCR_07b | If an attestation is revocable, the Attestation Provider SHOULD revoke that attestation upon the explicit request of the User to whom the attestation was issued. |
-| VCR_07c | If a PID is revocable, the PID Provider SHALL revoke that PID if the Wallet Unit on which it resides is revoked, in compliance with requirement WURevocation_18 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation). |
-| VCR_07d | If an attestation is revocable, the Attestation Provider MAY revoke that attestation if the Wallet Unit on which it resides is revoked, in compliance with requirement WURevocation_19 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation). |
-| VCR_07e | If a Wallet Provider uses the per-KA approach for key attestation revocation (see WUA_28), it SHALL revoke a WSCD or keystore upon the explicit request of the User to revoke their WSCD or keystore. *Note: a) The most likely cause of such a request would be that the WSCD or keystore is a local external smart card and the User lost their WSCD or keystore. b) In contrast, under the type-shared index approach (see WUA_28), revoking the WSCD or keystore is not a per-Wallet Unit action that can be triggered by user requests. c) See also WURevocation_07a.* |
-| VCR_08 | If a PID is revocable, the PID Provider SHALL revoke a PID upon the death of the natural person who is the subject of the PID. *Note: a) In addition, in these circumstances the PID Provider also requests the Wallet Provider to revoke the Wallet Unit, see WURevocation_11. b) The topic of Wallet Units for legal persons, possibly containing a legal-person PID, has has been removed from this ARF in view of the development of a separate business wallet.* |
-| VCR_09 | If a technical PID or attestation is revocable, the PID Provider or Attestation Provider SHALL revoke that PID or attestation if the value of one or more of the attributes in the corresponding logical PID or attestation was changed (including attributes being added or deleted) and it is still valid for at least 24 hours. Subsequently, if the User's contact details are known, the PID Provider or Attestation Provider SHOULD, via an out-of-band manner, notify the User about the revocation and ask the User to request re-issuance of the PID or attestation using their Wallet Unit. *Note: If the value of the attributes is determined by a party different from the Provider, such as an Authentic Source, the Provider is responsible for ensuring that this third party notifies them about such changes.* |
-| VCR_10 | Wallet Providers SHALL implement the attestation revocation mechanisms specified per VCR_11 in their Wallet Solutions. |
-| VCR_11 | The Commission SHALL create or reference technical specifications providing all necessary details for PID Providers, Attestation Providers, and Wallet Providers to implement an Attestation Status List mechanism or an Attestation Revocation List mechanism for the PIDs, attestations, and WIAs and KAs they issue. These technical specifications SHALL also contain all details necessary for Relying Party Instances, Relying Parties, and Wallet Units interacting with other Wallet Units to use these mechanisms to verify the revocation status of PIDs, attestations, and WIAs and KAs. *Note: 'Attestation Status List' and 'Attestation Revocation List' are specific mechanisms, defined in Annex 1. Attestation Revocation Lists are sometimes referred to as 'Identifier Lists'.* |
-| VCR_12 | If a Relying Party decides it needs to be able to verify the revocation status of PIDs or attestations, it SHALL support both the Attestation Status List mechanism and the Attestation Revocation List mechanism specified per VCR_11. *Note: Per VCR_13, it is recommended but not mandatory for a Relying Party to verify whether a PID or attestation is revoked.* |
-| VCR_12a | A PID Provider or Attestation Provider SHALL support both the Attestation Status List mechanism and the Attestation Revocation List mechanism specified per VCR_11 for verifying the revocation status of a WIA or KA. |
-| VCR_13 | A Relying Party Instance SHOULD verify the revocation status of a PID or attestation upon obtaining it from a Wallet Unit, following the steps specified per VCR_11. When a Relying Party considers deviating from this recommendation by not performing revocation checking, it SHALL perform a risk analysis considering all relevant factors for the use case, including risks to the User and risks to the Relying Party itself. |
-| VCR_14 | A Relying Party SHALL perform a risk analysis considering all relevant factors for the use case, including risks to the User and risks to the Relying Party itself, to determine whether it will accept or refuse a PID or attestation in case no reliable information regarding the revocation status of that PID or attestation is available. *Note: Examples of conditions under which no reliable revocation information is available are 1) The attestation does not contain revocation information (because it is not revocable). 2) The Relying Party Instance is offline and any cached status information is no longer valid. 3) The latest attestation status lists or attestation identifier lists provided by the PID Provider or Attestation Provider (i.e., available online) are no longer valid. 4) The Relying Party Instance is offline, but the use case requires up-to-date revocation information (instead of trusting cached information that is still valid.)* |
-| VCR_15 | A Relying Party Instance SHOULD NOT request the relevant Attestation Status List or Attestation Revocation List each time an attestation is presented to it by a Wallet Unit. Rather, the Relying Party operating the Relying Party Instance SHOULD download each new version of the list once, at a time and from a location unrelated to the presentation of a PID or attestation by a User. The Relying Party SHOULD then distribute the list to all of its Relying Party Instances, using an Relying Party-internal distribution mechanism. Each Relying Party Instance SHOULD cache the list, so that it can perform revocation checks without making an online request. The Relying Party SHOULD perform a risk analysis to determine the frequency with which it will download the revocation lists and the maximum caching period its Relying Party Instances will use. |
-| VCR_16 | A PID Provider, Attestation Provider or Wallet Provider SHALL NOT require the Relying Party or Relying Party Instance to authenticate itself before downloading an Attestation Status List or Attestation Revocation List. |
-| VCR_17 | When using an Attestation Status List for revocation, the PID Provider, Attestation Provider or Wallet Provider SHALL randomly assign the index for each PID or attestation, to prevent this index from becoming a correlator. *Note: Randomly assigning indices within a bitstring or byte array is more complicated than creating random identifiers (e.g. serial numbers) for attestations, as is needed for an Attestation Revocation List. This is because duplicate indices and unnecessarily long bitstrings or byte arrays must be prevented.* |
-| VCR_18 | When using an Attestation Status List for revocation, the PID Provider, Attestation Provider, or Wallet Provider SHALL represent a sufficiently large number of PIDs, attestations, WIAs, or KAs on each Attestation Status List to ensure herd privacy. *Note: In this context, herd privacy means that if an entity requests a particular status list, the PID Provider, Attestation Provider, or Wallet Provider is not able to deduce which PID, attestation, WIA, or KA (likely) was presented to that entity. Complying with this requirement may be difficult in case the number of PIDs, attestations, WIAs, or KAs to be represented on the list is small. In such a case, decoy entries can be added to the list to obfuscate the real number of referenced PIDs, attestations, WIAs, or KAs.* |
-| VCR_19 | A Wallet Unit SHOULD regularly check the revocation status of its PIDs and attestations. In addition, the Wallet Unit SHOULD regularly check whether itself or any WSCD or keystore it uses has been revoked. In case of any revocation, the Wallet Unit SHALL notify the User accordingly. *Note: A Wallet Unit can check its own revocation status using its WIAs, and the revocation status of its WSCD and keystores using its key attestations.* |
+<div class="eudi-hlr" id="VCR_01" markdown>
+<div class="eudi-hlr__id">VCR_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider, QEAA Provider, or PuB-EAA Provider SHALL use one of the following methods for revocation of a PID, QEAA, or PuB-EAA: - Only issue short-lived attestations having a validity period of 24 hours or less, such that revocation will never be necessary, - Use an Attestation Status List mechanism specified per VCR_11, or - Use an Attestation Revocation List mechanism specified per VCR_11.
+
+*Note: The 24-hour period originates from [ETSI EN 319 411-1] V1.4.1, requirement REV-6.2.4-03A. This requires that the process of revocation must take at most 24 hours. Consequently, revocation may make no sense if the attestation is valid for less than 24 hours, because it may reach the end of its validity period before it is revoked.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_01a" markdown>
+<div class="eudi-hlr__id">VCR_01a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL use the method specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) for maintaining the revocation status of the underlying objects referenced in a WIA or key attestation.
+
+*Note: The 'underlying object' is the object that is actually revoked by revoking the WIA or key attestation, i.e., the Wallet Instance in case of a WIA and a WSCA/WSCD or keystore in case of a key attestation.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_02" markdown>
+<div class="eudi-hlr__id">VCR_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For non-qualified EAAs, the relevant Rulebook SHALL specify whether that type of EAA must be revocable. If a non-qualified EAA type must be revocable, the relevant Rulebook SHALL determine which of the methods mentioned in VCR_01 must be implemented by the relevant EAA Providers for the revocation of such an EAA.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_03" markdown>
+<div class="eudi-hlr__id">VCR_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a PID or attestation is revocable, the PID Provider of a given PID, or the Attestation Provider of a given attestation, SHALL be the only party in the EUDI Wallet ecosystem responsible for executing the revocation of that PID or attestation.
+
+*Note: A PID Provider or Attestation Provider MAY outsource the operation of the revocation process to a third party.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_03a" markdown>
+<div class="eudi-hlr__id">VCR_03a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Provider of a given WIA or KA SHALL be the only party in the EUDI Wallet ecosystem responsible for maintaining the revocation status of the underlying object attested in that WIA or KA.
+
+*Note: A Wallet Provider MAY outsource the operation of the revocation process to a third party.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_04" markdown>
+<div class="eudi-hlr__id">VCR_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider, Attestation Provider or Wallet Provider that revoked a PID, attestation, WIA, or KA SHALL NOT reverse the revocation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_05" markdown>
+<div class="eudi-hlr__id">VCR_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a PID, attestation, WIA, or KA is revocable, the PID Provider, Attestation Provider, or Wallet Provider SHALL have a policy specifying under which conditions a PID, attestation, WIA, or KA it issued will be revoked.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_06" markdown>
+<div class="eudi-hlr__id">VCR_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a PID or attestation is revocable, the PID Provider or Attestation Provider SHALL revoke a PID or attestation when its security has been compromised.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_07" markdown>
+<div class="eudi-hlr__id">VCR_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL revoke the Wallet Instance upon the explicit request of the User to revoke their Wallet Unit.
+
+*Note: See also WURevocation_07 and _10.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_07a" markdown>
+<div class="eudi-hlr__id">VCR_07a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a PID is revocable, the PID Provider SHALL revoke that PID upon the explicit request of the User to whom the PID was issued.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_07b" markdown>
+<div class="eudi-hlr__id">VCR_07b<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If an attestation is revocable, the Attestation Provider SHOULD revoke that attestation upon the explicit request of the User to whom the attestation was issued.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_07c" markdown>
+<div class="eudi-hlr__id">VCR_07c<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a PID is revocable, the PID Provider SHALL revoke that PID if the Wallet Unit on which it resides is revoked, in compliance with requirement WURevocation_18 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_07d" markdown>
+<div class="eudi-hlr__id">VCR_07d<span class="kw-may">MAY</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If an attestation is revocable, the Attestation Provider MAY revoke that attestation if the Wallet Unit on which it resides is revoked, in compliance with requirement WURevocation_19 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_07e" markdown>
+<div class="eudi-hlr__id">VCR_07e<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Provider uses the per-KA approach for key attestation revocation (see WUA_28), it SHALL revoke a WSCD or keystore upon the explicit request of the User to revoke their WSCD or keystore.
+
+*Note: a) The most likely cause of such a request would be that the WSCD or keystore is a local external smart card and the User lost their WSCD or keystore. b) In contrast, under the type-shared index approach (see WUA_28), revoking the WSCD or keystore is not a per-Wallet Unit action that can be triggered by user requests. c) See also WURevocation_07a.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_08" markdown>
+<div class="eudi-hlr__id">VCR_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a PID is revocable, the PID Provider SHALL revoke a PID upon the death of the natural person who is the subject of the PID.
+
+*Note: a) In addition, in these circumstances the PID Provider also requests the Wallet Provider to revoke the Wallet Unit, see WURevocation_11. b) The topic of Wallet Units for legal persons, possibly containing a legal-person PID, has has been removed from this ARF in view of the development of a separate business wallet.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_09" markdown>
+<div class="eudi-hlr__id">VCR_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a technical PID or attestation is revocable, the PID Provider or Attestation Provider SHALL revoke that PID or attestation if the value of one or more of the attributes in the corresponding logical PID or attestation was changed (including attributes being added or deleted) and it is still valid for at least 24 hours. Subsequently, if the User's contact details are known, the PID Provider or Attestation Provider SHOULD, via an out-of-band manner, notify the User about the revocation and ask the User to request re-issuance of the PID or attestation using their Wallet Unit.
+
+*Note: If the value of the attributes is determined by a party different from the Provider, such as an Authentic Source, the Provider is responsible for ensuring that this third party notifies them about such changes.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_10" markdown>
+<div class="eudi-hlr__id">VCR_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL implement the attestation revocation mechanisms specified per VCR_11 in their Wallet Solutions.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_11" markdown>
+<div class="eudi-hlr__id">VCR_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Commission SHALL create or reference technical specifications providing all necessary details for PID Providers, Attestation Providers, and Wallet Providers to implement an Attestation Status List mechanism or an Attestation Revocation List mechanism for the PIDs, attestations, and WIAs and KAs they issue. These technical specifications SHALL also contain all details necessary for Relying Party Instances, Relying Parties, and Wallet Units interacting with other Wallet Units to use these mechanisms to verify the revocation status of PIDs, attestations, and WIAs and KAs.
+
+*Note: 'Attestation Status List' and 'Attestation Revocation List' are specific mechanisms, defined in Annex 1. Attestation Revocation Lists are sometimes referred to as 'Identifier Lists'.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_12" markdown>
+<div class="eudi-hlr__id">VCR_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Relying Party decides it needs to be able to verify the revocation status of PIDs or attestations, it SHALL support both the Attestation Status List mechanism and the Attestation Revocation List mechanism specified per VCR_11.
+
+*Note: Per VCR_13, it is recommended but not mandatory for a Relying Party to verify whether a PID or attestation is revoked.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_12a" markdown>
+<div class="eudi-hlr__id">VCR_12a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider or Attestation Provider SHALL support both the Attestation Status List mechanism and the Attestation Revocation List mechanism specified per VCR_11 for verifying the revocation status of a WIA or KA.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_13" markdown>
+<div class="eudi-hlr__id">VCR_13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Relying Party Instance SHOULD verify the revocation status of a PID or attestation upon obtaining it from a Wallet Unit, following the steps specified per VCR_11. When a Relying Party considers deviating from this recommendation by not performing revocation checking, it SHALL perform a risk analysis considering all relevant factors for the use case, including risks to the User and risks to the Relying Party itself.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_14" markdown>
+<div class="eudi-hlr__id">VCR_14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Relying Party SHALL perform a risk analysis considering all relevant factors for the use case, including risks to the User and risks to the Relying Party itself, to determine whether it will accept or refuse a PID or attestation in case no reliable information regarding the revocation status of that PID or attestation is available.
+
+*Note: Examples of conditions under which no reliable revocation information is available are 1) The attestation does not contain revocation information (because it is not revocable). 2) The Relying Party Instance is offline and any cached status information is no longer valid. 3) The latest attestation status lists or attestation identifier lists provided by the PID Provider or Attestation Provider (i.e., available online) are no longer valid. 4) The Relying Party Instance is offline, but the use case requires up-to-date revocation information (instead of trusting cached information that is still valid.)*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_15" markdown>
+<div class="eudi-hlr__id">VCR_15<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Relying Party Instance SHOULD NOT request the relevant Attestation Status List or Attestation Revocation List each time an attestation is presented to it by a Wallet Unit. Rather, the Relying Party operating the Relying Party Instance SHOULD download each new version of the list once, at a time and from a location unrelated to the presentation of a PID or attestation by a User. The Relying Party SHOULD then distribute the list to all of its Relying Party Instances, using an Relying Party-internal distribution mechanism. Each Relying Party Instance SHOULD cache the list, so that it can perform revocation checks without making an online request. The Relying Party SHOULD perform a risk analysis to determine the frequency with which it will download the revocation lists and the maximum caching period its Relying Party Instances will use.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_16" markdown>
+<div class="eudi-hlr__id">VCR_16<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider, Attestation Provider or Wallet Provider SHALL NOT require the Relying Party or Relying Party Instance to authenticate itself before downloading an Attestation Status List or Attestation Revocation List.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_17" markdown>
+<div class="eudi-hlr__id">VCR_17<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When using an Attestation Status List for revocation, the PID Provider, Attestation Provider or Wallet Provider SHALL randomly assign the index for each PID or attestation, to prevent this index from becoming a correlator.
+
+*Note: Randomly assigning indices within a bitstring or byte array is more complicated than creating random identifiers (e.g. serial numbers) for attestations, as is needed for an Attestation Revocation List. This is because duplicate indices and unnecessarily long bitstrings or byte arrays must be prevented.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_18" markdown>
+<div class="eudi-hlr__id">VCR_18<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When using an Attestation Status List for revocation, the PID Provider, Attestation Provider, or Wallet Provider SHALL represent a sufficiently large number of PIDs, attestations, WIAs, or KAs on each Attestation Status List to ensure herd privacy.
+
+*Note: In this context, herd privacy means that if an entity requests a particular status list, the PID Provider, Attestation Provider, or Wallet Provider is not able to deduce which PID, attestation, WIA, or KA (likely) was presented to that entity. Complying with this requirement may be difficult in case the number of PIDs, attestations, WIAs, or KAs to be represented on the list is small. In such a case, decoy entries can be added to the list to obfuscate the real number of referenced PIDs, attestations, WIAs, or KAs.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="VCR_19" markdown>
+<div class="eudi-hlr__id">VCR_19<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHOULD regularly check the revocation status of its PIDs and attestations. In addition, the Wallet Unit SHOULD regularly check whether itself or any WSCD or keystore it uses has been revoked. In case of any revocation, the Wallet Unit SHALL notify the User accordingly.
+
+*Note: A Wallet Unit can check its own revocation status using its WIAs, and the revocation status of its WSCD and keystores using its key attestations.*
+
+</div>
+</div>
+
 
 #### A.2.3.6 Topic 9 - Wallet Unit Attestation and Wallet Instance Attestation
 
 ##### A. Key attestations <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WUA_01 | A Key Attestation SHALL contain information about the certification of the WSCA/WSCD or a keystore available to the Wallet Unit, and SHALL comply with the relevant requirements in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). *Note: A PID Provider or Attestation Provider can use this information to take a well-grounded decision on whether to issue a PID or attestation to the Wallet Unit.* |
-| WUA_02 | A Key Attestation SHALL enable PID Providers and Attestation Providers to verify the authenticity of a WSCD or keystore and to check whether the WSCD or keystore has been revoked. *Note: A KA carries a revocation reference that is valid for the WSCD or keystore of the Wallet Unit. How this revocation reference is managed (individually or per type of WSCD/keystore) depends on the approach chosen by the Wallet Provider (see WUA_28), but this is not relevant for the PID Provider or Attestation Provider that receives the KA.* |
-| WUA_03 | A Wallet Provider SHALL ensure that a non-revoked Wallet Unit at all times can present a temporally valid and non-revoked KA to a PID Provider or Attestation Provider during the issuance process of a PID or device-bound attestation. *Note: a) Revocation refers to the attested WSCD/keystore, not to the KA itself. b) For example, the Wallet Provider could pro-actively issue new KAs to the Wallet Unit, so that the Wallet Unit is always in possession of a valid KA. Alternatively, the Wallet Provider could ensure that whenever the User opens the Wallet Unit, it checks whether it is possession of a valid KA, and requests the Wallet Provider to issue a new KA if needed. A third possibility is that the Wallet Unit does this check only when it starts the process of requesting the (re-)issuance of a PID or attestation. Other alternatives to comply with this requirement may be used as well.* |
-| WUA_04 | When issuing, presenting, or verifying a WIA or KA, Wallet Providers, Wallet Units, PID Providers, and Attestation Providers SHALL only use cryptographic algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0]. |
-| WUA_05 | During issuance of a PID, the Wallet Unit SHALL provide the PID Provider with a valid KA describing the WSCA/WSCD that generated the new PID private key. *Note: A PID private key is always generated and managed by the WSCA/WSCD, which by definition complies with requirements for Level of Assurance High.* |
-| WUA_05a | During issuance of a device-bound attestation, a Wallet Unit SHALL retrieve the requirements of the Attestation Provider regarding key storage from the Credential Issuer metadata (see ISSU_27d). The Wallet Unit SHALL determine which of its WSCA/WSCD or keystore(s), if any, comply with these requirements. If a compliant WSCA/WSCD or keystore is available to the Wallet Unit, the Wallet Unit SHALL provide the Attestation Provider with a valid KA describing the selected WSCA/WSCD or keystore. *Note: A KA describes the certification properties of the WSCA/WSCD or a keystore (see WUA_01) and contains one or more public key(s) corresponding to private key(s) generated by and stored in that WSCA/WSCD or keystore (see WUA_09).* |
-| WUA_06 | If a Wallet Unit contains a WSCA/WSCD and one or more keystores, it SHALL, internally and securely, keep track of which PID(s) and attestation(s) are bound to which WSCA/WSCD or keystore. |
-| WUA_07 | A Wallet Unit SHALL present a KA only to a PID Provider or Attestation Provider, as part of the issuance process of a PID or a key-bound attestation, and not to a Relying Party or any other entity. |
-| WUA_08 | A WIA SHALL enable PID Providers to request a Wallet Provider to revoke a Wallet Unit, in accordance with requirement WURevocation_11, by including an identifier for the Wallet Instance in the WIA. The Wallet Provider SHALL ensure that this Wallet Instance identifier does not enable tracking of the User. *Note: a) This is a legal requirement from [CIR 2024/2977].  b) Under [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) V1.5, this Wallet Instance identifier is the URI and index to the Attestation Status List for WIAs.* |
+<div class="eudi-hlr" id="WUA_01" markdown>
+<div class="eudi-hlr__id">WUA_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Key Attestation SHALL contain information about the certification of the WSCA/WSCD or a keystore available to the Wallet Unit, and SHALL comply with the relevant requirements in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+*Note: A PID Provider or Attestation Provider can use this information to take a well-grounded decision on whether to issue a PID or attestation to the Wallet Unit.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_02" markdown>
+<div class="eudi-hlr__id">WUA_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Key Attestation SHALL enable PID Providers and Attestation Providers to verify the authenticity of a WSCD or keystore and to check whether the WSCD or keystore has been revoked.
+
+*Note: A KA carries a revocation reference that is valid for the WSCD or keystore of the Wallet Unit. How this revocation reference is managed (individually or per type of WSCD/keystore) depends on the approach chosen by the Wallet Provider (see WUA_28), but this is not relevant for the PID Provider or Attestation Provider that receives the KA.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_03" markdown>
+<div class="eudi-hlr__id">WUA_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL ensure that a non-revoked Wallet Unit at all times can present a temporally valid and non-revoked KA to a PID Provider or Attestation Provider during the issuance process of a PID or device-bound attestation.
+
+*Note: a) Revocation refers to the attested WSCD/keystore, not to the KA itself. b) For example, the Wallet Provider could pro-actively issue new KAs to the Wallet Unit, so that the Wallet Unit is always in possession of a valid KA. Alternatively, the Wallet Provider could ensure that whenever the User opens the Wallet Unit, it checks whether it is possession of a valid KA, and requests the Wallet Provider to issue a new KA if needed. A third possibility is that the Wallet Unit does this check only when it starts the process of requesting the (re-)issuance of a PID or attestation. Other alternatives to comply with this requirement may be used as well.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_04" markdown>
+<div class="eudi-hlr__id">WUA_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing, presenting, or verifying a WIA or KA, Wallet Providers, Wallet Units, PID Providers, and Attestation Providers SHALL only use cryptographic algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_05" markdown>
+<div class="eudi-hlr__id">WUA_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During issuance of a PID, the Wallet Unit SHALL provide the PID Provider with a valid KA describing the WSCA/WSCD that generated the new PID private key.
+
+*Note: A PID private key is always generated and managed by the WSCA/WSCD, which by definition complies with requirements for Level of Assurance High.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_05a" markdown>
+<div class="eudi-hlr__id">WUA_05a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During issuance of a device-bound attestation, a Wallet Unit SHALL retrieve the requirements of the Attestation Provider regarding key storage from the Credential Issuer metadata (see ISSU_27d). The Wallet Unit SHALL determine which of its WSCA/WSCD or keystore(s), if any, comply with these requirements. If a compliant WSCA/WSCD or keystore is available to the Wallet Unit, the Wallet Unit SHALL provide the Attestation Provider with a valid KA describing the selected WSCA/WSCD or keystore.
+
+*Note: A KA describes the certification properties of the WSCA/WSCD or a keystore (see WUA_01) and contains one or more public key(s) corresponding to private key(s) generated by and stored in that WSCA/WSCD or keystore (see WUA_09).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_06" markdown>
+<div class="eudi-hlr__id">WUA_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Unit contains a WSCA/WSCD and one or more keystores, it SHALL, internally and securely, keep track of which PID(s) and attestation(s) are bound to which WSCA/WSCD or keystore.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_07" markdown>
+<div class="eudi-hlr__id">WUA_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL present a KA only to a PID Provider or Attestation Provider, as part of the issuance process of a PID or a key-bound attestation, and not to a Relying Party or any other entity.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_08" markdown>
+<div class="eudi-hlr__id">WUA_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A WIA SHALL enable PID Providers to request a Wallet Provider to revoke a Wallet Unit, in accordance with requirement WURevocation_11, by including an identifier for the Wallet Instance in the WIA. The Wallet Provider SHALL ensure that this Wallet Instance identifier does not enable tracking of the User.
+
+*Note: a) This is a legal requirement from [CIR 2024/2977].  b) Under [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) V1.5, this Wallet Instance identifier is the URI and index to the Attestation Status List for WIAs.*
+
+</div>
+</div>
+
 
 ##### B. Key Attestation and Cryptographic Keys <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WUA_09 | A KA SHALL contain one or more public keys, and the corresponding private keys SHALL be generated by and stored in the WSCA/WSCD or the keystore described in the KA. *Note: a) By signing the KA, the Wallet Provider attests to the fact that the private key(s) corresponding to the public key(s) in the KA are generated by and stored in this WSCA/WSCD or keystore. This implies that the Wallet Provider has verified that this is actually the case. However, neither the ARF nor [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) specify at which moment the WSCA/WSCD or keystore generated the private keys, or how the Wallet Provider verified that it did so. b) After receiving a KA during the issuance process for a (batch of) PID(s) or device-bound attestation(s), a PID Provider or Attestation Provider will include each of these public keys in a PID or attestation, thereby ensuring that this PID or attestation is bound to the WSCA/WSCD or keystore described in the KA.* |
-| WUA_10 | Wallet Providers SHALL ensure that the certificates they use for signing WIAs and KAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 5. |
-| WUA_10a | An Attestation Provider issuing non-device-bound attestations SHALL indicate in its Credential Issuer metadata that it does not need a KA, as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). A Wallet Unit SHALL NOT send a KA to an Attestation Provider when requesting a non-device-bound attestation. *Note: A Wallet Unit sends a WIA to the Attestation Provider regardless of whether the attestations it issues are device-bound or not.* |
-| WUA_10b | A Wallet Provider SHALL ensure that the presentation of a KA is cryptographically bound to the specific context it is intended to be used in. *Note: As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), this is achieved by letting the signed KA itself contain a nonce provided by the PID Provider or Attestation Provider during the issuance process. Alternatively, the Wallet Unit presents the KA along with a Proof-of-Possession consisting of a signature over that nonce, created by the private key corresponding to one of the public keys attested in the KA.* |
-| WUA_11 | When asking for User approval to store an attestation (see ISSU_11), the Wallet Unit MAY indicate to the User whether the attestation requested by a Relying Party is device-bound or not. *Note: The intent of this indication is to warn the User that a non-device-bound attestation may be copied by an attacker breaching the Wallet Unit's security. See also RPA_12.* |
-| WUA_11a | During issuance of a PID or a device-bound attestation, the PID Provider or Attestation Provider SHALL verify the KA in accordance with the requirements in [OpenID4VCI] Appendix F.4. In addition, the PID Provider or Attestation Provider SHALL validate that the KA is not revoked. *Note: If the verification of the KA is successful, the PID Provider or Attestation Provider can trust that all public keys in the KA are bound to the WSCD or keystore described in the KA (see WUA_09).* |
-| WUA_11b | Empty |
-| WUA_12 | During issuance of a PID or a device-bound attestation, the PID Provider or Attestation Provider SHALL receive a proof that the Wallet Unit possesses the private keys corresponding to all public keys in the KA. *Note: As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), this proof consists of the signature of the Wallet Provider over the KA in combination with the proof mentioned in WUA_10b.* |
-| WUA_13 | Empty |
-| WUA_14 | Empty |
-| WUA_15 | Empty |
-| WUA_16 | Empty |
-| WUA_16a | A WSCA SHALL NOT enable export of private keys from a WSCD. *Note: The WSCA is dedicated firmware and/or software implementing specific functions needed within the EUDI Wallet ecosystem. Within that context, there is no need for private key export; therefore, a WSCA must not support it. However, a WSCD or a keystore may enable private key export via native firmware or software, for generic purposes.* |
+<div class="eudi-hlr" id="WUA_09" markdown>
+<div class="eudi-hlr__id">WUA_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A KA SHALL contain one or more public keys, and the corresponding private keys SHALL be generated by and stored in the WSCA/WSCD or the keystore described in the KA.
+
+*Note: a) By signing the KA, the Wallet Provider attests to the fact that the private key(s) corresponding to the public key(s) in the KA are generated by and stored in this WSCA/WSCD or keystore. This implies that the Wallet Provider has verified that this is actually the case. However, neither the ARF nor [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) specify at which moment the WSCA/WSCD or keystore generated the private keys, or how the Wallet Provider verified that it did so. b) After receiving a KA during the issuance process for a (batch of) PID(s) or device-bound attestation(s), a PID Provider or Attestation Provider will include each of these public keys in a PID or attestation, thereby ensuring that this PID or attestation is bound to the WSCA/WSCD or keystore described in the KA.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_10" markdown>
+<div class="eudi-hlr__id">WUA_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that the certificates they use for signing WIAs and KAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 5.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_10a" markdown>
+<div class="eudi-hlr__id">WUA_10a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attestation Provider issuing non-device-bound attestations SHALL indicate in its Credential Issuer metadata that it does not need a KA, as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). A Wallet Unit SHALL NOT send a KA to an Attestation Provider when requesting a non-device-bound attestation.
+
+*Note: A Wallet Unit sends a WIA to the Attestation Provider regardless of whether the attestations it issues are device-bound or not.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_10b" markdown>
+<div class="eudi-hlr__id">WUA_10b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL ensure that the presentation of a KA is cryptographically bound to the specific context it is intended to be used in.
+
+*Note: As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), this is achieved by letting the signed KA itself contain a nonce provided by the PID Provider or Attestation Provider during the issuance process. Alternatively, the Wallet Unit presents the KA along with a Proof-of-Possession consisting of a signature over that nonce, created by the private key corresponding to one of the public keys attested in the KA.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_11" markdown>
+<div class="eudi-hlr__id">WUA_11<span class="kw-may">MAY</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When asking for User approval to store an attestation (see ISSU_11), the Wallet Unit MAY indicate to the User whether the attestation requested by a Relying Party is device-bound or not.
+
+*Note: The intent of this indication is to warn the User that a non-device-bound attestation may be copied by an attacker breaching the Wallet Unit's security. See also RPA_12.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_11a" markdown>
+<div class="eudi-hlr__id">WUA_11a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During issuance of a PID or a device-bound attestation, the PID Provider or Attestation Provider SHALL verify the KA in accordance with the requirements in [OpenID4VCI] Appendix F.4. In addition, the PID Provider or Attestation Provider SHALL validate that the KA is not revoked.
+
+*Note: If the verification of the KA is successful, the PID Provider or Attestation Provider can trust that all public keys in the KA are bound to the WSCD or keystore described in the KA (see WUA_09).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_11b" markdown>
+<div class="eudi-hlr__id">WUA_11b</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_12" markdown>
+<div class="eudi-hlr__id">WUA_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During issuance of a PID or a device-bound attestation, the PID Provider or Attestation Provider SHALL receive a proof that the Wallet Unit possesses the private keys corresponding to all public keys in the KA.
+
+*Note: As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), this proof consists of the signature of the Wallet Provider over the KA in combination with the proof mentioned in WUA_10b.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_13" markdown>
+<div class="eudi-hlr__id">WUA_13</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_14" markdown>
+<div class="eudi-hlr__id">WUA_14</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_15" markdown>
+<div class="eudi-hlr__id">WUA_15</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_16" markdown>
+<div class="eudi-hlr__id">WUA_16</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_16a" markdown>
+<div class="eudi-hlr__id">WUA_16a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A WSCA SHALL NOT enable export of private keys from a WSCD.
+
+*Note: The WSCA is dedicated firmware and/or software implementing specific functions needed within the EUDI Wallet ecosystem. Within that context, there is no need for private key export; therefore, a WSCA must not support it. However, a WSCD or a keystore may enable private key export via native firmware or software, for generic purposes.*
+
+</div>
+</div>
+
 
 ##### C. Requirements Regarding Privacy <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WUA_17 | A Wallet Provider SHALL consider all relevant factors, including offline usage, interoperability, and the risk of a WIA or KA becoming a vector to track the User, when deciding on the validity period of a WIA or KA. *Note: a) Regarding interoperability, see WUA_30, which limits the validity period of PIDs issued based on the revocation maintenance periods of the WIA and KA received during issuance. b) As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), a PID Provider or Attestation Provider may communicate its preferences regarding the minimum revocation maintenance period of the WIA and KA to the Wallet Unit; the Wallet Unit and Wallet Provider should take this into account (see WUA_32). c) For the WIA specifically, a short technical validity period is required to ensure freshness; see WUA_33.* |
-| WUA_18 | Empty |
-| WUA_19 | Empty |
-| WUA_20 | Empty |
-| WUA_20a | Empty |
-| WUA_21 | Empty |
+<div class="eudi-hlr" id="WUA_17" markdown>
+<div class="eudi-hlr__id">WUA_17<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL consider all relevant factors, including offline usage, interoperability, and the risk of a WIA or KA becoming a vector to track the User, when deciding on the validity period of a WIA or KA.
+
+*Note: a) Regarding interoperability, see WUA_30, which limits the validity period of PIDs issued based on the revocation maintenance periods of the WIA and KA received during issuance. b) As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), a PID Provider or Attestation Provider may communicate its preferences regarding the minimum revocation maintenance period of the WIA and KA to the Wallet Unit; the Wallet Unit and Wallet Provider should take this into account (see WUA_32). c) For the WIA specifically, a short technical validity period is required to ensure freshness; see WUA_33.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_18" markdown>
+<div class="eudi-hlr__id">WUA_18</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_19" markdown>
+<div class="eudi-hlr__id">WUA_19</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_20" markdown>
+<div class="eudi-hlr__id">WUA_20</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_20a" markdown>
+<div class="eudi-hlr__id">WUA_20a</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_21" markdown>
+<div class="eudi-hlr__id">WUA_21</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 ##### D. Wallet Instance Attestations <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WUA_22 | A Wallet Provider SHALL ensure that a non-revoked Wallet Unit at all times can present a temporally valid and non-revoked WIA to a PID Provider or Attestation Provider during the issuance process of a PID or attestation. *Note: a) This requirement applies to both device-bound and non-device-bound attestations. b) Revocation refers to the attested Wallet Instance, not to the WIA itself. c) For example, the Wallet Provider could pro-actively issue new WIAs to the Wallet Unit, so that the Wallet Unit is always in possession of a valid WIA. Alternatively, the Wallet Provider could ensure that whenever the User opens the Wallet Unit, it checks whether it is possession of a valid WIA, and requests the Wallet Provider to issue a new WIA if needed. A third possibility is that the Wallet Unit does this check only when it starts the process of requesting the (re-)issuance of a PID or attestation. Other alternatives to comply with this requirement may be used as well.* |
-| WUA_23 | Empty |
-| WUA_24 | A Wallet Unit SHALL present a WIA only to a PID Provider or Attestation Provider, as part of the issuance process of a PID or an attestation, and not to a Relying Party or any other entity. |
-| WUA_25 | During issuance of a PID or attestation, the PID Provider or Attestation Provider SHALL verify the WIA in accordance with the requirements in [OpenID4VCI] Appendix E. In addition, the PID Provider or Attestation Provider SHALL validate that the WIA is not revoked. *Note: This requirement applies to both device-bound and non-device-bound attestations.* |
-| WUA_26 | A WIA SHALL enable PID Providers and Attestation Providers to verify the authenticity of a Wallet Instance and to check whether the Wallet Instance has been revoked. *Note: A WIA carries the revocation reference for a Wallet Instance; the revocation status of the Wallet Instance is maintained in a status list referenced in the WIA.* |
-| WUA_27 | A WIA SHALL contain information about the Wallet Solution, including its identity, version, and certification, and SHALL comply with the relevant requirements in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). *Note: This information allows PID Providers and Attestation Providers to verify that the Wallet Instance belongs to a trusted and certified Wallet Solution, as registered in the Wallet Provider Trusted List.* |
+<div class="eudi-hlr" id="WUA_22" markdown>
+<div class="eudi-hlr__id">WUA_22<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL ensure that a non-revoked Wallet Unit at all times can present a temporally valid and non-revoked WIA to a PID Provider or Attestation Provider during the issuance process of a PID or attestation.
+
+*Note: a) This requirement applies to both device-bound and non-device-bound attestations. b) Revocation refers to the attested Wallet Instance, not to the WIA itself. c) For example, the Wallet Provider could pro-actively issue new WIAs to the Wallet Unit, so that the Wallet Unit is always in possession of a valid WIA. Alternatively, the Wallet Provider could ensure that whenever the User opens the Wallet Unit, it checks whether it is possession of a valid WIA, and requests the Wallet Provider to issue a new WIA if needed. A third possibility is that the Wallet Unit does this check only when it starts the process of requesting the (re-)issuance of a PID or attestation. Other alternatives to comply with this requirement may be used as well.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_23" markdown>
+<div class="eudi-hlr__id">WUA_23</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_24" markdown>
+<div class="eudi-hlr__id">WUA_24<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL present a WIA only to a PID Provider or Attestation Provider, as part of the issuance process of a PID or an attestation, and not to a Relying Party or any other entity.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_25" markdown>
+<div class="eudi-hlr__id">WUA_25<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During issuance of a PID or attestation, the PID Provider or Attestation Provider SHALL verify the WIA in accordance with the requirements in [OpenID4VCI] Appendix E. In addition, the PID Provider or Attestation Provider SHALL validate that the WIA is not revoked.
+
+*Note: This requirement applies to both device-bound and non-device-bound attestations.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_26" markdown>
+<div class="eudi-hlr__id">WUA_26<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A WIA SHALL enable PID Providers and Attestation Providers to verify the authenticity of a Wallet Instance and to check whether the Wallet Instance has been revoked.
+
+*Note: A WIA carries the revocation reference for a Wallet Instance; the revocation status of the Wallet Instance is maintained in a status list referenced in the WIA.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_27" markdown>
+<div class="eudi-hlr__id">WUA_27<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A WIA SHALL contain information about the Wallet Solution, including its identity, version, and certification, and SHALL comply with the relevant requirements in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+*Note: This information allows PID Providers and Attestation Providers to verify that the Wallet Instance belongs to a trusted and certified Wallet Solution, as registered in the Wallet Provider Trusted List.*
+
+</div>
+</div>
+
 
 ##### E. Miscellaneous <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WUA_28 | A Wallet Provider SHALL select either the type-shared index approach or the per-KA index approach (as specified in Section 2.5.2 of [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md)) for managing the revocation status of the WSCD or keystore referenced in a Key Attestation. *Note: a) Under the type-shared index approach, the revocation reference is shared across all Wallet Units using the same type of WSCD or keystore, so that a single revocation action covers all affected Wallet Units (e.g., when a security vulnerability is identified in a hardware component type). Under the per-KA index approach, each KA carries a revocation reference scoped to the specific Wallet Unit's WSCD or keystore instance, enabling individual revocation that may also be triggered by user request. b) The detailed requirements for each approach are specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).* |
-| WUA_28a | If the per-KA index approach is used, the Wallet Provider SHALL ensure that the revocation reference in a KA cannot be used to link a Wallet Unit's interactions across different PID Providers or Attestation Providers. |
-| WUA_29 | Throughout the entire validity period of an issued PID, the PID Provider SHALL verify the revocation status of both the Wallet Instance and WSCD using the information in the WIA and the KA (respectively) received during the issuance of that PID. If either is revoked, the PID Provider SHALL revoke the PID. |
-| WUA_30 | The technical validity period of a PID SHALL be consistent with the period during which the Wallet Provider has committed to maintaining the revocation status of the Wallet Instance and the WSCD, as conveyed in the WIA and KA presented during issuance. *Note: a) This reflects the revocation chaining requirement: PID Providers must be able to check whether the Wallet Instance has been revoked (via the WIA) and whether the WSCD referenced in the KA has been revoked (WUA_29) for the entire PID validity period.* |
-| WUA_31 | A Wallet Provider SHALL maintain the revocation status of a Wallet Instance during the entire revocation maintenance period indicated in the WIAs issued to that Wallet Instance. |
-| WUA_31a | A Wallet Provider SHALL maintain the revocation status of a WSCD or keystore during the entire revocation maintenance period indicated in the KAs issued to the Wallet Instance(s) using that WSCD or keystore. |
-| WUA_32 | At the time of PID or attestation issuance, a PID Provider or Attestation Provider SHALL communicate to the Wallet Unit its minimum requirements regarding the remaining revocation maintenance period for Wallet Instances (in WIAs) or WSCDs/keystores (in KAs), as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). *Note: This allows PID Providers and Attestation Providers to ensure that they receive WIAs and KAs with a sufficiently long remaining revocation maintenance period, enabling revocation chaining for the intended validity period of the PID or attestation to be issued.* |
-| WUA_33 | A Wallet Provider SHALL ensure that WIAs have a short technical validity period as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), such that a WIA is fresh at the time of use. *Note: As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), the technical validity period of a WIA SHALL be less than 24 hours. This ensures that the WIA reflects a recent integrity check of the Wallet Instance. The revocation maintenance period (see WUA_26 and WUA_31) is specified separately in the WIA and may be considerably longer than the technical validity period.* |
-| WUA_34 | During issuance of a PID, a PID Provider SHALL verify that the keys attested in the KA are stored in the WSCA/WSCD described in the KA. *Note: PID private keys must be protected at Level of Assurance High, which requires key storage in a WSCA/WSCD. See also WUA_05, which requires the Wallet Unit to provide a KA describing the WSCA/WSCD that generated the PID private key.* |
-| WUA_35 | A Wallet Unit SHALL comply with all relevant requirements specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). |
-| WUA_36 | A PID Provider or Attestation Provider SHALL comply with all relevant requirements specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). |
-| WUA_37 | A Wallet Provider SHALL maintain, for each Wallet Unit it has activated, the set of WIAs and KAs it has issued to that Wallet Unit, in such a way that this association cannot be confused with that of any other Wallet Unit, including across different Wallet Solutions or different Wallet Solution versions. The Wallet Provider SHALL document the procedures, controls, and corresponding risk analysis implementing this requirement as part of the policy meant in WURevocation_03. *Note: This requirement makes explicit at the HLR level the record-keeping duty already implicit in WURevocation_07, WURevocation_07a, WIAM_05, WIAM_06, and WIAM_10, and required of the Wallet Provider by Section 2.4.2 of [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).* |
+<div class="eudi-hlr" id="WUA_28" markdown>
+<div class="eudi-hlr__id">WUA_28<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL select either the type-shared index approach or the per-KA index approach (as specified in Section 2.5.2 of [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md)) for managing the revocation status of the WSCD or keystore referenced in a Key Attestation.
+
+*Note: a) Under the type-shared index approach, the revocation reference is shared across all Wallet Units using the same type of WSCD or keystore, so that a single revocation action covers all affected Wallet Units (e.g., when a security vulnerability is identified in a hardware component type). Under the per-KA index approach, each KA carries a revocation reference scoped to the specific Wallet Unit's WSCD or keystore instance, enabling individual revocation that may also be triggered by user request. b) The detailed requirements for each approach are specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_28a" markdown>
+<div class="eudi-hlr__id">WUA_28a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the per-KA index approach is used, the Wallet Provider SHALL ensure that the revocation reference in a KA cannot be used to link a Wallet Unit's interactions across different PID Providers or Attestation Providers.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_29" markdown>
+<div class="eudi-hlr__id">WUA_29<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Throughout the entire validity period of an issued PID, the PID Provider SHALL verify the revocation status of both the Wallet Instance and WSCD using the information in the WIA and the KA (respectively) received during the issuance of that PID. If either is revoked, the PID Provider SHALL revoke the PID.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_30" markdown>
+<div class="eudi-hlr__id">WUA_30<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The technical validity period of a PID SHALL be consistent with the period during which the Wallet Provider has committed to maintaining the revocation status of the Wallet Instance and the WSCD, as conveyed in the WIA and KA presented during issuance.
+
+*Note: a) This reflects the revocation chaining requirement: PID Providers must be able to check whether the Wallet Instance has been revoked (via the WIA) and whether the WSCD referenced in the KA has been revoked (WUA_29) for the entire PID validity period.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_31" markdown>
+<div class="eudi-hlr__id">WUA_31<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL maintain the revocation status of a Wallet Instance during the entire revocation maintenance period indicated in the WIAs issued to that Wallet Instance.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_31a" markdown>
+<div class="eudi-hlr__id">WUA_31a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL maintain the revocation status of a WSCD or keystore during the entire revocation maintenance period indicated in the KAs issued to the Wallet Instance(s) using that WSCD or keystore.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_32" markdown>
+<div class="eudi-hlr__id">WUA_32<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+At the time of PID or attestation issuance, a PID Provider or Attestation Provider SHALL communicate to the Wallet Unit its minimum requirements regarding the remaining revocation maintenance period for Wallet Instances (in WIAs) or WSCDs/keystores (in KAs), as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+*Note: This allows PID Providers and Attestation Providers to ensure that they receive WIAs and KAs with a sufficiently long remaining revocation maintenance period, enabling revocation chaining for the intended validity period of the PID or attestation to be issued.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_33" markdown>
+<div class="eudi-hlr__id">WUA_33<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL ensure that WIAs have a short technical validity period as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), such that a WIA is fresh at the time of use.
+
+*Note: As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), the technical validity period of a WIA SHALL be less than 24 hours. This ensures that the WIA reflects a recent integrity check of the Wallet Instance. The revocation maintenance period (see WUA_26 and WUA_31) is specified separately in the WIA and may be considerably longer than the technical validity period.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_34" markdown>
+<div class="eudi-hlr__id">WUA_34<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During issuance of a PID, a PID Provider SHALL verify that the keys attested in the KA are stored in the WSCA/WSCD described in the KA.
+
+*Note: PID private keys must be protected at Level of Assurance High, which requires key storage in a WSCA/WSCD. See also WUA_05, which requires the Wallet Unit to provide a KA describing the WSCA/WSCD that generated the PID private key.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_35" markdown>
+<div class="eudi-hlr__id">WUA_35<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL comply with all relevant requirements specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_36" markdown>
+<div class="eudi-hlr__id">WUA_36<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider or Attestation Provider SHALL comply with all relevant requirements specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WUA_37" markdown>
+<div class="eudi-hlr__id">WUA_37<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL maintain, for each Wallet Unit it has activated, the set of WIAs and KAs it has issued to that Wallet Unit, in such a way that this association cannot be confused with that of any other Wallet Unit, including across different Wallet Solutions or different Wallet Solution versions. The Wallet Provider SHALL document the procedures, controls, and corresponding risk analysis implementing this requirement as part of the policy meant in WURevocation_03.
+
+*Note: This requirement makes explicit at the HLR level the record-keeping duty already implicit in WURevocation_07, WURevocation_07a, WIAM_05, WIAM_06, and WIAM_10, and required of the Wallet Provider by Section 2.4.2 of [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).*
+
+</div>
+</div>
+
 
 #### A.2.3.7 Topic 10 - Issuing a PID or attestation to a Wallet Unit
 
 ##### A - Generic HLRs <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ISSU_01 | Wallet Providers SHALL ensure that their Wallet Solution supports the OpenID4VCI protocol specified in [OpenID4VCI], as profiled in Sections 4 and 6 of [HAIP], and with additions and changes as documented in this Annex (see e.g. this Topic and [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)) and in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). *Note: For clarity: in [HAIP] v1.0, Section 6 implies that Wallet Units must comply with the applicable requirements in [OpenID4VCI] Annex A.2 when requesting the issuance of an attestation in ISO/IEC 18013-5-compliant format, and with the applicable requirements in [OpenID4VCI] Annex A.3 when requesting the issuance of an attestation in SD-JWT VC format.* |
-| ISSU_01a | PID Providers and Attestation Providers SHALL support the OpenID4VCI protocol specified in [OpenID4VCI], as profiled in Sections 4 and 6 of [HAIP], and with additions and changes as documented in this Annex (see e.g. this Topic and [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)) and in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). *Note: For clarity: in [HAIP] v1.0, Section 6 implies that PID Providers and Attestation Providers must comply with the applicable requirements in [OpenID4VCI] Annex A.2 when issuing an attestation in ISO/IEC 18013-5-compliant format, and with the applicable requirements in [OpenID4VCI] Annex A.3 when issuing an attestation in SD-JWT VC format.* |
-| ISSU_02 | Wallet Providers SHALL ensure that their Wallet Solution supports the attestation formats specified in ISO/IEC 18013-5, see [ISO18013-5], and in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC], with additions and changes as documented in this Annex and in future technical specifications created by or on behalf of the Commission. |
-| ISSU_03 | Wallet Units, PID Providers, and Attestation Providers SHALL support the [W3C Digital Credentials API](https://wicg.github.io/digital-credentials/) for the issuance of PIDs and attestations. *Note: This requirement implies that the following conditions will be satisfied: a) the DC API specification will become a W3C Recommendation, b) this specification will comply with the principles outlined in [Section 4.4.3.1](../../architecture-and-reference-framework-main.md#4431-introduction) of the ARF main document, c) this specification will be broadly supported by relevant browsers and operating systems, and d) the [OpenID4VCI] standard will specify how to use OpenID4VCI with the DC API.* |
-| ISSU_04 | The OpenID4VCI protocol referenced in requirement ISSU_01, or an EUDI Wallet-specific extension or profile thereof, SHALL enable PID Providers and Attestation Provider to issue to a Wallet Unit a batch of multiple PIDs or attestations that are simultaneously valid and contain the same attributes. |
-| ISSU_05 | A Wallet Unit SHALL support a process to activate a newly issued PID, in accordance with the requirements for LoA High in [Commission Implementing Regulation (EU) 2015/1502](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32015R1502) Section 2.2.2. The Wallet Unit SHALL NOT allow a User to use a non-activated PID. *Note: a) The goal of the activation process is to verify that the PID was delivered into the Wallet Unit and WSCA/WSCD of the User who is the subject of the PID. b) This requirement is not applicable for QEAAs, PuB-EAAs or non-qualified EAAs, since these are not identity means in the sense of Commission Implementing Regulation (EU) 2015/1502.* |
-| ISSU_06 | After a Wallet Unit receives a PID or an attestation from a PID Provider or Attestation Provider, it SHALL verify that the PID or attestation it received matches the PID or attestation requested by the Wallet Unit. |
-| ISSU_07 | After a Wallet Unit receives a PID from a PID Provider, it SHALL validate the signature of the PID using a trust anchor of the PID Provider provided in a LoTE made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)]. *Note: The Wallet Provider and PID Provider may be the same entity. In such a case, the remote WSCD used by the Wallet Provider may be the same hardware HSM that is also used by the PID Provider to sign PIDs. In such a situation, this requirement may look superfluous, since the same HSM would generate the signature and verify it. However, this is not true, since for security reasons the PID Provider and Wallet Provider must use proper partitioning and logical key segregation within the HSM. Therefore, this requirement also applies in such a situation.* |
-| ISSU_08 | After a Wallet Unit receives a QEAA from a QEAA Provider, it SHALL validate the qualified signature of the QEAA in accordance with Art. 32 of the [European Digital Identity Regulation]. For the verification, the Wallet Unit SHALL use a trust anchor provided in a QEAA Provider Trusted List made available in accordance with [Art. 22](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ.L_.2014.257.01.0073.01.ENG#d1e2162-73-1) of the [European Digital Identity Regulation]. *Note: a) Requirements ISSU_07 to ISSU_10 are equivalent to requirements OIA_12 to OIA_15 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit). b) These requirements imply that a Wallet Instance must be aware whether the attestation it is requesting from an issuer is a PID, a QEAA, a PuB-EAA, or a non-qualified EAA. These requirements also imply that the Wallet Unit must store trust anchors in such a way that, when it receives an issued attestation, it is able to distinguish between trust anchors usable either for PIDs, for QEAAs, for PuB-EAAs, or for non-qualified EAAs.* |
-| ISSU_09 | After a Wallet Unit receives a PuB-EAA from a PUB-EAA Provider, it SHALL validate the signature of a PuB-EAA using a trust anchor provided in a PUB-EAA Provider Trusted List made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)]. |
-| ISSU_10 | After a Wallet Unit receives a non-qualified EAA from an EAA Provider, it SHALL validate the signature of the EAA if it has access to the trust anchors of the EAA Provider. *Note: For a non-qualified EAA, an Attestation Rulebook may be available, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)], explaining how EAA Providers distribute their trust anchors. However, it is not required for Wallet Units to be in possession of the trust anchors of all non-qualified EAA Providers, even when an Attestation Rulebook is available.* |
-| ISSU_11 | A Wallet Unit SHALL request the User's approval before storing a PID or attestation obtained from a PID Provider or Attestation Provider. When requesting approval, the Wallet Instance SHALL display the contents of the PID or attestation to the User. The Wallet Instance SHALL also inform the User about the identity of the PID Provider or Attestation Provider, using the subject information in the PID Provider's or Attestation Provider's access certificate. |
-| ISSU_11a | In case a PID or attestation is issued in batches, the Wallet Unit SHALL verify that  all PIDs and attestations in a batch have the same attribute values and the same technical validity period. *Note: PIDs and attestations are issued in batches when Method A, Method B, or Method D is used, see ISSU_37, ISSU_43, ISSU_51.* |
-| ISSU_11b | In case one or more of the verifications in ISSU_06 - ISSU_11a fail, the Wallet Unit SHALL immediately delete the PID or attestation it received. The Wallet Instance SHALL notify the User about the fact that issuance of the PID or attestation was not successful, including the reason for this failure. |
-| ISSU_12 | A PID Provider or Attestation Provider SHALL offer its PIDs or attestations in all formats required in the PID Rulebook or the applicable Attestation Rulebook, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)]. *Note: Examples include the mdoc format specified in [ISO/IEC 18013-5] and the SD-JWT VC-format specified in [SD-JWT VC].* |
-| ISSU_12a | When a User instructs their Wallet Unit to request a PID or attestation from a PID Provider or Attestation Provider, the Wallet Unit SHALL request that PID or attestation in all formats offered by the PID Provider or Attestation Provider. *Note: Examples include the mdoc format specified in [ISO/IEC 18013-5] and the SD-JWT VC-format specified in [SD-JWT VC].* |
-| ISSU_12b | The WSCA/WSCD or a keystore SHALL generate a new key pair for a new PID or attestation on request of the Wallet Instance, unless that PID or attestation is issued synchronously in a remote HSM architecture. This generation request MAY be done either prior to the issuance of any PID or attestation, or during the issuance process. *Note: a) See also WUA_05 and WUA_05a. b) In case of synchronous issuing in a remote HSM architecture, re-use of an existing key pair within a limited period of time can be acceptable, based on the PID Provider's or Attestation Provider's issuance security policy. This is similar to a choice between Method A or Method B (see ISSU_37 and ISSU_38) when issuing PIDs or attestations non-synchronously.* |
-| ISSU_12c | The expiration date of a PID SHALL be no later than the end of the revocation maintenance periods of the WIA and the KA presented as part of the PID issuance process. *Note: This requirement is an implication of WURevocation_18 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation) and WUA_29-WUA_31. If the PID would be valid beyond the period for which the Wallet Provider has committed to maintaining the revocation status of the Wallet Instance and the WSCD or keystore, the PID Provider would not be able to fulfil its obligation to regularly check whether the Wallet Instance and WSCD or keystore have been revoked for the full PID validity period.* |
-| ISSU_12d | If an Attestation Provider supports revocation chaining for its attestations per WURevocation_19 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation), the expiration date of an attestation SHALL be no later than the end of the revocation maintenance periods of the WIA and the KA (if applicable) presented as part of the attestation issuance process. *Note: See note in ISSU_12c.* |
+<div class="eudi-hlr" id="ISSU_01" markdown>
+<div class="eudi-hlr__id">ISSU_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that their Wallet Solution supports the OpenID4VCI protocol specified in [OpenID4VCI], as profiled in Sections 4 and 6 of [HAIP], and with additions and changes as documented in this Annex (see e.g. this Topic and [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)) and in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+*Note: For clarity: in [HAIP] v1.0, Section 6 implies that Wallet Units must comply with the applicable requirements in [OpenID4VCI] Annex A.2 when requesting the issuance of an attestation in ISO/IEC 18013-5-compliant format, and with the applicable requirements in [OpenID4VCI] Annex A.3 when requesting the issuance of an attestation in SD-JWT VC format.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_01a" markdown>
+<div class="eudi-hlr__id">ISSU_01a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+PID Providers and Attestation Providers SHALL support the OpenID4VCI protocol specified in [OpenID4VCI], as profiled in Sections 4 and 6 of [HAIP], and with additions and changes as documented in this Annex (see e.g. this Topic and [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)) and in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+*Note: For clarity: in [HAIP] v1.0, Section 6 implies that PID Providers and Attestation Providers must comply with the applicable requirements in [OpenID4VCI] Annex A.2 when issuing an attestation in ISO/IEC 18013-5-compliant format, and with the applicable requirements in [OpenID4VCI] Annex A.3 when issuing an attestation in SD-JWT VC format.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_02" markdown>
+<div class="eudi-hlr__id">ISSU_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that their Wallet Solution supports the attestation formats specified in ISO/IEC 18013-5, see [ISO18013-5], and in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC], with additions and changes as documented in this Annex and in future technical specifications created by or on behalf of the Commission.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_03" markdown>
+<div class="eudi-hlr__id">ISSU_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Units, PID Providers, and Attestation Providers SHALL support the [W3C Digital Credentials API](https://wicg.github.io/digital-credentials/) for the issuance of PIDs and attestations.
+
+*Note: This requirement implies that the following conditions will be satisfied: a) the DC API specification will become a W3C Recommendation, b) this specification will comply with the principles outlined in [Section 4.4.3.1](../../architecture-and-reference-framework-main.md#4431-introduction) of the ARF main document, c) this specification will be broadly supported by relevant browsers and operating systems, and d) the [OpenID4VCI] standard will specify how to use OpenID4VCI with the DC API.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_04" markdown>
+<div class="eudi-hlr__id">ISSU_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The OpenID4VCI protocol referenced in requirement ISSU_01, or an EUDI Wallet-specific extension or profile thereof, SHALL enable PID Providers and Attestation Provider to issue to a Wallet Unit a batch of multiple PIDs or attestations that are simultaneously valid and contain the same attributes.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_05" markdown>
+<div class="eudi-hlr__id">ISSU_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL support a process to activate a newly issued PID, in accordance with the requirements for LoA High in [Commission Implementing Regulation (EU) 2015/1502](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32015R1502) Section 2.2.2. The Wallet Unit SHALL NOT allow a User to use a non-activated PID.
+
+*Note: a) The goal of the activation process is to verify that the PID was delivered into the Wallet Unit and WSCA/WSCD of the User who is the subject of the PID. b) This requirement is not applicable for QEAAs, PuB-EAAs or non-qualified EAAs, since these are not identity means in the sense of Commission Implementing Regulation (EU) 2015/1502.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_06" markdown>
+<div class="eudi-hlr__id">ISSU_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+After a Wallet Unit receives a PID or an attestation from a PID Provider or Attestation Provider, it SHALL verify that the PID or attestation it received matches the PID or attestation requested by the Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_07" markdown>
+<div class="eudi-hlr__id">ISSU_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+After a Wallet Unit receives a PID from a PID Provider, it SHALL validate the signature of the PID using a trust anchor of the PID Provider provided in a LoTE made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].
+
+*Note: The Wallet Provider and PID Provider may be the same entity. In such a case, the remote WSCD used by the Wallet Provider may be the same hardware HSM that is also used by the PID Provider to sign PIDs. In such a situation, this requirement may look superfluous, since the same HSM would generate the signature and verify it. However, this is not true, since for security reasons the PID Provider and Wallet Provider must use proper partitioning and logical key segregation within the HSM. Therefore, this requirement also applies in such a situation.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_08" markdown>
+<div class="eudi-hlr__id">ISSU_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+After a Wallet Unit receives a QEAA from a QEAA Provider, it SHALL validate the qualified signature of the QEAA in accordance with Art. 32 of the [European Digital Identity Regulation]. For the verification, the Wallet Unit SHALL use a trust anchor provided in a QEAA Provider Trusted List made available in accordance with [Art. 22](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ.L_.2014.257.01.0073.01.ENG#d1e2162-73-1) of the [European Digital Identity Regulation].
+
+*Note: a) Requirements ISSU_07 to ISSU_10 are equivalent to requirements OIA_12 to OIA_15 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit). b) These requirements imply that a Wallet Instance must be aware whether the attestation it is requesting from an issuer is a PID, a QEAA, a PuB-EAA, or a non-qualified EAA. These requirements also imply that the Wallet Unit must store trust anchors in such a way that, when it receives an issued attestation, it is able to distinguish between trust anchors usable either for PIDs, for QEAAs, for PuB-EAAs, or for non-qualified EAAs.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_09" markdown>
+<div class="eudi-hlr__id">ISSU_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+After a Wallet Unit receives a PuB-EAA from a PUB-EAA Provider, it SHALL validate the signature of a PuB-EAA using a trust anchor provided in a PUB-EAA Provider Trusted List made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_10" markdown>
+<div class="eudi-hlr__id">ISSU_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+After a Wallet Unit receives a non-qualified EAA from an EAA Provider, it SHALL validate the signature of the EAA if it has access to the trust anchors of the EAA Provider.
+
+*Note: For a non-qualified EAA, an Attestation Rulebook may be available, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)], explaining how EAA Providers distribute their trust anchors. However, it is not required for Wallet Units to be in possession of the trust anchors of all non-qualified EAA Providers, even when an Attestation Rulebook is available.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_11" markdown>
+<div class="eudi-hlr__id">ISSU_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL request the User's approval before storing a PID or attestation obtained from a PID Provider or Attestation Provider. When requesting approval, the Wallet Instance SHALL display the contents of the PID or attestation to the User. The Wallet Instance SHALL also inform the User about the identity of the PID Provider or Attestation Provider, using the subject information in the PID Provider's or Attestation Provider's access certificate.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_11a" markdown>
+<div class="eudi-hlr__id">ISSU_11a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+In case a PID or attestation is issued in batches, the Wallet Unit SHALL verify that  all PIDs and attestations in a batch have the same attribute values and the same technical validity period.
+
+*Note: PIDs and attestations are issued in batches when Method A, Method B, or Method D is used, see ISSU_37, ISSU_43, ISSU_51.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_11b" markdown>
+<div class="eudi-hlr__id">ISSU_11b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+In case one or more of the verifications in ISSU_06 - ISSU_11a fail, the Wallet Unit SHALL immediately delete the PID or attestation it received. The Wallet Instance SHALL notify the User about the fact that issuance of the PID or attestation was not successful, including the reason for this failure.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_12" markdown>
+<div class="eudi-hlr__id">ISSU_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider or Attestation Provider SHALL offer its PIDs or attestations in all formats required in the PID Rulebook or the applicable Attestation Rulebook, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)].
+
+*Note: Examples include the mdoc format specified in [ISO/IEC 18013-5] and the SD-JWT VC-format specified in [SD-JWT VC].*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_12a" markdown>
+<div class="eudi-hlr__id">ISSU_12a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When a User instructs their Wallet Unit to request a PID or attestation from a PID Provider or Attestation Provider, the Wallet Unit SHALL request that PID or attestation in all formats offered by the PID Provider or Attestation Provider.
+
+*Note: Examples include the mdoc format specified in [ISO/IEC 18013-5] and the SD-JWT VC-format specified in [SD-JWT VC].*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_12b" markdown>
+<div class="eudi-hlr__id">ISSU_12b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The WSCA/WSCD or a keystore SHALL generate a new key pair for a new PID or attestation on request of the Wallet Instance, unless that PID or attestation is issued synchronously in a remote HSM architecture. This generation request MAY be done either prior to the issuance of any PID or attestation, or during the issuance process.
+
+*Note: a) See also WUA_05 and WUA_05a. b) In case of synchronous issuing in a remote HSM architecture, re-use of an existing key pair within a limited period of time can be acceptable, based on the PID Provider's or Attestation Provider's issuance security policy. This is similar to a choice between Method A or Method B (see ISSU_37 and ISSU_38) when issuing PIDs or attestations non-synchronously.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_12c" markdown>
+<div class="eudi-hlr__id">ISSU_12c<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The expiration date of a PID SHALL be no later than the end of the revocation maintenance periods of the WIA and the KA presented as part of the PID issuance process.
+
+*Note: This requirement is an implication of WURevocation_18 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation) and WUA_29-WUA_31. If the PID would be valid beyond the period for which the Wallet Provider has committed to maintaining the revocation status of the Wallet Instance and the WSCD or keystore, the PID Provider would not be able to fulfil its obligation to regularly check whether the Wallet Instance and WSCD or keystore have been revoked for the full PID validity period.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_12d" markdown>
+<div class="eudi-hlr__id">ISSU_12d<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If an Attestation Provider supports revocation chaining for its attestations per WURevocation_19 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation), the expiration date of an attestation SHALL be no later than the end of the revocation maintenance periods of the WIA and the KA (if applicable) presented as part of the attestation issuance process.
+
+*Note: See note in ISSU_12c.*
+
+</div>
+</div>
+
 
 ##### B - HLRs for PID issuance <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ISSU_13 | A Wallet Provider SHALL ensure that at least one PID Provider is willing to issue a PID complying with [PID Rulebook] to Users of the Wallet Units it provides. |
-| ISSU_14 | A PID Provider SHALL ensure that all PIDs it issues to Wallet Units comply with the requirements specified in [PID Rulebook]. |
-| ISSU_15 | A PID Provider SHALL support the OpenID4VCI protocol referenced in ISSU_01 for issuing PIDs. |
-| ISSU_16 | Empty |
-| ISSU_17 | A PID Provider SHALL implement device binding for all PIDs it issues, meaning it SHALL ensure that a PID is cryptographically bound to the WSCA/WSCD included in the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation). *Note: Device binding is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT-VC].* |
-| ISSU_18 | A PID Provider SHALL verify the identity of the subject of the PID in compliance with Level of Assurance (LoA) High requirements. *Note: These requirements will be determined by the relevant eID scheme.* |
-| ISSU_18a | A PID Provider SHALL ensure that the attributes attested in the PID issued are valid for the identified PID subject at any point of time of PID validity. |
-| ISSU_19 | For the verification of a WIA or KA, a PID Provider SHALL accept the trust anchors in the Wallet Provider LoTE(s) it needs. *Note: a) The Wallet Provider LoTE is explained in [Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates). b) It is not mandatory for a PID Provider to accept all Wallet Provider LoTEs, if there are multiple. This is because it is not mandatory for a PID Provider to accept all certified Wallet Solutions in the EUDI Wallet ecosystem. Each PID Provider will choose which LoTEs they need to subscribe to.* |
-| ISSU_19a | A PID Provider SHALL support all Wallet Solutions recognised under the corresponding notified eID scheme, meaning that it is willing and able to issue a PID to a Wallet Unit on request of the User. |
-| ISSU_20 | To inform its potential PID subjects about the Wallet Solution(s) they can use for requesting a PID, a PID Provider SHALL publish a list of supported Wallet Solutions in such a way that it can be easily found, for example on the PID Provider's website. *Note: This a policy requirement rather than a technical requirement.* |
-| ISSU_21 | Before issuing a PID, a PID Provider SHALL verify the Wallet Unit's WIA and KA using a trust anchor registered in the Wallet Provider LoTE. Moreover, it SHALL verify that the Wallet Instance referenced in the WIA has not been revoked, and that the WSCD referenced in the KA has not been revoked. *Note: a) For WIAs and KAs, see [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation) and [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation). b) [CIR 2024/2977], Article 3 (9), also allows another authentication mechanism in accordance with an electronic identity scheme notified at assurance level high. However, the ARF does not further specify such other authentication mechanisms, which means that in general they will not be interoperable.* |
-| ISSU_22 | A PID Provider SHALL sign its Credential Issuer metadata as specified in section 12.2.3 of [OpenID4VCI]. To do so, the PID Provider SHALL use the private key corresponding to the public key in its access certificate. The PID Provider SHALL include its access certificate, as well as all intermediate certificate(s) leading up to the trust anchor of the corresponding Access Certificate Authority (see ISSU_33) in the LoTE, in the ``x5c`` parameter in the JOSE header of the JSON Web Signature for the metadata. |
-| ISSU_22a | Empty |
-| ISSU_22b | Empty |
-| ISSU_23 | For the verification of a PID Provider's access certificates, a Wallet Unit SHALL accept the trust anchors in the LoTE(s) of Access Certificate Authorities it needs. *Note: a) Access Certificate Authority LoTEs are explained in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].* |
-| ISSU_23a | A Wallet Provider SHALL support at least one PID Provider, meaning that its Wallet Units SHALL be capable of requesting the issuance of a PID from these PID Provider(s), and that the Wallet Provider has agreed with the PID Provider(s) that the PID Provider(s) will process such a request according to the agreed rules and procedures. |
-| ISSU_23b | Prior to or during installation of a Wallet Instance, the Wallet Provider SHALL notify the User about the PID Provider(s) that are supported by the Wallet Unit. |
-| ISSU_24 | A Wallet Unit SHALL authenticate and validate the access certificate of the PID Provider before requesting the issuance of a PID. The Wallet Unit SHALL verify that the access certificate is authentic and is valid at the time of validation, and that the issuer of the access certificate is included in an Access Certificate Authority LoTE. |
-| ISSU_24a | Before requesting the issuance of a PID, the Wallet Unit SHALL verify that the PID Provider is indeed a registered PID Provider. To do so, the Wallet Unit SHALL a) Inspect the ``entitlement`` member in the registration certificate of the PID Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``entitlement``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``entitlement`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the PID Provider is indeed registered as a PID Provider, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of a PID. *Note: The information in the ``entitlement`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the PID Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful.* |
-| ISSU_24b | Before requesting the issuance of a PID, the Wallet Unit SHALL verify whether the PID Provider properly registered for the issuance of PIDs. To do so, the Wallet Unit SHALL a) Inspect the ``providesAttestations`` member in the registration certificate of the PID Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``providesAttestations``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``providesAttestations`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the PID Provider registered for the issuance of PIDs, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of a PID. *Note: a) The information in the ``providesAttestations``  member included in the Credential Issuer Metadata (3rd option above) is self-declared by the PID Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful. b) It may be argued that this verification is superfluous, since an entity registered as a PID Provider (ISSU_24a) by definition is registered for issuing PIDs. However, this verification was added to ensure that Wallet Unit can use the same verification process for PIDs as for other attestations (see ISSU_34b), as well as to ensure that in the future, it is possible to distinguish between different types of PID if needed, where not all PID Providers are registered to issue all types of PID.* |
+<div class="eudi-hlr" id="ISSU_13" markdown>
+<div class="eudi-hlr__id">ISSU_13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL ensure that at least one PID Provider is willing to issue a PID complying with [PID Rulebook] to Users of the Wallet Units it provides.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_14" markdown>
+<div class="eudi-hlr__id">ISSU_14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider SHALL ensure that all PIDs it issues to Wallet Units comply with the requirements specified in [PID Rulebook].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_15" markdown>
+<div class="eudi-hlr__id">ISSU_15<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider SHALL support the OpenID4VCI protocol referenced in ISSU_01 for issuing PIDs.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_16" markdown>
+<div class="eudi-hlr__id">ISSU_16</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_17" markdown>
+<div class="eudi-hlr__id">ISSU_17<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider SHALL implement device binding for all PIDs it issues, meaning it SHALL ensure that a PID is cryptographically bound to the WSCA/WSCD included in the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation).
+
+*Note: Device binding is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT-VC].*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_18" markdown>
+<div class="eudi-hlr__id">ISSU_18<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider SHALL verify the identity of the subject of the PID in compliance with Level of Assurance (LoA) High requirements.
+
+*Note: These requirements will be determined by the relevant eID scheme.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_18a" markdown>
+<div class="eudi-hlr__id">ISSU_18a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider SHALL ensure that the attributes attested in the PID issued are valid for the identified PID subject at any point of time of PID validity.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_19" markdown>
+<div class="eudi-hlr__id">ISSU_19<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the verification of a WIA or KA, a PID Provider SHALL accept the trust anchors in the Wallet Provider LoTE(s) it needs.
+
+*Note: a) The Wallet Provider LoTE is explained in [Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates). b) It is not mandatory for a PID Provider to accept all Wallet Provider LoTEs, if there are multiple. This is because it is not mandatory for a PID Provider to accept all certified Wallet Solutions in the EUDI Wallet ecosystem. Each PID Provider will choose which LoTEs they need to subscribe to.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_19a" markdown>
+<div class="eudi-hlr__id">ISSU_19a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider SHALL support all Wallet Solutions recognised under the corresponding notified eID scheme, meaning that it is willing and able to issue a PID to a Wallet Unit on request of the User.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_20" markdown>
+<div class="eudi-hlr__id">ISSU_20<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+To inform its potential PID subjects about the Wallet Solution(s) they can use for requesting a PID, a PID Provider SHALL publish a list of supported Wallet Solutions in such a way that it can be easily found, for example on the PID Provider's website.
+
+*Note: This a policy requirement rather than a technical requirement.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_21" markdown>
+<div class="eudi-hlr__id">ISSU_21<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before issuing a PID, a PID Provider SHALL verify the Wallet Unit's WIA and KA using a trust anchor registered in the Wallet Provider LoTE. Moreover, it SHALL verify that the Wallet Instance referenced in the WIA has not been revoked, and that the WSCD referenced in the KA has not been revoked.
+
+*Note: a) For WIAs and KAs, see [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation) and [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation). b) [CIR 2024/2977], Article 3 (9), also allows another authentication mechanism in accordance with an electronic identity scheme notified at assurance level high. However, the ARF does not further specify such other authentication mechanisms, which means that in general they will not be interoperable.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_22" markdown>
+<div class="eudi-hlr__id">ISSU_22<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider SHALL sign its Credential Issuer metadata as specified in section 12.2.3 of [OpenID4VCI]. To do so, the PID Provider SHALL use the private key corresponding to the public key in its access certificate. The PID Provider SHALL include its access certificate, as well as all intermediate certificate(s) leading up to the trust anchor of the corresponding Access Certificate Authority (see ISSU_33) in the LoTE, in the ``x5c`` parameter in the JOSE header of the JSON Web Signature for the metadata.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_22a" markdown>
+<div class="eudi-hlr__id">ISSU_22a</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_22b" markdown>
+<div class="eudi-hlr__id">ISSU_22b</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_23" markdown>
+<div class="eudi-hlr__id">ISSU_23<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the verification of a PID Provider's access certificates, a Wallet Unit SHALL accept the trust anchors in the LoTE(s) of Access Certificate Authorities it needs.
+
+*Note: a) Access Certificate Authority LoTEs are explained in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_23a" markdown>
+<div class="eudi-hlr__id">ISSU_23a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL support at least one PID Provider, meaning that its Wallet Units SHALL be capable of requesting the issuance of a PID from these PID Provider(s), and that the Wallet Provider has agreed with the PID Provider(s) that the PID Provider(s) will process such a request according to the agreed rules and procedures.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_23b" markdown>
+<div class="eudi-hlr__id">ISSU_23b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Prior to or during installation of a Wallet Instance, the Wallet Provider SHALL notify the User about the PID Provider(s) that are supported by the Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_24" markdown>
+<div class="eudi-hlr__id">ISSU_24<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL authenticate and validate the access certificate of the PID Provider before requesting the issuance of a PID. The Wallet Unit SHALL verify that the access certificate is authentic and is valid at the time of validation, and that the issuer of the access certificate is included in an Access Certificate Authority LoTE.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_24a" markdown>
+<div class="eudi-hlr__id">ISSU_24a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before requesting the issuance of a PID, the Wallet Unit SHALL verify that the PID Provider is indeed a registered PID Provider. To do so, the Wallet Unit SHALL a) Inspect the ``entitlement`` member in the registration certificate of the PID Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``entitlement``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``entitlement`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the PID Provider is indeed registered as a PID Provider, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of a PID.
+
+*Note: The information in the ``entitlement`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the PID Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_24b" markdown>
+<div class="eudi-hlr__id">ISSU_24b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before requesting the issuance of a PID, the Wallet Unit SHALL verify whether the PID Provider properly registered for the issuance of PIDs. To do so, the Wallet Unit SHALL a) Inspect the ``providesAttestations`` member in the registration certificate of the PID Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``providesAttestations``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``providesAttestations`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the PID Provider registered for the issuance of PIDs, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of a PID.
+
+*Note: a) The information in the ``providesAttestations``  member included in the Credential Issuer Metadata (3rd option above) is self-declared by the PID Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful. b) It may be argued that this verification is superfluous, since an entity registered as a PID Provider (ISSU_24a) by definition is registered for issuing PIDs. However, this verification was added to ensure that Wallet Unit can use the same verification process for PIDs as for other attestations (see ISSU_34b), as well as to ensure that in the future, it is possible to distinguish between different types of PID if needed, where not all PID Providers are registered to issue all types of PID.*
+
+</div>
+</div>
+
 
 ##### C - HLRs for Attestation Issuance <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ISSU_25 | An Attestation Provider SHALL ensure all attestations issued to Wallet Units comply with the requirements specified in the applicable Rulebook, as described in [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)]. |
-| ISSU_26 | An Attestation Provider SHALL support the OpenID4VCI protocol referenced in ISSU_01 for issuing attestations. |
-| ISSU_27 | An Attestation Provider SHOULD implement device binding for all attestations it issues. If an issued attestation is device-bound, the Attestation Provider SHALL ensure that the attestation is cryptographically bound to a WSCA/WSCD or a keystore available to the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation). *Note: a) Device binding is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT-VC]. b) Implementing mdoc authentication is mandatory in [ISO/IEC 18013-5] and therefore, it is mandatory for attestations complying with that standard. c) See ISSU_27d.* |
-| ISSU_27a | If the subject of the attestation is a natural person, an Attestation Provider SHALL verify the identity of the subject of the attestation, in compliance with applicable requirements and in accordance with relevant standards or Implementing Regulations. *Note: Not every attestation has a natural person as its subject. For example, a holiday voucher may be valid for any User that can present it to a Relying Party and therefore has no subject. This is comparable to the concept of a 'bearer token'.* |
-| ISSU_27b | If applicable, an Attestation Provider SHALL ensure that the attributes attested in the attestation issued are valid for the identified attestation subject. |
-| ISSU_27c | The Attestation Provider SHALL verify that the User requesting the attestation has the right to receive it. |
-| ISSU_27d | An Attestation Provider issuing device-bound attestations SHALL indicate the desired level of security for the private key storage and for User authentication in its Credential Issuer metadata, according to [OpenID4VCI] section 12.2.4 and Appendix D.2. *Note: See also WIAM_14b, WIAM_14c, and WUA_05 and WUA_05a.* |
-| ISSU_28 | For the verification of a WIA or KA, an Attestation Provider SHALL accept the trust anchors in the Wallet Provider LoTE. *Note: The Wallet Provider LoTE is explained in [Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates).* |
-| ISSU_29 | A QEAA Provider or PuB-EAA Provider SHALL support all Wallet Solutions, except in case the attestation in question is a Strong User Authentication (SUA) attestation as meant in [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments) and the Wallet Provider does not support processing of the transactional data associated with the SUA attestation. Except for such cases, A QEAA Provider or PuB-EAA Provider SHALL NOT discriminate between Wallet Solutions when processing a request for the issuance of an attestation. *Note: This requirement is not applicable for non-qualified EAA Providers. For example, a non-qualified EAA Provider may choose to issue attestations in the format specified in [W3C VCDM], see ARB_01a. In that case, it will support only those Wallet Solutions that have implemented this attestation format.* |
-| ISSU_30 | Before issuing a device-bound attestation, an Attestation Provider SHALL verify the Wallet Unit's key attestation using a trust anchor registered in the Wallet Provider LoTE. Moreover, it SHALL verify that the WSCD or keystore referenced in the KA has not been revoked. *Note: This requirement applies specifically to the KA received during device-bound attestation issuance. The corresponding requirement for verifying the WIA is ISSU_30a.* |
-| ISSU_30a | Before issuing an attestation, an Attestation Provider SHALL: - verify that the Wallet Provider mentioned in the Wallet Unit's WIA is present in the Wallet Provider LoTE. - authenticate and validate the WIA using the trust anchor(s) registered for the Wallet Provider in that LoTE. *Note: This requirement applies to both device-bound and non-device-bound attestations* |
-| ISSU_31 | Empty |
-| ISSU_32 | An Attestation Provider SHALL sign its Credential Issuer metadata as specified in section 12.2.3 of [OpenID4VCI]. To do so, the Attestation Provider SHALL use the private key corresponding to the public key in its access certificate. The Attestation Provider SHALL include its access certificate, as well as all intermediate certificate(s) leading up to the trust anchor of the corresponding Access Certificate Authority  in the LoTE (see ISSU_33), in the ``x5c`` parameter in the JOSE header of the JSON Web Signature for the metadata. |
-| ISSU_32a | Empty |
-| ISSU_33 | For the verification of access certificates, a Wallet Unit SHALL accept only the trust anchors in all LoTE(s) for Access Certificate Authorities. *Note: Access Certificate Authority LoTEs are explained in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].* |
-| ISSU_33a | For the verification of the registration certificates of Attestation Providers, a Wallet Unit SHALL accept only the trust anchors in all LoTE(s) for Providers of registration certificates. |
-| ISSU_33b | A Wallet Provider SHALL support all Attestation Providers, except possibly if the attestation in question is a Strong User Authentication (SUA) attestation as meant in [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments) and the Wallet Provider chooses to not support processing of the transactional data associated with that attestation. Except for such cases, Wallet Units SHALL be capable of requesting the issuance of a QEAA, PuB-EAA, or non-qualified EAA from all Attestation Providers at the User's request. |
-| ISSU_34 | A Wallet Unit SHALL authenticate and validate the access certificate of the Attestation Provider before requesting the issuance of an attestation. The Wallet Unit SHALL verify that the access certificate is authentic and is valid at the time of validation, and that the issuer of the access certificate is in the Access Certificate Authority LoTE(s), as documented in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)]. |
-| ISSU_34a | Before requesting the issuance of an attestation, the Wallet Unit SHALL verify that the Attestation Provider is a registered QEAA Provider, PuB-EAA Provider, or EAA Provider. To do so, the Wallet Unit SHALL a) Inspect the ``entitlement`` member in the registration certificate of the Attestation Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``entitlement``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``entitlement`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the Attestation Provider is indeed registered as a QEAA Provider, PuB-EAA Provider, or EAA Provider, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of an attestation. *Note: The information in the ``entitlement`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the Attestation Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful.* |
-| ISSU_34b | Before requesting the issuance of an attestation, the Wallet Unit SHALL verify whether the Provider properly registered for the issuance of the type of attestation that the User wants to obtain. To do so, the Wallet Unit SHALL a) Inspect the ``providesAttestations`` member in the registration certificate of the Attestation Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``providesAttestations``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``providesAttestations`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the Attestation Provider registered for the relevant type of attestation, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of an attestation. *Note: The information in the ``providesAttestation`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the Attestation Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful.* |
+<div class="eudi-hlr" id="ISSU_25" markdown>
+<div class="eudi-hlr__id">ISSU_25<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attestation Provider SHALL ensure all attestations issued to Wallet Units comply with the requirements specified in the applicable Rulebook, as described in [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_26" markdown>
+<div class="eudi-hlr__id">ISSU_26<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attestation Provider SHALL support the OpenID4VCI protocol referenced in ISSU_01 for issuing attestations.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_27" markdown>
+<div class="eudi-hlr__id">ISSU_27<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attestation Provider SHOULD implement device binding for all attestations it issues. If an issued attestation is device-bound, the Attestation Provider SHALL ensure that the attestation is cryptographically bound to a WSCA/WSCD or a keystore available to the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation).
+
+*Note: a) Device binding is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT-VC]. b) Implementing mdoc authentication is mandatory in [ISO/IEC 18013-5] and therefore, it is mandatory for attestations complying with that standard. c) See ISSU_27d.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_27a" markdown>
+<div class="eudi-hlr__id">ISSU_27a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the subject of the attestation is a natural person, an Attestation Provider SHALL verify the identity of the subject of the attestation, in compliance with applicable requirements and in accordance with relevant standards or Implementing Regulations.
+
+*Note: Not every attestation has a natural person as its subject. For example, a holiday voucher may be valid for any User that can present it to a Relying Party and therefore has no subject. This is comparable to the concept of a 'bearer token'.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_27b" markdown>
+<div class="eudi-hlr__id">ISSU_27b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If applicable, an Attestation Provider SHALL ensure that the attributes attested in the attestation issued are valid for the identified attestation subject.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_27c" markdown>
+<div class="eudi-hlr__id">ISSU_27c<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Attestation Provider SHALL verify that the User requesting the attestation has the right to receive it.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_27d" markdown>
+<div class="eudi-hlr__id">ISSU_27d<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attestation Provider issuing device-bound attestations SHALL indicate the desired level of security for the private key storage and for User authentication in its Credential Issuer metadata, according to [OpenID4VCI] section 12.2.4 and Appendix D.2.
+
+*Note: See also WIAM_14b, WIAM_14c, and WUA_05 and WUA_05a.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_28" markdown>
+<div class="eudi-hlr__id">ISSU_28<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the verification of a WIA or KA, an Attestation Provider SHALL accept the trust anchors in the Wallet Provider LoTE.
+
+*Note: The Wallet Provider LoTE is explained in [Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_29" markdown>
+<div class="eudi-hlr__id">ISSU_29<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A QEAA Provider or PuB-EAA Provider SHALL support all Wallet Solutions, except in case the attestation in question is a Strong User Authentication (SUA) attestation as meant in [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments) and the Wallet Provider does not support processing of the transactional data associated with the SUA attestation. Except for such cases, A QEAA Provider or PuB-EAA Provider SHALL NOT discriminate between Wallet Solutions when processing a request for the issuance of an attestation.
+
+*Note: This requirement is not applicable for non-qualified EAA Providers. For example, a non-qualified EAA Provider may choose to issue attestations in the format specified in [W3C VCDM], see ARB_01a. In that case, it will support only those Wallet Solutions that have implemented this attestation format.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_30" markdown>
+<div class="eudi-hlr__id">ISSU_30<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before issuing a device-bound attestation, an Attestation Provider SHALL verify the Wallet Unit's key attestation using a trust anchor registered in the Wallet Provider LoTE. Moreover, it SHALL verify that the WSCD or keystore referenced in the KA has not been revoked.
+
+*Note: This requirement applies specifically to the KA received during device-bound attestation issuance. The corresponding requirement for verifying the WIA is ISSU_30a.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_30a" markdown>
+<div class="eudi-hlr__id">ISSU_30a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before issuing an attestation, an Attestation Provider SHALL: - verify that the Wallet Provider mentioned in the Wallet Unit's WIA is present in the Wallet Provider LoTE. - authenticate and validate the WIA using the trust anchor(s) registered for the Wallet Provider in that LoTE.
+
+*Note: This requirement applies to both device-bound and non-device-bound attestations*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_31" markdown>
+<div class="eudi-hlr__id">ISSU_31</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_32" markdown>
+<div class="eudi-hlr__id">ISSU_32<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attestation Provider SHALL sign its Credential Issuer metadata as specified in section 12.2.3 of [OpenID4VCI]. To do so, the Attestation Provider SHALL use the private key corresponding to the public key in its access certificate. The Attestation Provider SHALL include its access certificate, as well as all intermediate certificate(s) leading up to the trust anchor of the corresponding Access Certificate Authority  in the LoTE (see ISSU_33), in the ``x5c`` parameter in the JOSE header of the JSON Web Signature for the metadata.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_32a" markdown>
+<div class="eudi-hlr__id">ISSU_32a</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_33" markdown>
+<div class="eudi-hlr__id">ISSU_33<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the verification of access certificates, a Wallet Unit SHALL accept only the trust anchors in all LoTE(s) for Access Certificate Authorities.
+
+*Note: Access Certificate Authority LoTEs are explained in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_33a" markdown>
+<div class="eudi-hlr__id">ISSU_33a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the verification of the registration certificates of Attestation Providers, a Wallet Unit SHALL accept only the trust anchors in all LoTE(s) for Providers of registration certificates.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_33b" markdown>
+<div class="eudi-hlr__id">ISSU_33b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL support all Attestation Providers, except possibly if the attestation in question is a Strong User Authentication (SUA) attestation as meant in [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments) and the Wallet Provider chooses to not support processing of the transactional data associated with that attestation. Except for such cases, Wallet Units SHALL be capable of requesting the issuance of a QEAA, PuB-EAA, or non-qualified EAA from all Attestation Providers at the User's request.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_34" markdown>
+<div class="eudi-hlr__id">ISSU_34<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL authenticate and validate the access certificate of the Attestation Provider before requesting the issuance of an attestation. The Wallet Unit SHALL verify that the access certificate is authentic and is valid at the time of validation, and that the issuer of the access certificate is in the Access Certificate Authority LoTE(s), as documented in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_34a" markdown>
+<div class="eudi-hlr__id">ISSU_34a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before requesting the issuance of an attestation, the Wallet Unit SHALL verify that the Attestation Provider is a registered QEAA Provider, PuB-EAA Provider, or EAA Provider. To do so, the Wallet Unit SHALL a) Inspect the ``entitlement`` member in the registration certificate of the Attestation Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``entitlement``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``entitlement`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the Attestation Provider is indeed registered as a QEAA Provider, PuB-EAA Provider, or EAA Provider, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of an attestation.
+
+*Note: The information in the ``entitlement`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the Attestation Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_34b" markdown>
+<div class="eudi-hlr__id">ISSU_34b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before requesting the issuance of an attestation, the Wallet Unit SHALL verify whether the Provider properly registered for the issuance of the type of attestation that the User wants to obtain. To do so, the Wallet Unit SHALL a) Inspect the ``providesAttestations`` member in the registration certificate of the Attestation Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``providesAttestations``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``providesAttestations`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the Attestation Provider registered for the relevant type of attestation, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of an attestation.
+
+*Note: The information in the ``providesAttestation`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the Attestation Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful.*
+
+</div>
+</div>
+
 
 ##### D - HLRs for Privacy Risks and Mitigation <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ISSU_35 | A PID Provider or Attestation Provider SHALL ensure that all unique elements in a PID or attestation have a negligible chance of having the same value across all PIDs or attestations issued by that Provider. This SHALL include at least a) the salt used for hashing every attribute, b) the hash values of all attributes, c) the attestation identifier or index used for revocation purposes (if applicable), d) the attestation public key used for device binding (if applicable), and e) the value of the Attestation Provider signature. *Note: a) The list of unique elements is based on [ISO/IEC 18013-5] and [SD-JWT VC]. b) This requirement can be achieved, for example, by ensuring that salt values, indexes and attestation identifiers are pseudo-random numbers generated by a cryptographically secure pseudo-random number generator (CSPRNG).* |
-| ISSU_35a | A Wallet Provider SHALL ensure that all unique elements in a  WIA or KA have a negligible chance of having the same value across all WIAs and KAs issued by that Wallet Provider and intended to be presented to different PID Providers or Attestation Providers. This SHALL include at least a) the attestation identifier or index, unless the per-KA index approach meant in WUA_28 is used,  b) the WIA or KA public key, and c) the value of the Wallet Provider signature over the WIA or KA. *Note:  In other words, the following do not have to be unique: i) WIAs presented to the same PID Provider or Attestation Provider; and ii) the revocation reference in a KA under the type-shared index approach (see WUA_28). However, under the per-KA index approach (see WUA_28), the KA revocation reference is unique per KA or per KA-issuer pair and is subject to this requirement.* |
-| ISSU_35b | After issuing a PID, attestation, KA, or WIA, a PID Provider, Attestation Provider or Wallet Provider SHALL discard the values of all unique elements, including at least the ones mentioned in requirement ISSU_35 or ISSU_35a (as applicable) above, as well as any timestamps, as soon as they are no longer needed. The Provider SHALL NOT communicate these values to any other party inside or outside the EUDI Wallet ecosystem. |
-| ISSU_36 | When issuing PIDs, attestations, or WIAs or KAs in a batch to a Wallet Unit, a PID Provider, Attestation Provider, or Wallet Provider SHALL ensure that the timestamps in these PIDs, attestations, or WIAs and KAs do not enable Relying Parties to conclude that they are part of the same batch (and therefore belong to the same User). *Note: a) This can be done, for example, by making timestamps sufficiently imprecise that a high number of batches, each issued to a different Wallet Unit, share the same timestamp values (herd privacy). b) This requirement does not apply to timestamps included in the attestation as selectively disclosable attributes, see ISSU_36a.* |
-| ISSU_36a | If the exact time of the issuance of an attestation or the beginning or end of its validity period is relevant for the use case, the applicable Rulebook SHALL specify one or more selectively disclosable attribute(s) containing a timestamp with the required precision. *Note: a) An example of this may be a vehicle registration attestation indicating the date and time (down to the second) at which a car changed ownership and therefore legal responsibility. b) This requirement ensures that requirement ISSU_36 can be complied with without running into challenges related to the use case.* |
-| ISSU_37 | A Wallet Provider SHALL ensure that its Wallet Solution supports the following methods for limiting the number of times a User can present the same technical PID or attestation to Relying Parties: Method A (Once-only attestations, as specified in requirement ISSU_43 - ISSU_47) and Method B (Limited-time attestations, as specified in requirement ISSU_48 - ISSU_50). In addition, a Wallet Provider MAY ensure that its Wallet Solution supports Method C (Rotating-batch attestations, as specified in requirement ISSU_51 - ISSU_54) or Method D (Per-Relying Party attestations, as specified in requirement ISSU_55 - ISSU_57). *Note: Wallet Solutions, PID Providers, Attestation Providers, and Wallet Providers are free to define and use other methods as well. However, such other methods are out of scope of the ARF.* |
-| ISSU_38 | A PID Provider or Attestation Provider SHALL have a policy describing which method(s) (i.e,  A, B, C, and/or D) it will use to limit the number of times a Wallet Unit may present a single technical PID or attestation. For each supported method, the policy SHALL also specify how the values for respective parameters for that method, such as technical validity period and batch size, will be chosen. The goal of the policy SHALL be to ensure that the risk of linkability is mitigated to an acceptable level, given the (expected) usage of the logical PID or attestation by the User. To determine what an acceptable level of risk is, the PID Provider or Attestation Provider SHALL carry out a risk analysis regarding linkability. *Note: a) If an Attestation Provider issues multiple attestation types, these requirements apply for each type of attestation separately. b) [Technical Specification 3] specifies that WIAs and KAs shall be sent to a PID Provider or Attestation Provider only once. In other words, for WIAs and KAs, the use of Method A is mandatory.* |
-| ISSU_39 | PID Providers and Attestation Providers SHALL include the ``credential_reuse_policy`` parameter, specified in section 4.2.4.2 of [ETSI TS 119 472-3], in their Credential Issuer Metadata to specify which of the methods A, B, C, or D the Wallet Unit must use for the logical PID or attestation issued. Indicated methods SHALL be ordered by preference. *Note: See also ISSU_40.* |
-| ISSU_39a | Wallet Units SHALL support the ``credential_reuse_policy`` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3] and SHALL present each technical PID and attestation in accordance with the values set for this parameter by the relevant PID Provider or Attestation Provider. |
-| ISSU_40 | A PID Provider or Attestation Provider SHALL indicate in their OpenID4VCI Issuer metadata that either method A or method B must be used for a given type of PID or attestation. In addition, a PID Provider or Attestation Provider MAY indicate that it prefers using method C and/or method D over method A or method B, by including the methods in the metadata in the appropriate order. In such a case, a Wallet Unit supporting method C and/or method D SHALL use that method, while a Wallet Unit not supporting these methods SHALL use method A or method B, as applicable. *Note: a) This requirement implies that a PID Provider or Attestation Provider must not include both method A and method B in its metadata.  b) Example: An Attestation Provider indicates methods {D, C, A} in its metadata, in that order. A Wallet Unit that supports methods C and D (as well as A and B) then uses method D for this type of attestation. A Wallet Unit supporting methods A, B and C uses method C. A Wallet Unit supporting only methods A and B uses method A.* |
-| ISSU_40a | When implementing any of the methods mentioned in ISSU_37, a  Wallet Unit, PID Provider, or Attestation Provider SHALL comply with the applicable requirements in [ETSI TS 119 472-3], section 4.2.4. |
-| ISSU_41 | To the maximum extent possible, Wallet Providers, PID Providers, and Attestation Providers SHALL ensure that Users do not notice which of the methods A, B, C, or D is used for their PIDs and attestations. |
-| ISSU_42 | To the maximum extent possible, Wallet Providers, PID Providers, and Attestation Providers SHALL ensure that no User action is needed for the re-issuance of WIAs or KAs, PIDs, or attestations. *Note: For the topic of re-issuance, see also the [Discussion Paper for Topic B](../../discussion-topics/b-re-issuance-and-batch-issuance-of-pids-and-attestations.md).* |
+<div class="eudi-hlr" id="ISSU_35" markdown>
+<div class="eudi-hlr__id">ISSU_35<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider or Attestation Provider SHALL ensure that all unique elements in a PID or attestation have a negligible chance of having the same value across all PIDs or attestations issued by that Provider. This SHALL include at least a) the salt used for hashing every attribute, b) the hash values of all attributes, c) the attestation identifier or index used for revocation purposes (if applicable), d) the attestation public key used for device binding (if applicable), and e) the value of the Attestation Provider signature.
+
+*Note: a) The list of unique elements is based on [ISO/IEC 18013-5] and [SD-JWT VC]. b) This requirement can be achieved, for example, by ensuring that salt values, indexes and attestation identifiers are pseudo-random numbers generated by a cryptographically secure pseudo-random number generator (CSPRNG).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_35a" markdown>
+<div class="eudi-hlr__id">ISSU_35a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL ensure that all unique elements in a  WIA or KA have a negligible chance of having the same value across all WIAs and KAs issued by that Wallet Provider and intended to be presented to different PID Providers or Attestation Providers. This SHALL include at least a) the attestation identifier or index, unless the per-KA index approach meant in WUA_28 is used,  b) the WIA or KA public key, and c) the value of the Wallet Provider signature over the WIA or KA.
+
+*Note:  In other words, the following do not have to be unique: i) WIAs presented to the same PID Provider or Attestation Provider; and ii) the revocation reference in a KA under the type-shared index approach (see WUA_28). However, under the per-KA index approach (see WUA_28), the KA revocation reference is unique per KA or per KA-issuer pair and is subject to this requirement.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_35b" markdown>
+<div class="eudi-hlr__id">ISSU_35b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+After issuing a PID, attestation, KA, or WIA, a PID Provider, Attestation Provider or Wallet Provider SHALL discard the values of all unique elements, including at least the ones mentioned in requirement ISSU_35 or ISSU_35a (as applicable) above, as well as any timestamps, as soon as they are no longer needed. The Provider SHALL NOT communicate these values to any other party inside or outside the EUDI Wallet ecosystem.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_36" markdown>
+<div class="eudi-hlr__id">ISSU_36<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When issuing PIDs, attestations, or WIAs or KAs in a batch to a Wallet Unit, a PID Provider, Attestation Provider, or Wallet Provider SHALL ensure that the timestamps in these PIDs, attestations, or WIAs and KAs do not enable Relying Parties to conclude that they are part of the same batch (and therefore belong to the same User).
+
+*Note: a) This can be done, for example, by making timestamps sufficiently imprecise that a high number of batches, each issued to a different Wallet Unit, share the same timestamp values (herd privacy). b) This requirement does not apply to timestamps included in the attestation as selectively disclosable attributes, see ISSU_36a.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_36a" markdown>
+<div class="eudi-hlr__id">ISSU_36a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the exact time of the issuance of an attestation or the beginning or end of its validity period is relevant for the use case, the applicable Rulebook SHALL specify one or more selectively disclosable attribute(s) containing a timestamp with the required precision.
+
+*Note: a) An example of this may be a vehicle registration attestation indicating the date and time (down to the second) at which a car changed ownership and therefore legal responsibility. b) This requirement ensures that requirement ISSU_36 can be complied with without running into challenges related to the use case.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_37" markdown>
+<div class="eudi-hlr__id">ISSU_37<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL ensure that its Wallet Solution supports the following methods for limiting the number of times a User can present the same technical PID or attestation to Relying Parties: Method A (Once-only attestations, as specified in requirement ISSU_43 - ISSU_47) and Method B (Limited-time attestations, as specified in requirement ISSU_48 - ISSU_50). In addition, a Wallet Provider MAY ensure that its Wallet Solution supports Method C (Rotating-batch attestations, as specified in requirement ISSU_51 - ISSU_54) or Method D (Per-Relying Party attestations, as specified in requirement ISSU_55 - ISSU_57).
+
+*Note: Wallet Solutions, PID Providers, Attestation Providers, and Wallet Providers are free to define and use other methods as well. However, such other methods are out of scope of the ARF.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_38" markdown>
+<div class="eudi-hlr__id">ISSU_38<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider or Attestation Provider SHALL have a policy describing which method(s) (i.e,  A, B, C, and/or D) it will use to limit the number of times a Wallet Unit may present a single technical PID or attestation. For each supported method, the policy SHALL also specify how the values for respective parameters for that method, such as technical validity period and batch size, will be chosen. The goal of the policy SHALL be to ensure that the risk of linkability is mitigated to an acceptable level, given the (expected) usage of the logical PID or attestation by the User. To determine what an acceptable level of risk is, the PID Provider or Attestation Provider SHALL carry out a risk analysis regarding linkability.
+
+*Note: a) If an Attestation Provider issues multiple attestation types, these requirements apply for each type of attestation separately. b) [Technical Specification 3] specifies that WIAs and KAs shall be sent to a PID Provider or Attestation Provider only once. In other words, for WIAs and KAs, the use of Method A is mandatory.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_39" markdown>
+<div class="eudi-hlr__id">ISSU_39<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+PID Providers and Attestation Providers SHALL include the ``credential_reuse_policy`` parameter, specified in section 4.2.4.2 of [ETSI TS 119 472-3], in their Credential Issuer Metadata to specify which of the methods A, B, C, or D the Wallet Unit must use for the logical PID or attestation issued. Indicated methods SHALL be ordered by preference.
+
+*Note: See also ISSU_40.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_39a" markdown>
+<div class="eudi-hlr__id">ISSU_39a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Units SHALL support the ``credential_reuse_policy`` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3] and SHALL present each technical PID and attestation in accordance with the values set for this parameter by the relevant PID Provider or Attestation Provider.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_40" markdown>
+<div class="eudi-hlr__id">ISSU_40<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider or Attestation Provider SHALL indicate in their OpenID4VCI Issuer metadata that either method A or method B must be used for a given type of PID or attestation. In addition, a PID Provider or Attestation Provider MAY indicate that it prefers using method C and/or method D over method A or method B, by including the methods in the metadata in the appropriate order. In such a case, a Wallet Unit supporting method C and/or method D SHALL use that method, while a Wallet Unit not supporting these methods SHALL use method A or method B, as applicable.
+
+*Note: a) This requirement implies that a PID Provider or Attestation Provider must not include both method A and method B in its metadata.  b) Example: An Attestation Provider indicates methods {D, C, A} in its metadata, in that order. A Wallet Unit that supports methods C and D (as well as A and B) then uses method D for this type of attestation. A Wallet Unit supporting methods A, B and C uses method C. A Wallet Unit supporting only methods A and B uses method A.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_40a" markdown>
+<div class="eudi-hlr__id">ISSU_40a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When implementing any of the methods mentioned in ISSU_37, a  Wallet Unit, PID Provider, or Attestation Provider SHALL comply with the applicable requirements in [ETSI TS 119 472-3], section 4.2.4.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_41" markdown>
+<div class="eudi-hlr__id">ISSU_41<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+To the maximum extent possible, Wallet Providers, PID Providers, and Attestation Providers SHALL ensure that Users do not notice which of the methods A, B, C, or D is used for their PIDs and attestations.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_42" markdown>
+<div class="eudi-hlr__id">ISSU_42<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+To the maximum extent possible, Wallet Providers, PID Providers, and Attestation Providers SHALL ensure that no User action is needed for the re-issuance of WIAs or KAs, PIDs, or attestations.
+
+*Note: For the topic of re-issuance, see also the [Discussion Paper for Topic B](../../discussion-topics/b-re-issuance-and-batch-issuance-of-pids-and-attestations.md).*
+
+</div>
+</div>
+
 
 ##### Method A: Once-only attestations <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ISSU_43 | If Method A is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue technical PIDs or attestations in batches to the Wallet Unit. All PIDs or attestations in a batch SHALL have the same attribute values and the same technical validity period. |
-| ISSU_44 | If Method A is used, the Wallet Unit SHALL present each technical PID or attestation only once to a Relying Party that requests the corresponding logical PID or attestation, except when it has fallen back to Method B as specified in ISSU_47. |
-| ISSU_45 | If Method A is used, the Wallet Unit SHALL have a lower limit for the number of unused technical PIDs or attestations it holds for each logical PID or attestation, and SHALL request the issuance of a new batch when this limit is reached. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the value of the lower limit and the size of the batch to be requested, using the ``credential_reuse_policy`` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3]. |
-| ISSU_46 | If Method A is used and the Wallet Unit must request a new batch of technical PIDs or attestations but is not able to do so (for instance because it is offline), the Wallet Unit SHALL warn the User that they are about to lose the possibility to present the corresponding logical PID or attestation to Relying Parties, and request them to connect their device to the internet. |
-| ISSU_47 | If Method A is used and the Wallet Unit has run out of unused technical PIDs or attestations, but is not able to request a new batch, it SHALL fall back to method B (see ISSU_48 - ISSU_50). This means that, when requested by a Relying Party or Attestation Provider, the Wallet Unit SHALL again present one of the already used technical PIDs or attestations. The Wallet Unit SHALL return to using method A as soon as it is able to go online and request a new batch of PIDs or attestations. |
+<div class="eudi-hlr" id="ISSU_43" markdown>
+<div class="eudi-hlr__id">ISSU_43<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method A is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue technical PIDs or attestations in batches to the Wallet Unit. All PIDs or attestations in a batch SHALL have the same attribute values and the same technical validity period.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_44" markdown>
+<div class="eudi-hlr__id">ISSU_44<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method A is used, the Wallet Unit SHALL present each technical PID or attestation only once to a Relying Party that requests the corresponding logical PID or attestation, except when it has fallen back to Method B as specified in ISSU_47.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_45" markdown>
+<div class="eudi-hlr__id">ISSU_45<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method A is used, the Wallet Unit SHALL have a lower limit for the number of unused technical PIDs or attestations it holds for each logical PID or attestation, and SHALL request the issuance of a new batch when this limit is reached. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the value of the lower limit and the size of the batch to be requested, using the ``credential_reuse_policy`` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_46" markdown>
+<div class="eudi-hlr__id">ISSU_46<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method A is used and the Wallet Unit must request a new batch of technical PIDs or attestations but is not able to do so (for instance because it is offline), the Wallet Unit SHALL warn the User that they are about to lose the possibility to present the corresponding logical PID or attestation to Relying Parties, and request them to connect their device to the internet.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_47" markdown>
+<div class="eudi-hlr__id">ISSU_47<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method A is used and the Wallet Unit has run out of unused technical PIDs or attestations, but is not able to request a new batch, it SHALL fall back to method B (see ISSU_48 - ISSU_50). This means that, when requested by a Relying Party or Attestation Provider, the Wallet Unit SHALL again present one of the already used technical PIDs or attestations. The Wallet Unit SHALL return to using method A as soon as it is able to go online and request a new batch of PIDs or attestations.
+
+</div>
+</div>
+
 
 ##### Method B: Limited-time attestations <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ISSU_48 | If Method B is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue a single technical PID or attestation to the Wallet Unit. |
-| ISSU_49 | If Method B is used, the Wallet Unit SHALL present a technical PID or attestation multiple times to the same Relying Party or to different Relying Parties, when a Relying Party requests the corresponding logical PID or attestation. |
-| ISSU_50 | If Method B is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to re-issue a technical PID or attestation some time before the one existing in the Wallet Unit expires. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the moment at which the Wallet Unit must request the re-issuance of a technical PID or attestation, relative to the expiration date of the existing one. To do so, the  PID Provider or Attestation Provider SHALL use the `credential_reuse_policy` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3]. *Note: It is the responsibility of the Relying Party receiving a PID or attestation to validate whether a presented technical PID or attestation is temporally valid. A Wallet Unit is allowed to present a PID or attestation even if its expiration date is in the past.* |
+<div class="eudi-hlr" id="ISSU_48" markdown>
+<div class="eudi-hlr__id">ISSU_48<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method B is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue a single technical PID or attestation to the Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_49" markdown>
+<div class="eudi-hlr__id">ISSU_49<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method B is used, the Wallet Unit SHALL present a technical PID or attestation multiple times to the same Relying Party or to different Relying Parties, when a Relying Party requests the corresponding logical PID or attestation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_50" markdown>
+<div class="eudi-hlr__id">ISSU_50<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method B is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to re-issue a technical PID or attestation some time before the one existing in the Wallet Unit expires. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the moment at which the Wallet Unit must request the re-issuance of a technical PID or attestation, relative to the expiration date of the existing one. To do so, the  PID Provider or Attestation Provider SHALL use the `credential_reuse_policy` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3].
+
+*Note: It is the responsibility of the Relying Party receiving a PID or attestation to validate whether a presented technical PID or attestation is temporally valid. A Wallet Unit is allowed to present a PID or attestation even if its expiration date is in the past.*
+
+</div>
+</div>
+
 
 ##### Method C: Rotating-batch attestations <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ISSU_51 | If Method C is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue technical PIDs or attestations in batches to the Wallet Unit. All PIDs or attestations in a batch SHALL have the same attribute values and the same technical validity period. |
-| ISSU_52 | If Method C is used, the Wallet Unit SHALL present each technical PID or attestation in a batch once to a Relying Party that requests the corresponding logical PID or attestation, in a random order. When all PIDs or attestations in a batch have been presented once, the Wallet Unit SHALL reset the batch, and start presenting each PID or attestation in the batch again, in a random order. The Wallet Unit SHALL continue doing this until it receives a new batch, see ISSU_54. |
-| ISSU_53 | Empty |
-| ISSU_54 | If Method C is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to re-issue a batch of technical PIDs or attestations some time before the batch in the Wallet Unit expires. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the size of the batch and about the moment at which the Wallet Unit must request the re-issuance of a batch, relative to the expiration date of the existing batch.  To do so, the  PID Provider or Attestation Provider SHALL use the `credential_reuse_policy` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3]. |
+<div class="eudi-hlr" id="ISSU_51" markdown>
+<div class="eudi-hlr__id">ISSU_51<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method C is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue technical PIDs or attestations in batches to the Wallet Unit. All PIDs or attestations in a batch SHALL have the same attribute values and the same technical validity period.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_52" markdown>
+<div class="eudi-hlr__id">ISSU_52<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method C is used, the Wallet Unit SHALL present each technical PID or attestation in a batch once to a Relying Party that requests the corresponding logical PID or attestation, in a random order. When all PIDs or attestations in a batch have been presented once, the Wallet Unit SHALL reset the batch, and start presenting each PID or attestation in the batch again, in a random order. The Wallet Unit SHALL continue doing this until it receives a new batch, see ISSU_54.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_53" markdown>
+<div class="eudi-hlr__id">ISSU_53</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_54" markdown>
+<div class="eudi-hlr__id">ISSU_54<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method C is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to re-issue a batch of technical PIDs or attestations some time before the batch in the Wallet Unit expires. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the size of the batch and about the moment at which the Wallet Unit must request the re-issuance of a batch, relative to the expiration date of the existing batch.  To do so, the  PID Provider or Attestation Provider SHALL use the `credential_reuse_policy` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3].
+
+</div>
+</div>
+
 
 ##### Method D: Per-Relying Party attestations <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ISSU_55 | If Method D is used, the Wallet Unit SHALL present a different technical PID or attestation to each different Relying Party that requests the corresponding logical PID or attestation. This means that it SHALL comply with all requirements for Method A for such Relying Parties. *Note: This means the Wallet Unit presents an unused technical attestation to each new Relying Party that request the logical attestation, and it requests a new batch of technical attestations if the number of remaining unused attestations goes below the lower limit. If for some reason requesting a new batch is not successful and the Wallet Unit runs out of unused technical attestations, it re-uses one of the already used technical attestations.* |
-| ISSU_56 | If Method D is used and a given Relying Party requests attributes from a given logical  PID or attestation multiple times, the Wallet Unit MAY present the same technical PID or attestation to this Relying Party each time. If it does, it SHALL comply with all requirements for Method B for such a Relying Party. |
-| ISSU_56a | Empty |
-| ISSU_57 | If Method D is used, the Wallet Unit SHALL keep track of which technical PID or attestation it has presented to which Relying Party. *Note: To do so, the Wallet Unit can use the unique RP identifier from the extension of the presentation request meant in RPRC_19a.* |
-| ISSU_57a | Empty |
+<div class="eudi-hlr" id="ISSU_55" markdown>
+<div class="eudi-hlr__id">ISSU_55<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method D is used, the Wallet Unit SHALL present a different technical PID or attestation to each different Relying Party that requests the corresponding logical PID or attestation. This means that it SHALL comply with all requirements for Method A for such Relying Parties.
+
+*Note: This means the Wallet Unit presents an unused technical attestation to each new Relying Party that request the logical attestation, and it requests a new batch of technical attestations if the number of remaining unused attestations goes below the lower limit. If for some reason requesting a new batch is not successful and the Wallet Unit runs out of unused technical attestations, it re-uses one of the already used technical attestations.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_56" markdown>
+<div class="eudi-hlr__id">ISSU_56<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method D is used and a given Relying Party requests attributes from a given logical  PID or attestation multiple times, the Wallet Unit MAY present the same technical PID or attestation to this Relying Party each time. If it does, it SHALL comply with all requirements for Method B for such a Relying Party.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_56a" markdown>
+<div class="eudi-hlr__id">ISSU_56a</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_57" markdown>
+<div class="eudi-hlr__id">ISSU_57<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Method D is used, the Wallet Unit SHALL keep track of which technical PID or attestation it has presented to which Relying Party.
+
+*Note: To do so, the Wallet Unit can use the unique RP identifier from the extension of the presentation request meant in RPRC_19a.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_57a" markdown>
+<div class="eudi-hlr__id">ISSU_57a</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 ##### E - HLRs for re-issuance and batch issuance of PIDs and attestations <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ISSU_58 | A Wallet Unit SHALL give its User the option to manually initiate a re-issuance process for any of the logical PIDs or attestations in their Wallet Unit. If the User uses this option, the Wallet Unit SHALL attempt to start the re-issuance process immediately, and SHALL notify the User if it did not succeed in requesting re-issuance. *Note: a) This requirement does not apply for KAs or WIAs, since Users must not be involved in their management. b) In the case of a PID or an attestation bound to the WSCA/WSCD, the Wallet Unit will request the User to authenticate to the WSCA/WSCD (see WIAM_14). In case of an attestation bound to a keystore, no additional User authentication is needed, see WIAM_15c.* |
-| ISSU_59 | After a successful re-issuance, a Wallet Unit SHALL compare the attribute values of the re-issued technical PID or attestation with those of the existing technical PID or attestation, and SHALL notify the User in case of any differences. *Note: a) This requirement does not apply for KAs or WIAs, since Users must not be involved in their management. b) The point of this requirement is to allow the User to detect errors in the attribute values in the new attestation. The follow-up process in case of errors is not defined. Presumably, the User can contact the Attestation Provider to discuss the fact that it apparently holds false attribute values for the User, and as a result, the Attestation Provider may decide to revoke the attestation.* |
-| ISSU_60 | A Wallet Unit SHALL gracefully handle situations in which re-issuance of a PID, attestation, KA, or WIA fails or is refused by the PID Provider, Attestation Provider, or Wallet Provider, for example by attempting a retry after an appropriate delay. |
-| ISSU_61 | A Wallet Unit SHALL support PID or attestation first-time batch issuance with a single User authentication, regardless of the size of the batch. *Note:  See also requirement WIAM_14.* |
-| ISSU_62 | If a technical PID or attestation was successfully re-issued because the value of one or more of its attributes was changed (including attributes being added or deleted), a Wallet Unit SHALL no longer present the (now obsolete) pre-existing technical PID or attestation, and SHOULD delete it. *Note: a) It is up to the Wallet Unit, possibly using metadata provided by the PID Provider or Attestation Provider using the [OpenID4VCI] protocol, to determine the technical PID or attestation to be deleted. b) Additionally, per requirement VCR_09, the PID Provider or Attestation Provider revokes the pre-existing technical PID or attestation.* |
-| ISSU_63 | PID Providers and Attestation Providers, and Wallet Units SHALL support the features of [OpenID4VCI] enabling the re-issuance of PIDs and attestations. |
-| ISSU_64 | PID Providers, Attestation Providers, and Wallet Units SHALL support the features of [OpenID4VCI] enabling the batch issuance of technical PIDs or attestations. |
-| ISSU_65 | A PID Provider or an Attestation Provider of device-bound attestations SHALL verify that a re-issued technical PID or device-bound attestation is issued to the same Wallet Unit as the existing PID or attestation. *Note: A PID Provider or Attestation Provider can do so by issuing a device-bound refresh token to the Wallet Instance during the original issuance of the PID or attestation, and requiring that the Wallet Instance uses it to obtain a fresh access token during re-issuance; see [OpenID4VCI] section 14.5. The PID Provider or Attestation Provider needs to be able to trust that the Wallet Instance handles the refresh tokens in a secure way, so that an attacker cannot use them from another Wallet Instance. This requires trust in the (continued) security and integrity of both the original Wallet Instance and the other Wallet Instance. This trust is provided by providing the PID Provider or Attestation Provider with a valid KA for the new Wallet Unit during re-issuance, and by enabling the PID Provider or Attestation Provider to verify that the original Wallet Unit has not been revoked.* |
-| ISSU_66 | Empty |
+<div class="eudi-hlr" id="ISSU_58" markdown>
+<div class="eudi-hlr__id">ISSU_58<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL give its User the option to manually initiate a re-issuance process for any of the logical PIDs or attestations in their Wallet Unit. If the User uses this option, the Wallet Unit SHALL attempt to start the re-issuance process immediately, and SHALL notify the User if it did not succeed in requesting re-issuance.
+
+*Note: a) This requirement does not apply for KAs or WIAs, since Users must not be involved in their management. b) In the case of a PID or an attestation bound to the WSCA/WSCD, the Wallet Unit will request the User to authenticate to the WSCA/WSCD (see WIAM_14). In case of an attestation bound to a keystore, no additional User authentication is needed, see WIAM_15c.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_59" markdown>
+<div class="eudi-hlr__id">ISSU_59<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+After a successful re-issuance, a Wallet Unit SHALL compare the attribute values of the re-issued technical PID or attestation with those of the existing technical PID or attestation, and SHALL notify the User in case of any differences.
+
+*Note: a) This requirement does not apply for KAs or WIAs, since Users must not be involved in their management. b) The point of this requirement is to allow the User to detect errors in the attribute values in the new attestation. The follow-up process in case of errors is not defined. Presumably, the User can contact the Attestation Provider to discuss the fact that it apparently holds false attribute values for the User, and as a result, the Attestation Provider may decide to revoke the attestation.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_60" markdown>
+<div class="eudi-hlr__id">ISSU_60<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL gracefully handle situations in which re-issuance of a PID, attestation, KA, or WIA fails or is refused by the PID Provider, Attestation Provider, or Wallet Provider, for example by attempting a retry after an appropriate delay.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_61" markdown>
+<div class="eudi-hlr__id">ISSU_61<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL support PID or attestation first-time batch issuance with a single User authentication, regardless of the size of the batch.
+
+*Note:  See also requirement WIAM_14.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_62" markdown>
+<div class="eudi-hlr__id">ISSU_62<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a technical PID or attestation was successfully re-issued because the value of one or more of its attributes was changed (including attributes being added or deleted), a Wallet Unit SHALL no longer present the (now obsolete) pre-existing technical PID or attestation, and SHOULD delete it.
+
+*Note: a) It is up to the Wallet Unit, possibly using metadata provided by the PID Provider or Attestation Provider using the [OpenID4VCI] protocol, to determine the technical PID or attestation to be deleted. b) Additionally, per requirement VCR_09, the PID Provider or Attestation Provider revokes the pre-existing technical PID or attestation.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_63" markdown>
+<div class="eudi-hlr__id">ISSU_63<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+PID Providers and Attestation Providers, and Wallet Units SHALL support the features of [OpenID4VCI] enabling the re-issuance of PIDs and attestations.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_64" markdown>
+<div class="eudi-hlr__id">ISSU_64<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+PID Providers, Attestation Providers, and Wallet Units SHALL support the features of [OpenID4VCI] enabling the batch issuance of technical PIDs or attestations.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_65" markdown>
+<div class="eudi-hlr__id">ISSU_65<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider or an Attestation Provider of device-bound attestations SHALL verify that a re-issued technical PID or device-bound attestation is issued to the same Wallet Unit as the existing PID or attestation.
+
+*Note: A PID Provider or Attestation Provider can do so by issuing a device-bound refresh token to the Wallet Instance during the original issuance of the PID or attestation, and requiring that the Wallet Instance uses it to obtain a fresh access token during re-issuance; see [OpenID4VCI] section 14.5. The PID Provider or Attestation Provider needs to be able to trust that the Wallet Instance handles the refresh tokens in a secure way, so that an attacker cannot use them from another Wallet Instance. This requires trust in the (continued) security and integrity of both the original Wallet Instance and the other Wallet Instance. This trust is provided by providing the PID Provider or Attestation Provider with a valid KA for the new Wallet Unit during re-issuance, and by enabling the PID Provider or Attestation Provider to verify that the original Wallet Unit has not been revoked.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_66" markdown>
+<div class="eudi-hlr__id">ISSU_66</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 ##### F - HLRs for attestation-signing certificate profiles and certificate policies <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ISSU_67 | A PID Provider SHALL have a policy governing all aspects of PID issuance and management. The policy SHALL comply with at least the extended normalised certificate policy (‘NCP+’) requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of PIDs rather than public key certificates. *Note: A common dedicated policy for issuing PIDs may be developed in the future. If so, this requirement will be changed to refer to it.* |
-| ISSU_68 | PID Providers SHALL ensure that the certificates they use for signing PIDs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 4. |
-| ISSU_69 | A QEAA Provider SHALL have a policy governing all aspects of QEAA issuance and management. The policy SHALL comply with at least the policy for qualified certificates issued to a natural person where the private key and the related certificate reside on a QSCD (‘QCP-n-qscd’) or qualified certificates issued to a legal person where the private key and the related certificate reside on a QSCD (‘QCP-l-qscd’) requirements as specified in [ETSI EN 319 411-2], insofar applicable for the issuance of QEAAs rather than public key certificates. *Note: A common dedicated policy for issuing QEAAs may be developed in the future. If so, this requirement will be changed to refer to it.* |
-| ISSU_70 | QEAA Providers SHALL ensure that the certificates they use for signing QEAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 7. |
-| ISSU_71 | Providers of non-qualified EAAs SHALL ensure that the certificates they use for signing EAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 6. |
-| ISSU_72 | A PuB-EAA Provider SHALL have a policy governing all aspects of PuB-EAA issuance and management. The policy SHALL comply with at least the extended normalised certificate policy (‘NCP+’) requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of PuB-EAAs rather than public key certificates. *Note: A common dedicated policy for issuing PuB-EAAs may be developed in the future. If so, this requirement will be changed to refer to it* |
-| ISSU_73 | PuB-EAAs Providers SHALL ensure that the certificates they use for signing PuB-EAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 8. |
+<div class="eudi-hlr" id="ISSU_67" markdown>
+<div class="eudi-hlr__id">ISSU_67<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider SHALL have a policy governing all aspects of PID issuance and management. The policy SHALL comply with at least the extended normalised certificate policy (‘NCP+’) requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of PIDs rather than public key certificates.
+
+*Note: A common dedicated policy for issuing PIDs may be developed in the future. If so, this requirement will be changed to refer to it.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_68" markdown>
+<div class="eudi-hlr__id">ISSU_68<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+PID Providers SHALL ensure that the certificates they use for signing PIDs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 4.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_69" markdown>
+<div class="eudi-hlr__id">ISSU_69<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A QEAA Provider SHALL have a policy governing all aspects of QEAA issuance and management. The policy SHALL comply with at least the policy for qualified certificates issued to a natural person where the private key and the related certificate reside on a QSCD (‘QCP-n-qscd’) or qualified certificates issued to a legal person where the private key and the related certificate reside on a QSCD (‘QCP-l-qscd’) requirements as specified in [ETSI EN 319 411-2], insofar applicable for the issuance of QEAAs rather than public key certificates.
+
+*Note: A common dedicated policy for issuing QEAAs may be developed in the future. If so, this requirement will be changed to refer to it.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_70" markdown>
+<div class="eudi-hlr__id">ISSU_70<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+QEAA Providers SHALL ensure that the certificates they use for signing QEAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 7.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_71" markdown>
+<div class="eudi-hlr__id">ISSU_71<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Providers of non-qualified EAAs SHALL ensure that the certificates they use for signing EAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 6.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_72" markdown>
+<div class="eudi-hlr__id">ISSU_72<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PuB-EAA Provider SHALL have a policy governing all aspects of PuB-EAA issuance and management. The policy SHALL comply with at least the extended normalised certificate policy (‘NCP+’) requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of PuB-EAAs rather than public key certificates.
+
+*Note: A common dedicated policy for issuing PuB-EAAs may be developed in the future. If so, this requirement will be changed to refer to it*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ISSU_73" markdown>
+<div class="eudi-hlr__id">ISSU_73<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+PuB-EAAs Providers SHALL ensure that the certificates they use for signing PuB-EAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 8.
+
+</div>
+</div>
+
 
 #### A.2.3.8 Topic 11 - Pseudonyms
 
 ##### A. HLRs related to Use Cases A and B <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| PA_01 | A Wallet Unit SHALL enable a User to generate a Pseudonym and register it at a Relying Party. *Note: For an attested pseudonym, pseudonym generation takes place by requesting the issuance of a pseudonym attestation. Pseudonym registration takes place by presenting the attestation.* |
-| PA_02 | A Wallet Unit SHALL enable a User to authenticate with a Pseudonym towards a Relying Party if the Wallet Unit was used previously to register the Pseudonym for the same Relying Party |
-| PA_03 | A Wallet Unit SHALL be able to perform the actions specified in the above two requirements independently of whether the interaction with the Relying Party is initiated on the same device hosting the Wallet Instance or on a device different from the one hosting the Wallet Instance. |
-| PA_04 | A Wallet Unit SHALL enable the User to use multiple different Pseudonyms at a given Relying Party, unless it is explicitly designed as a scope rate-limited attestation. |
-| PA_05 | A Wallet Unit SHOULD enable a User to freely choose a User alias for each Pseudonym registered at a Relying Party. Setting an alias SHOULD be optional for the User. The User SHOULD be able to change the alias for any Pseudonym. |
-| PA_06 | A Wallet Unit SHALL enable a User to choose which Pseudonym to authenticate with towards a Relying Party, if multiple Pseudonyms are registered for this Relying Party. The Wallet Unit SHOULD present the User with the aliases of the applicable Pseudonyms, if assigned, when making this choice. |
-| PA_07 | A Wallet Unit SHALL enable a User to delete a Pseudonym. |
-| PA_08 | A Wallet Unit SHALL enable the User to manage Pseudonyms within the Wallet Unit in a user-friendly and transparent manner. |
-| PA_08a | A Wallet Unit SHALL log Pseudonym registration and presentation transactions as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency). |
-| PA_09 | A Wallet Unit SHALL enable the User to see all existing pseudonyms, including the associated Relying Party (if any). |
+<div class="eudi-hlr" id="PA_01" markdown>
+<div class="eudi-hlr__id">PA_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL enable a User to generate a Pseudonym and register it at a Relying Party.
+
+*Note: For an attested pseudonym, pseudonym generation takes place by requesting the issuance of a pseudonym attestation. Pseudonym registration takes place by presenting the attestation.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_02" markdown>
+<div class="eudi-hlr__id">PA_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL enable a User to authenticate with a Pseudonym towards a Relying Party if the Wallet Unit was used previously to register the Pseudonym for the same Relying Party
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_03" markdown>
+<div class="eudi-hlr__id">PA_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL be able to perform the actions specified in the above two requirements independently of whether the interaction with the Relying Party is initiated on the same device hosting the Wallet Instance or on a device different from the one hosting the Wallet Instance.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_04" markdown>
+<div class="eudi-hlr__id">PA_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL enable the User to use multiple different Pseudonyms at a given Relying Party, unless it is explicitly designed as a scope rate-limited attestation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_05" markdown>
+<div class="eudi-hlr__id">PA_05<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHOULD enable a User to freely choose a User alias for each Pseudonym registered at a Relying Party. Setting an alias SHOULD be optional for the User. The User SHOULD be able to change the alias for any Pseudonym.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_06" markdown>
+<div class="eudi-hlr__id">PA_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL enable a User to choose which Pseudonym to authenticate with towards a Relying Party, if multiple Pseudonyms are registered for this Relying Party. The Wallet Unit SHOULD present the User with the aliases of the applicable Pseudonyms, if assigned, when making this choice.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_07" markdown>
+<div class="eudi-hlr__id">PA_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL enable a User to delete a Pseudonym.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_08" markdown>
+<div class="eudi-hlr__id">PA_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL enable the User to manage Pseudonyms within the Wallet Unit in a user-friendly and transparent manner.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_08a" markdown>
+<div class="eudi-hlr__id">PA_08a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL log Pseudonym registration and presentation transactions as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_09" markdown>
+<div class="eudi-hlr__id">PA_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL enable the User to see all existing pseudonyms, including the associated Relying Party (if any).
+
+</div>
+</div>
+
 
 ##### B. HLRs related to Relying Parties <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| PA_10 | A Relying Party SHALL be able to verify that a User is registering a Pseudonym using a non-revoked Wallet Unit. |
-| PA_11 | A Relying Party SHALL be able to verify that a User is authenticating with a Pseudonym using a non-revoked Wallet Unit. |
-| PA_12 | If Wallet Unit is used to register a Pseudonym at a Relying Party in combination with a PID or attestation being presented to the same Relying Party, then this Relying Party SHALL be able to verify that the same User performed both actions. |
-| PA_13 | The Relying Party SHALL be able to validate that the pseudonym presented to them belongs to the User presenting it. |
+<div class="eudi-hlr" id="PA_10" markdown>
+<div class="eudi-hlr__id">PA_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Relying Party SHALL be able to verify that a User is registering a Pseudonym using a non-revoked Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_11" markdown>
+<div class="eudi-hlr__id">PA_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Relying Party SHALL be able to verify that a User is authenticating with a Pseudonym using a non-revoked Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_12" markdown>
+<div class="eudi-hlr__id">PA_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If Wallet Unit is used to register a Pseudonym at a Relying Party in combination with a PID or attestation being presented to the same Relying Party, then this Relying Party SHALL be able to verify that the same User performed both actions.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_13" markdown>
+<div class="eudi-hlr__id">PA_13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Relying Party SHALL be able to validate that the pseudonym presented to them belongs to the User presenting it.
+
+</div>
+</div>
+
 
 ##### C. HLRs related to privacy <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| PA_14 | A Wallet Unit SHALL store the information necessary for authenticating with a Pseudonym in either a WSCA/WSCD or in a keystore. |
-| PA_15 | A Relying Party SHALL NOT be able to derive the User's true identity, or any data identifying the User, from the Pseudonym value received by the Relying Party. |
-| PA_16 | A Wallet Unit SHALL NOT reveal the same Pseudonym to different Relying Parties, unless the User explicitly chooses otherwise. |
-| PA_17 | The Wallet Provider SHALL use method(s) and/or protocol(s) to implement pseudonyms which make it impossible to correlate Pseudonyms based on their values or on metadata sent by the Wallet Unit to Relying Parties during registration and authentication. *Note: This implies that colluding Relying Parties will not be able to conclude that different Pseudonyms belong to the same User.* |
-| PA_18 | The Wallet Unit SHALL ensure that Pseudonyms contain sufficient entropy to make the chance of colliding Pseudonyms (meaning two Users having the same Pseudonym value for the same Relying Party) negligible. |
-| PA_19 | A Wallet Unit SHALL NOT share the User's optionally assigned Pseudonym aliases with any Relying Party. |
-| PA_20 | The Wallet Unit SHALL verify the identity of a Relying Party when a User registers a Pseudonym or authenticates with a Pseudonym. If the profile or extension of [W3C WebAuthn] meant in PA_21 does not enable the Wallet Unit to do this, the Wallet Unit SHALL trust the WebAuthn Client (i.e., the browser) to verify the Relying Party identity. *Note: [W3C WebAuthn] currently does not offer a way for an Authenticator (i.e., the Wallet Unit) to authenticate a Relying Party. Instead, the Client (i.e., the browser) will authenticate the Relying Party, using TLS. The notion of trust is that the Wallet Unit receives the Relying Party identity from the browser and uses it without further verifications.* |
+<div class="eudi-hlr" id="PA_14" markdown>
+<div class="eudi-hlr__id">PA_14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL store the information necessary for authenticating with a Pseudonym in either a WSCA/WSCD or in a keystore.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_15" markdown>
+<div class="eudi-hlr__id">PA_15<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Relying Party SHALL NOT be able to derive the User's true identity, or any data identifying the User, from the Pseudonym value received by the Relying Party.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_16" markdown>
+<div class="eudi-hlr__id">PA_16<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL NOT reveal the same Pseudonym to different Relying Parties, unless the User explicitly chooses otherwise.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_17" markdown>
+<div class="eudi-hlr__id">PA_17<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Provider SHALL use method(s) and/or protocol(s) to implement pseudonyms which make it impossible to correlate Pseudonyms based on their values or on metadata sent by the Wallet Unit to Relying Parties during registration and authentication.
+
+*Note: This implies that colluding Relying Parties will not be able to conclude that different Pseudonyms belong to the same User.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_18" markdown>
+<div class="eudi-hlr__id">PA_18<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL ensure that Pseudonyms contain sufficient entropy to make the chance of colliding Pseudonyms (meaning two Users having the same Pseudonym value for the same Relying Party) negligible.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_19" markdown>
+<div class="eudi-hlr__id">PA_19<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL NOT share the User's optionally assigned Pseudonym aliases with any Relying Party.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_20" markdown>
+<div class="eudi-hlr__id">PA_20<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL verify the identity of a Relying Party when a User registers a Pseudonym or authenticates with a Pseudonym. If the profile or extension of [W3C WebAuthn] meant in PA_21 does not enable the Wallet Unit to do this, the Wallet Unit SHALL trust the WebAuthn Client (i.e., the browser) to verify the Relying Party identity.
+
+*Note: [W3C WebAuthn] currently does not offer a way for an Authenticator (i.e., the Wallet Unit) to authenticate a Relying Party. Instead, the Client (i.e., the browser) will authenticate the Relying Party, using TLS. The notion of trust is that the Wallet Unit receives the Relying Party identity from the browser and uses it without further verifications.*
+
+</div>
+</div>
+
 
 ##### D. HLRs related to interoperability <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| PA_21 | The Commission SHALL create or reference a technical specification containing a profile or extension of the [W3C WebAuthn] specification compliant with the HLRs specified in this Topic. This specification SHALL contain all details necessary for Wallet Units and Relying Parties to generate, register, and use Pseudonyms. |
-| PA_22 | Wallet Providers MAY ensure that their Wallet Solution supports the HLRs defined for this topic by letting their Wallet Units perform the role of a WebAuthn authenticator following the [W3C WebAuthn] specification and the technical specification referenced in referenced in PA_21. |
+<div class="eudi-hlr" id="PA_21" markdown>
+<div class="eudi-hlr__id">PA_21<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Commission SHALL create or reference a technical specification containing a profile or extension of the [W3C WebAuthn] specification compliant with the HLRs specified in this Topic. This specification SHALL contain all details necessary for Wallet Units and Relying Parties to generate, register, and use Pseudonyms.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_22" markdown>
+<div class="eudi-hlr__id">PA_22<span class="kw-may">MAY</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers MAY ensure that their Wallet Solution supports the HLRs defined for this topic by letting their Wallet Units perform the role of a WebAuthn authenticator following the [W3C WebAuthn] specification and the technical specification referenced in referenced in PA_21.
+
+</div>
+</div>
+
 
 ##### E. HLRs related to scope rate-limited pseudonyms <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| PA_23 | A protocol enabling scope rate-limited pseudonyms SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0]. |
-| PA_24 | A protocol enabling scope rate-limited pseudonyms SHALL enable a Wallet Unit to allow a User to generate a scope rate-limited pseudonym, register this by a Relying Party, and prove that this is within the rate and scope restrictions determined by the Relying Party. |
-| PA_25 | A protocol enabling scope rate-limited pseudonyms SHALL allow a Relying Party, when a User presents a scope rate-limited pseudonym, to verify that the rate is not exceeded for this User. |
-| PA_26 | A protocol enabling scope rate-limited pseudonyms SHALL allow a Relying Party to choose the scope and rate when requesting a scope rate-limited pseudonym from a User. |
-| PA_27 | A protocol enabling scope rate-limited pseudonyms SHALL NOT allow any entity or collusion of entities not including the User, to link scope rate-limited pseudonyms of the same User when used across several different Relying Parties. This SHALL hold even if the scope and rate are identical across the different Relying Parties and both for registration and authentication of the scope rate-limited pseudonym |
-| PA_28 | A protocol enabling scope rate-limited pseudonyms SHALL ensure that if the rate is larger than 1, a User's different pseudonyms SHALL be unlinkable for the same scope. This SHALL hold against any entity or collusion of entities, not including the User. Further, such protocol SHALL ensure that during registration or authentication with such a pseudonym, it SHALL NOT be possible for the Relying Party to deduce any information about how many pseudonyms the User has already registered (except that it does not exceed the predetermined rate). |
-| PA_29 | A protocol enabling scope rate-limited pseudonyms SHALL ensure that no entity or collusion of entities, not including a User, is able to authenticate or register with a scope rate-limited pseudonym of this User. |
-| PA_30 | A Wallet Unit SHALL store cryptographic material necessary for authenticating as a scope rate-limited pseudonyms in either a WSCA/WSCD or in a keystore. |
-| PA_31 | A User's scope rate limited pseudonyms for a particular scope and rate SHALL be persistent over time even if they start using another Wallet Unit. |
+<div class="eudi-hlr" id="PA_23" markdown>
+<div class="eudi-hlr__id">PA_23<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A protocol enabling scope rate-limited pseudonyms SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_24" markdown>
+<div class="eudi-hlr__id">PA_24<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A protocol enabling scope rate-limited pseudonyms SHALL enable a Wallet Unit to allow a User to generate a scope rate-limited pseudonym, register this by a Relying Party, and prove that this is within the rate and scope restrictions determined by the Relying Party.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_25" markdown>
+<div class="eudi-hlr__id">PA_25<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A protocol enabling scope rate-limited pseudonyms SHALL allow a Relying Party, when a User presents a scope rate-limited pseudonym, to verify that the rate is not exceeded for this User.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_26" markdown>
+<div class="eudi-hlr__id">PA_26<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A protocol enabling scope rate-limited pseudonyms SHALL allow a Relying Party to choose the scope and rate when requesting a scope rate-limited pseudonym from a User.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_27" markdown>
+<div class="eudi-hlr__id">PA_27<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A protocol enabling scope rate-limited pseudonyms SHALL NOT allow any entity or collusion of entities not including the User, to link scope rate-limited pseudonyms of the same User when used across several different Relying Parties. This SHALL hold even if the scope and rate are identical across the different Relying Parties and both for registration and authentication of the scope rate-limited pseudonym
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_28" markdown>
+<div class="eudi-hlr__id">PA_28<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A protocol enabling scope rate-limited pseudonyms SHALL ensure that if the rate is larger than 1, a User's different pseudonyms SHALL be unlinkable for the same scope. This SHALL hold against any entity or collusion of entities, not including the User. Further, such protocol SHALL ensure that during registration or authentication with such a pseudonym, it SHALL NOT be possible for the Relying Party to deduce any information about how many pseudonyms the User has already registered (except that it does not exceed the predetermined rate).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_29" markdown>
+<div class="eudi-hlr__id">PA_29<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A protocol enabling scope rate-limited pseudonyms SHALL ensure that no entity or collusion of entities, not including a User, is able to authenticate or register with a scope rate-limited pseudonym of this User.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_30" markdown>
+<div class="eudi-hlr__id">PA_30<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL store cryptographic material necessary for authenticating as a scope rate-limited pseudonyms in either a WSCA/WSCD or in a keystore.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PA_31" markdown>
+<div class="eudi-hlr__id">PA_31<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A User's scope rate limited pseudonyms for a particular scope and rate SHALL be persistent over time even if they start using another Wallet Unit.
+
+</div>
+</div>
+
 
 #### A.2.3.9 Topic 12 - Attestation Rulebooks
 
 ##### A. Requirements regarding attestation formats <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ARB_01 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL specify that one or more of the following two common format(s) must be used for these attestations: - The format specified in ISO/IEC 18013-5, see [ISO18013-5]. - The format specified in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC]. |
-| ARB_01a | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHALL specify that one or more of the following three common format(s) must be used for these attestations: - The format specified in ISO/IEC 18013-5, see [ISO18013-5]. - The format specified in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC]. - The format specified in W3C Verifiable Credentials Data Model, see [W3C VCDM v2.0]. |
-| ARB_01b | The Scheme Provider for an Attestation Rulebook describing attestations using the format specified in [SD-JWT VC] SHALL ensure that these attestations comply with the 'IETF SD-JWT VC Profile' specified in [HAIP] Section 6.1. |
-| ARB_02 | The Scheme Provider for an Attestation Rulebook SHALL analyse whether it must be possible for a User to present that type of attestation when the Wallet Unit and the Relying Party are in proximity and attestations are presented without using the internet. If so, the Attestation Rulebook SHALL specify that the attestations must be issued in the ISO/IEC 18013-5-compliant mdoc format. *Note: In theory, it is possible to use SD-JWT VC-compliant attestations in proximity use cases. In practice, however, the only protocol available to request and present SD-JWT VC-compliant attestations between a Wallet Unit and a Relying Party Instance is OpenID4VP. That protocol cannot be used without internet connectivity.* |
-| ARB_03 | The Scheme Provider for an Attestation Rulebook MAY specify in the Attestation Rulebook that that type of attestation must be issued in the [SD-JWT VC]-compliant format, provided the [SD-JWT VC] specification has been approved by an EU standardisation body or by the European Digital Identity Cooperation Group established pursuant to [Article 46e](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e4536-1-1)(1) of the [European Digital Identity Regulation]. |
-| ARB_04 | If an Attestation Rulebook specifies that a type of attestation can be issued in a format compliant with [W3C VCDM v2.0], the Scheme Provider for that Attestation Rulebook SHALL ensure the Rulebook references one or more documents specifying in detail how a Relying Party can request attributes from a such an attestation, and how a User can selectively disclose attributes from such an attestation. Moreover, these referenced documents SHALL be approved by an EU standardisation body or by the European Digital Identity Cooperation Group established pursuant to [Article 46e](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e4536-1-1)(1) of the [European Digital Identity Regulation]. |
+<div class="eudi-hlr" id="ARB_01" markdown>
+<div class="eudi-hlr__id">ARB_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL specify that one or more of the following two common format(s) must be used for these attestations: - The format specified in ISO/IEC 18013-5, see [ISO18013-5]. - The format specified in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_01a" markdown>
+<div class="eudi-hlr__id">ARB_01a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHALL specify that one or more of the following three common format(s) must be used for these attestations: - The format specified in ISO/IEC 18013-5, see [ISO18013-5]. - The format specified in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC]. - The format specified in W3C Verifiable Credentials Data Model, see [W3C VCDM v2.0].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_01b" markdown>
+<div class="eudi-hlr__id">ARB_01b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing attestations using the format specified in [SD-JWT VC] SHALL ensure that these attestations comply with the 'IETF SD-JWT VC Profile' specified in [HAIP] Section 6.1.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_02" markdown>
+<div class="eudi-hlr__id">ARB_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook SHALL analyse whether it must be possible for a User to present that type of attestation when the Wallet Unit and the Relying Party are in proximity and attestations are presented without using the internet. If so, the Attestation Rulebook SHALL specify that the attestations must be issued in the ISO/IEC 18013-5-compliant mdoc format.
+
+*Note: In theory, it is possible to use SD-JWT VC-compliant attestations in proximity use cases. In practice, however, the only protocol available to request and present SD-JWT VC-compliant attestations between a Wallet Unit and a Relying Party Instance is OpenID4VP. That protocol cannot be used without internet connectivity.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_03" markdown>
+<div class="eudi-hlr__id">ARB_03<span class="kw-may">MAY</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook MAY specify in the Attestation Rulebook that that type of attestation must be issued in the [SD-JWT VC]-compliant format, provided the [SD-JWT VC] specification has been approved by an EU standardisation body or by the European Digital Identity Cooperation Group established pursuant to [Article 46e](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e4536-1-1)(1) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_04" markdown>
+<div class="eudi-hlr__id">ARB_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If an Attestation Rulebook specifies that a type of attestation can be issued in a format compliant with [W3C VCDM v2.0], the Scheme Provider for that Attestation Rulebook SHALL ensure the Rulebook references one or more documents specifying in detail how a Relying Party can request attributes from a such an attestation, and how a User can selectively disclose attributes from such an attestation. Moreover, these referenced documents SHALL be approved by an EU standardisation body or by the European Digital Identity Cooperation Group established pursuant to [Article 46e](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e4536-1-1)(1) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
 
 ##### B. Requirements regarding attestation types <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ARB_05 | The Scheme Provider for an Attestation Rulebook SHALL specify a value for the attestation type, which SHALL be unique within the scope of the EUDI Wallet ecosystem. *Note: In ISO/IEC 18013-5, the attestation type is called 'document type' and is included as a ``docType`` key-value pair in both the mdoc request and the mdoc response. Also, a method for generating unique attestation type values is recommended. In OpenID4VP, the attestation type is included in the ``meta`` property of a Credential Query in a presentation request. In [SD-JWT VC], the attestation type is called 'SD-JWT VC type' and is included as a ``vct`` claim in the SD-JWT VC.* |
+<div class="eudi-hlr" id="ARB_05" markdown>
+<div class="eudi-hlr__id">ARB_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook SHALL specify a value for the attestation type, which SHALL be unique within the scope of the EUDI Wallet ecosystem.
+
+*Note: In ISO/IEC 18013-5, the attestation type is called 'document type' and is included as a ``docType`` key-value pair in both the mdoc request and the mdoc response. Also, a method for generating unique attestation type values is recommended. In OpenID4VP, the attestation type is included in the ``meta`` property of a Credential Query in a presentation request. In [SD-JWT VC], the attestation type is called 'SD-JWT VC type' and is included as a ``vct`` claim in the SD-JWT VC.*
+
+</div>
+</div>
+
 
 ##### C. Requirements regarding attestation schemes <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ARB_06 | The Scheme Provider for an Attestation Rulebook SHALL define all attributes that an attestation of that type may contain. This definition SHALL first describe the semantics of each attribute in an encoding-independent manner and SHALL subsequently for each attribute specify an ISO/IEC 18013-5-compliant format, an SD-JWT VC-compliant format, or both, as needed given the choices made according to ARB_01 - ARB_04. |
-| ARB_06a | For ISO/IEC 18013-5-compliant attestations, the Attestation Rulebook SHALL define each attribute within an attribute namespace. An attribute namespace SHALL fully define the identifier, the syntax, and the semantics of each attribute within that namespace. An attribute namespace SHALL have an identifier that is unique within the scope of the EUDI Wallet ecosystem, and each attribute identifier SHALL be unique within that namespace. *Note: In ISO/IEC 18013-5, namespaces are discussed and a method for generating unique namespace identifiers is recommended.* |
-| ARB_06b | For [SD-JWT VC]-compliant attestations, the Scheme Provider for the Attestation Rulebook SHALL ensure that each claim name is either: - included in the IANA registry for JWT claims, - is a Public Name as defined in [RFC 7519], or is a Private Name specific to the attestation type. *Note: [SD-JWT VC] does not discuss how to avoid conflicting claim names. Since SD-JWTs are a special kind of JWTs, the methods specified in RFC 7519 are applicable.* |
-| ARB_07 | When determining the attributes to be included in a new attestation type, the Scheme Provider for the applicable Attestation Rulebook SHOULD consider referring to attributes that are already included in the catalogue of attributes specified in [Topic 25](./annex-2.02-high-level-requirements-by-topic.md#a2315-topic-25-unified-definition-and-controlled-vocabularies-for-attributes) or specified in an attestation scheme included in the catalogue of attestation schemes specified in [Commission Implementing Regulation 2025/1569](http://data.europa.eu/eli/reg_impl/2025/1569/oj), rather than unnecessarily re-defining all attributes. |
-| ARB_08 | The Scheme Provider for an Attestation Rulebook SHOULD, when specifying a new attribute, take into consideration existing conventions for attribute identifier values and attribute syntaxes. *Note: These conventions may depend on the format of the attestation, i.e., CBOR for ISO/IEC 18013-5-compliant attestations or JSON for SD-JWT VC-compliant attestations.* |
-| ARB_09 | The Scheme Provider for an Attestation Rulebook SHALL specify, for each attribute in the attestation, whether the presence of that attribute is mandatory, optional, or conditional. |
-| ARB_10 | The Scheme Provider for an Attestation Rulebook for an ISO/IEC 18013-5 compliant attestation MAY define a domestic namespace to specify attributes that are specific to that Rulebook and are not included in the applicable EU-wide or sectoral namespace. All requirements for namespaces in this Topic SHALL also apply for domestic namespaces. |
-| ARB_11 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook an attribute as meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point a) and [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point a) of the [European Digital Identity Regulation]. This attribute SHALL reference the technical specification meant in ARB_25. |
-| ARB_12 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include an attribute in the Rulebook indicating that the attestation is an EAA. This attribute SHALL reference the technical specification meant in ARB_25. |
-| ARB_13 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point b) of the [European Digital Identity Regulation]. |
-| ARB_14 | The Scheme Provider for an attestation Rulebook describing a type of attestation that is a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point b) of the [European Digital Identity Regulation]. |
-| ARB_15 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point b) of the [European Digital Identity Regulation]. |
-| ARB_16 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point c) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e46-55-1) point c) of the [European Digital Identity Regulation]. |
-| ARB_17 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point c) of the [European Digital Identity Regulation]. |
-| ARB_18 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point e) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point e) of the [European Digital Identity Regulation]. |
-| ARB_19 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point e) of the [European Digital Identity Regulation]. |
-| ARB_20 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the location meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point h) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point h) of the [European Digital Identity Regulation]. This location SHALL indicate at least the URL at which a machine-readable version of the trust anchor to be used for verifying the QEAA or PuB-EAA can be found or looked up. |
-| ARB_21 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes or metadata representing the location at which a machine-readable version of the trust anchor to be used for verifying the EAA can be found or looked up. *Note: What this location indicates precisely is dependent on the nature of the mechanism used for distributing trust anchors - see requirement ARB_26.* |
+<div class="eudi-hlr" id="ARB_06" markdown>
+<div class="eudi-hlr__id">ARB_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook SHALL define all attributes that an attestation of that type may contain. This definition SHALL first describe the semantics of each attribute in an encoding-independent manner and SHALL subsequently for each attribute specify an ISO/IEC 18013-5-compliant format, an SD-JWT VC-compliant format, or both, as needed given the choices made according to ARB_01 - ARB_04.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_06a" markdown>
+<div class="eudi-hlr__id">ARB_06a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For ISO/IEC 18013-5-compliant attestations, the Attestation Rulebook SHALL define each attribute within an attribute namespace. An attribute namespace SHALL fully define the identifier, the syntax, and the semantics of each attribute within that namespace. An attribute namespace SHALL have an identifier that is unique within the scope of the EUDI Wallet ecosystem, and each attribute identifier SHALL be unique within that namespace.
+
+*Note: In ISO/IEC 18013-5, namespaces are discussed and a method for generating unique namespace identifiers is recommended.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_06b" markdown>
+<div class="eudi-hlr__id">ARB_06b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For [SD-JWT VC]-compliant attestations, the Scheme Provider for the Attestation Rulebook SHALL ensure that each claim name is either: - included in the IANA registry for JWT claims, - is a Public Name as defined in [RFC 7519], or is a Private Name specific to the attestation type.
+
+*Note: [SD-JWT VC] does not discuss how to avoid conflicting claim names. Since SD-JWTs are a special kind of JWTs, the methods specified in RFC 7519 are applicable.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_07" markdown>
+<div class="eudi-hlr__id">ARB_07<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When determining the attributes to be included in a new attestation type, the Scheme Provider for the applicable Attestation Rulebook SHOULD consider referring to attributes that are already included in the catalogue of attributes specified in [Topic 25](./annex-2.02-high-level-requirements-by-topic.md#a2315-topic-25-unified-definition-and-controlled-vocabularies-for-attributes) or specified in an attestation scheme included in the catalogue of attestation schemes specified in [Commission Implementing Regulation 2025/1569](http://data.europa.eu/eli/reg_impl/2025/1569/oj), rather than unnecessarily re-defining all attributes.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_08" markdown>
+<div class="eudi-hlr__id">ARB_08<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook SHOULD, when specifying a new attribute, take into consideration existing conventions for attribute identifier values and attribute syntaxes.
+
+*Note: These conventions may depend on the format of the attestation, i.e., CBOR for ISO/IEC 18013-5-compliant attestations or JSON for SD-JWT VC-compliant attestations.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_09" markdown>
+<div class="eudi-hlr__id">ARB_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook SHALL specify, for each attribute in the attestation, whether the presence of that attribute is mandatory, optional, or conditional.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_10" markdown>
+<div class="eudi-hlr__id">ARB_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook for an ISO/IEC 18013-5 compliant attestation MAY define a domestic namespace to specify attributes that are specific to that Rulebook and are not included in the applicable EU-wide or sectoral namespace. All requirements for namespaces in this Topic SHALL also apply for domestic namespaces.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_11" markdown>
+<div class="eudi-hlr__id">ARB_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook an attribute as meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point a) and [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point a) of the [European Digital Identity Regulation]. This attribute SHALL reference the technical specification meant in ARB_25.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_12" markdown>
+<div class="eudi-hlr__id">ARB_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include an attribute in the Rulebook indicating that the attestation is an EAA. This attribute SHALL reference the technical specification meant in ARB_25.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_13" markdown>
+<div class="eudi-hlr__id">ARB_13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point b) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_14" markdown>
+<div class="eudi-hlr__id">ARB_14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an attestation Rulebook describing a type of attestation that is a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point b) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_15" markdown>
+<div class="eudi-hlr__id">ARB_15<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point b) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_16" markdown>
+<div class="eudi-hlr__id">ARB_16<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point c) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e46-55-1) point c) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_17" markdown>
+<div class="eudi-hlr__id">ARB_17<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point c) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_18" markdown>
+<div class="eudi-hlr__id">ARB_18<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point e) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point e) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_19" markdown>
+<div class="eudi-hlr__id">ARB_19<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point e) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_20" markdown>
+<div class="eudi-hlr__id">ARB_20<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the location meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point h) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point h) of the [European Digital Identity Regulation]. This location SHALL indicate at least the URL at which a machine-readable version of the trust anchor to be used for verifying the QEAA or PuB-EAA can be found or looked up.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_21" markdown>
+<div class="eudi-hlr__id">ARB_21<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes or metadata representing the location at which a machine-readable version of the trust anchor to be used for verifying the EAA can be found or looked up.
+
+*Note: What this location indicates precisely is dependent on the nature of the mechanism used for distributing trust anchors - see requirement ARB_26.*
+
+</div>
+</div>
+
 
 ##### D. Miscellaneous requirements <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ARB_22 | The Scheme Provider for an Attestation Rulebook SHALL specify all technical details necessary to ensure interoperability, security, and privacy of that attestation. *Note: An Attestation Rulebook may also specify requirements regarding how the Wallet Unit must display the attestation and the attributes in it to the User.* |
-| ARB_23 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL specify which of the revocation mechanisms specified in [Topic 7](./annex-2.02-high-level-requirements-by-topic.md#a235-topic-7-attestation-revocation-and-revocation-checking) SHALL be supported by that attestation. |
-| ARB_24 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHALL specify whether that type of EAA must be revocable. If an EAA type must be revocable, the relevant Rulebook SHALL determine which of the revocation mechanisms specified in [Topic 7](./annex-2.02-high-level-requirements-by-topic.md#a235-topic-7-attestation-revocation-and-revocation-checking) SHALL be supported by that attestation. |
-| ARB_25 | An Attribute Schema Provider SHALL include in its Attestation Rulebook the attribute ``attestation_legal_category``, specified in the [Attestation Rulebook Template](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/template/attestation-rulebook-template.md), with the appropriate value as specified in the Template. *Note: This attribute contains the indication meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point a) and [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point a).* |
-| ARB_26 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD define in the Rulebook the mechanism(s) allowing a Relying Party to obtain, in a trustworthy manner, the trust anchor(s) of the EAA Providers issuing this type of EAA. *Note: [Technical Specification 11](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts11-interfaces-and-formats-for-catalogue-of-attributes-and-catalogue-of-schemes.md), section 4.3.1, recommends the use of the List of trusted entities (LoTE) data model as defined in [ETSI TS 119 602](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/issues/278) for non-qualified EAAs.* |
-| ARB_27 | Empty |
-| ARB_28 | An Attribute Scheme Provider MAY specify an attribute in an Attestation Rulebook that indicates whether the Attestation Provider during attestation issuance requested a cryptographic binding (as specified in [Topic 18](./annex-2.02-high-level-requirements-by-topic.md#a2311-topic-18-combined-presentations-of-attributes)) between the new attestation and an existing PID or attestation. If present in a Rulebook, the identifier for this attribute SHALL be ``cryptographically_bound_to``, and its contents SHALL be an attestation type or vct (see ARB_05). *Note: The meaning of this attribute, if present, is that this attestation is cryptographically bound to one or more attestations of the given attestation type or vct on this Wallet Unit. If a Relying Party receives this attribute from a Wallet Unit, it can subsequently request the Wallet Unit to send a proof of cryptographic binding between the attestation and an attestation indicated in the ``cryptographically_bound_to`` attribute.* |
-| ARB_29 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA, PuB-EAA, or non-qualified EAA SHOULD ensure that the structure and contents of the Attestation Rulebook follow the descriptions in the [Attestation Rulebook template](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/template/attestation-rulebook-template.md). |
-| ARB_30 | If an Attestation Rulebook specifies a [SD-JWT VC]-compliant attestation, the Scheme Provider for that Attestation Rulebook SHALL specify for all claims (i.e., all top-level properties, all nested properties, and all array entries) whether an Attestation Provider MUST, MAY, or MUST NOT make that claim selectively disclosable. *Note: a) This requirement does not apply to claims defined as non-selectively disclosable in [SD-JWT VC]. b) There will be use cases where a specific claim must not be disclosed without simultaneously disclosing one or more other claims. Such cases should be solved by making all of these claims members of the same JSON object (or elements of the same JSON array). That JSON object (or array) is then the claim that must be selectively disclosable, while the nested properties (or individual array elements) must not be selectively disclosable. c) This requirement does not apply to [ISO/IEC 18013-5]-compliant attestations, since in such attestations, by definition all data elements are selectively disclosable, while none of the key-value pairs or array elements inside a data element (if any) are selectively disclosable.* |
-| ARB_31 | If an Attestation Rulebook specifies a [SD-JWT VC]-compliant attestation, the Scheme Provider for that Attestation Rulebook SHOULD consider defining a Type Metadata Document for it, as defined in Chapter 6 of [SD-JWT VC]. If the Scheme Provider defines such a document, it SHOULD contain the Claim Selective Disclosure Metadata (defined in Section 9.3 of [SD-JWT VC]) for each of the claims, in order to specify if that claim is selectively disclosable (see requirement ARB_30). *Note: Although a Type Metadata Document is a highly technical document, defining it has a number of advantages for developers, Attestation Providers, Relying Parties, and Wallet Units, as spelled out in Chapter 6 of [SD-JWT VC].* |
-| ARB_32 | Empty |
-| ARB_33 | If a Scheme Provider for an Attestation Rulebook registers an attestation scheme in the catalogue of attestation schemes meant in [Commission Implementing Regulation 2025/1569](http://data.europa.eu/eli/reg_impl/2025/1569/oj), Article 8, the registration SHALL include a reference to the corresponding Attestation Rulebook. *Note: By definition, an attestation scheme is machine-readable, whereas an Attestation Rulebook is human-readable.* |
-| ARB_34 | The Scheme Provider for an Attestation Rulebook SHALL specify whether that attestation is device-bound or not. |
+<div class="eudi-hlr" id="ARB_22" markdown>
+<div class="eudi-hlr__id">ARB_22<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook SHALL specify all technical details necessary to ensure interoperability, security, and privacy of that attestation.
+
+*Note: An Attestation Rulebook may also specify requirements regarding how the Wallet Unit must display the attestation and the attributes in it to the User.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_23" markdown>
+<div class="eudi-hlr__id">ARB_23<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL specify which of the revocation mechanisms specified in [Topic 7](./annex-2.02-high-level-requirements-by-topic.md#a235-topic-7-attestation-revocation-and-revocation-checking) SHALL be supported by that attestation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_24" markdown>
+<div class="eudi-hlr__id">ARB_24<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHALL specify whether that type of EAA must be revocable. If an EAA type must be revocable, the relevant Rulebook SHALL determine which of the revocation mechanisms specified in [Topic 7](./annex-2.02-high-level-requirements-by-topic.md#a235-topic-7-attestation-revocation-and-revocation-checking) SHALL be supported by that attestation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_25" markdown>
+<div class="eudi-hlr__id">ARB_25<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attribute Schema Provider SHALL include in its Attestation Rulebook the attribute ``attestation_legal_category``, specified in the [Attestation Rulebook Template](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/template/attestation-rulebook-template.md), with the appropriate value as specified in the Template.
+
+*Note: This attribute contains the indication meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point a) and [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point a).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_26" markdown>
+<div class="eudi-hlr__id">ARB_26<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD define in the Rulebook the mechanism(s) allowing a Relying Party to obtain, in a trustworthy manner, the trust anchor(s) of the EAA Providers issuing this type of EAA.
+
+*Note: [Technical Specification 11](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts11-interfaces-and-formats-for-catalogue-of-attributes-and-catalogue-of-schemes.md), section 4.3.1, recommends the use of the List of trusted entities (LoTE) data model as defined in [ETSI TS 119 602](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/issues/278) for non-qualified EAAs.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_27" markdown>
+<div class="eudi-hlr__id">ARB_27</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_28" markdown>
+<div class="eudi-hlr__id">ARB_28<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attribute Scheme Provider MAY specify an attribute in an Attestation Rulebook that indicates whether the Attestation Provider during attestation issuance requested a cryptographic binding (as specified in [Topic 18](./annex-2.02-high-level-requirements-by-topic.md#a2311-topic-18-combined-presentations-of-attributes)) between the new attestation and an existing PID or attestation. If present in a Rulebook, the identifier for this attribute SHALL be ``cryptographically_bound_to``, and its contents SHALL be an attestation type or vct (see ARB_05).
+
+*Note: The meaning of this attribute, if present, is that this attestation is cryptographically bound to one or more attestations of the given attestation type or vct on this Wallet Unit. If a Relying Party receives this attribute from a Wallet Unit, it can subsequently request the Wallet Unit to send a proof of cryptographic binding between the attestation and an attestation indicated in the ``cryptographically_bound_to`` attribute.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_29" markdown>
+<div class="eudi-hlr__id">ARB_29<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA, PuB-EAA, or non-qualified EAA SHOULD ensure that the structure and contents of the Attestation Rulebook follow the descriptions in the [Attestation Rulebook template](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/template/attestation-rulebook-template.md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_30" markdown>
+<div class="eudi-hlr__id">ARB_30<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If an Attestation Rulebook specifies a [SD-JWT VC]-compliant attestation, the Scheme Provider for that Attestation Rulebook SHALL specify for all claims (i.e., all top-level properties, all nested properties, and all array entries) whether an Attestation Provider MUST, MAY, or MUST NOT make that claim selectively disclosable.
+
+*Note: a) This requirement does not apply to claims defined as non-selectively disclosable in [SD-JWT VC]. b) There will be use cases where a specific claim must not be disclosed without simultaneously disclosing one or more other claims. Such cases should be solved by making all of these claims members of the same JSON object (or elements of the same JSON array). That JSON object (or array) is then the claim that must be selectively disclosable, while the nested properties (or individual array elements) must not be selectively disclosable. c) This requirement does not apply to [ISO/IEC 18013-5]-compliant attestations, since in such attestations, by definition all data elements are selectively disclosable, while none of the key-value pairs or array elements inside a data element (if any) are selectively disclosable.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_31" markdown>
+<div class="eudi-hlr__id">ARB_31<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If an Attestation Rulebook specifies a [SD-JWT VC]-compliant attestation, the Scheme Provider for that Attestation Rulebook SHOULD consider defining a Type Metadata Document for it, as defined in Chapter 6 of [SD-JWT VC]. If the Scheme Provider defines such a document, it SHOULD contain the Claim Selective Disclosure Metadata (defined in Section 9.3 of [SD-JWT VC]) for each of the claims, in order to specify if that claim is selectively disclosable (see requirement ARB_30).
+
+*Note: Although a Type Metadata Document is a highly technical document, defining it has a number of advantages for developers, Attestation Providers, Relying Parties, and Wallet Units, as spelled out in Chapter 6 of [SD-JWT VC].*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_32" markdown>
+<div class="eudi-hlr__id">ARB_32</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_33" markdown>
+<div class="eudi-hlr__id">ARB_33<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Scheme Provider for an Attestation Rulebook registers an attestation scheme in the catalogue of attestation schemes meant in [Commission Implementing Regulation 2025/1569](http://data.europa.eu/eli/reg_impl/2025/1569/oj), Article 8, the registration SHALL include a reference to the corresponding Attestation Rulebook.
+
+*Note: By definition, an attestation scheme is machine-readable, whereas an Attestation Rulebook is human-readable.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ARB_34" markdown>
+<div class="eudi-hlr__id">ARB_34<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Scheme Provider for an Attestation Rulebook SHALL specify whether that attestation is device-bound or not.
+
+</div>
+</div>
+
 
 #### A.2.3.10 Topic 16 - Signing documents with a Wallet Unit
 
 ##### A. Requirement for Wallet Providers <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| QES_01 | Wallet Providers SHALL ensure that each User has the possibility to receive a qualified certificate for Qualified Electronic Signatures, bound to a QSCD, that is either local, external, or remotely managed in relation to the Wallet Instance. |
-| QES_02 | Wallet Providers SHALL ensure that each User who is a natural person has, at least for non-professional purposes, free-of-charge access to a Signature Creation Application which allows the creation of free-of-charge Qualified Electronic Signatures using the certificates referred to in QES_01. Wallet Providers SHALL ensure that: - The Signature Creation Application SHALL, as a minimum, be capable of signing or sealing User-provided data and Relying Party-provided data. - The Signature Creation Application SHALL be implemented as part of a Wallet Solution or external to it (by providers of trust services or by Relying Parties). - The Signature Creation Application SHALL be able to generate signatures or seals in formats compliant with at least the mandatory formats referred to in QES_08. *Note: a) Signature Creation Application (SCA): see definition in [ETSI TS 119 432]. 2) If the SCA is external to the Wallet Solution, it may be for example a separate mobile application, or be hosted remotely, for instance by the QTSP or by a Relying Party.* |
-| QES_03 | For the use of the qualified certificate referred to in QES_01, Wallet Providers SHALL ensure that a Wallet Unit implements secure authentication of the User, as well as signature or seal invocation capabilities, as a part of a local, external or remote QSCD. |
-| QES_04 | Wallet Providers SHALL enable their Wallet Units to interface with QSCDs using protocols and interfaces necessary for the implementation of secure User authentication and signature or seal functionality. *Note: In a Relying Party-centric flow, the remote QTSP will likely be selected by the Relying Party, which implies the QSCD is managed by the remote QTSP. In a Wallet Unit-driven flow, the User should be able to choose the QSCD.* |
-| QES_05 | Wallet Providers SHALL enable their Wallet Units to be used for User enrolment to a remote QES Provider (i.e., a QTSP offering remote QES), except where the Wallet Unit interfaces with local or external QSCDs. |
-| QES_06 | Wallet Providers SHALL ensure that their Wallet Solution supports at least one of the following options for remote QES signature creation: - remote QES creation through secure authentication to a QTSP signature web portal, - remote QES creation channelled by the Wallet Unit, - remote QES creation channelled by a Relying Party. |
-| QES_07 | Wallet Providers SHALL ensure that, where a Signature Creation Application relies on a remote Qualified Signature Creation Device and where it is integrated into a Wallet Unit, it supports the Cloud Signature Consortium API Specification 2.0 [CSC API]. |
-| QES_08 | Wallet Providers SHALL ensure that their Wallet Units are able to create signatures or seals in accordance with the mandatory PAdES format as specified in [ETSI EN 319 142-1[ V1.1.1 (2016-04). In addition, Wallet Providers SHOULD ensure that their Wallet Units are able to create signatures or seals in accordance with the following formats: - XAdES as specified in [ETSI EN 319 132-1] V1.2.1 (2022-02), - JAdES as specified in [ETSI TS 119 182-1] V1.2.1 (2024-07), - CAdES as specified in [ETSI EN 319 122-1] V1.3.1 (2023-06), and - ASiC as specified in [ETSI EN 319 162-1] V1.1.1 (2016-04) and [ETSI EN 319 162-2] V1.1.1 (2016-04). |
-| QES_09 | Empty |
-| QES_10 | Wallet Providers SHALL ensure that, where the Signature Creation Application is implemented as part of the Wallet Unit and is used to generate signatures or seals of the representation of the document or data to be signed or sealed, the Wallet Unit presents the representation of the document or data to be signed or sealed to the User. |
-| QES_11 | Where the Signature Creation Application is implemented as part of the Wallet Unit, a Wallet Unit SHALL compute the hash or digest of the document or data to be signed through its Signature Create Application component. |
-| QES_12 | A Wallet Unit SHALL be able to create a signature over a document or data to be signed, either by using a local QSCD or by interfacing with a remote QES Provider. *Note: a local signing application is on-device. It may either be embedded in the Wallet Unit or be an external application.* |
-| QES_13 | A Wallet Unit SHALL provide a log of transactions related to qualified electronic signatures or seals generated by or through the Wallet Unit, allowing the User to view the history of previously signed data or documents, according to requirement DASH_04 in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency). *Note: If the signature is generated by a remote Signature Creation Application, the Wallet is at minimum used to authenticate the User to the remote QTSP and to obtain the User's consent for the usage of the private signing key. The logs then record information about these processes.* |
-| QES_14 | A Wallet Unit SHALL enable the User to explicitly authorise the creation of a qualified electronic signature or seal through their Wallet Unit. |
-| QES_15 | In remote signature creation scenarios, a Wallet Unit SHALL verify that the qualified electronic signature or seal creation device is part of a qualified service, which is carried out by a qualified trust service provider. |
-| QES_16 | A Wallet Unit SHOULD support multiple-signing scenarios, where multiple signatories are required to sign the same document or data. |
-| QES_17 | A Wallet Unit SHALL provide a signature creation confirmation upon the creation of a qualified electronic signature, informing the User about the outcome of the signature creation process. *Note: See also QES_17a.* |
-| QES_17a | If the Signature Creation Application is external to the Wallet Unit, after the User authorises the usage of the private signing key, the Signature Creation Application SHALL return the outcome of the signature creation process to the Wallet Unit. |
-| QES_18 | Wallet Providers SHALL configure at least one default qualified signing service in the Wallet Unit. |
-| QES_19 | Wallet Providers SHALL ensure that, where the Signature Creation Application is implemented as part of the Wallet Unit, a Wallet Unit supports [ETSI TS 119 101] when using signing keys managed by the QSCD, whether locally, externally, or remotely in relation to the Wallet Instance. |
-| QES_20 | Empty |
-| QES_21 | Empty |
-| QES_22 | Empty |
+<div class="eudi-hlr" id="QES_01" markdown>
+<div class="eudi-hlr__id">QES_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that each User has the possibility to receive a qualified certificate for Qualified Electronic Signatures, bound to a QSCD, that is either local, external, or remotely managed in relation to the Wallet Instance.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_02" markdown>
+<div class="eudi-hlr__id">QES_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that each User who is a natural person has, at least for non-professional purposes, free-of-charge access to a Signature Creation Application which allows the creation of free-of-charge Qualified Electronic Signatures using the certificates referred to in QES_01. Wallet Providers SHALL ensure that: - The Signature Creation Application SHALL, as a minimum, be capable of signing or sealing User-provided data and Relying Party-provided data. - The Signature Creation Application SHALL be implemented as part of a Wallet Solution or external to it (by providers of trust services or by Relying Parties). - The Signature Creation Application SHALL be able to generate signatures or seals in formats compliant with at least the mandatory formats referred to in QES_08.
+
+*Note: a) Signature Creation Application (SCA): see definition in [ETSI TS 119 432]. 2) If the SCA is external to the Wallet Solution, it may be for example a separate mobile application, or be hosted remotely, for instance by the QTSP or by a Relying Party.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_03" markdown>
+<div class="eudi-hlr__id">QES_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the use of the qualified certificate referred to in QES_01, Wallet Providers SHALL ensure that a Wallet Unit implements secure authentication of the User, as well as signature or seal invocation capabilities, as a part of a local, external or remote QSCD.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_04" markdown>
+<div class="eudi-hlr__id">QES_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL enable their Wallet Units to interface with QSCDs using protocols and interfaces necessary for the implementation of secure User authentication and signature or seal functionality.
+
+*Note: In a Relying Party-centric flow, the remote QTSP will likely be selected by the Relying Party, which implies the QSCD is managed by the remote QTSP. In a Wallet Unit-driven flow, the User should be able to choose the QSCD.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_05" markdown>
+<div class="eudi-hlr__id">QES_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL enable their Wallet Units to be used for User enrolment to a remote QES Provider (i.e., a QTSP offering remote QES), except where the Wallet Unit interfaces with local or external QSCDs.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_06" markdown>
+<div class="eudi-hlr__id">QES_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that their Wallet Solution supports at least one of the following options for remote QES signature creation: - remote QES creation through secure authentication to a QTSP signature web portal, - remote QES creation channelled by the Wallet Unit, - remote QES creation channelled by a Relying Party.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_07" markdown>
+<div class="eudi-hlr__id">QES_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that, where a Signature Creation Application relies on a remote Qualified Signature Creation Device and where it is integrated into a Wallet Unit, it supports the Cloud Signature Consortium API Specification 2.0 [CSC API].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_08" markdown>
+<div class="eudi-hlr__id">QES_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that their Wallet Units are able to create signatures or seals in accordance with the mandatory PAdES format as specified in [ETSI EN 319 142-1[ V1.1.1 (2016-04). In addition, Wallet Providers SHOULD ensure that their Wallet Units are able to create signatures or seals in accordance with the following formats: - XAdES as specified in [ETSI EN 319 132-1] V1.2.1 (2022-02), - JAdES as specified in [ETSI TS 119 182-1] V1.2.1 (2024-07), - CAdES as specified in [ETSI EN 319 122-1] V1.3.1 (2023-06), and - ASiC as specified in [ETSI EN 319 162-1] V1.1.1 (2016-04) and [ETSI EN 319 162-2] V1.1.1 (2016-04).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_09" markdown>
+<div class="eudi-hlr__id">QES_09</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_10" markdown>
+<div class="eudi-hlr__id">QES_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that, where the Signature Creation Application is implemented as part of the Wallet Unit and is used to generate signatures or seals of the representation of the document or data to be signed or sealed, the Wallet Unit presents the representation of the document or data to be signed or sealed to the User.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_11" markdown>
+<div class="eudi-hlr__id">QES_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Where the Signature Creation Application is implemented as part of the Wallet Unit, a Wallet Unit SHALL compute the hash or digest of the document or data to be signed through its Signature Create Application component.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_12" markdown>
+<div class="eudi-hlr__id">QES_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL be able to create a signature over a document or data to be signed, either by using a local QSCD or by interfacing with a remote QES Provider.
+
+*Note: a local signing application is on-device. It may either be embedded in the Wallet Unit or be an external application.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_13" markdown>
+<div class="eudi-hlr__id">QES_13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL provide a log of transactions related to qualified electronic signatures or seals generated by or through the Wallet Unit, allowing the User to view the history of previously signed data or documents, according to requirement DASH_04 in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+*Note: If the signature is generated by a remote Signature Creation Application, the Wallet is at minimum used to authenticate the User to the remote QTSP and to obtain the User's consent for the usage of the private signing key. The logs then record information about these processes.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_14" markdown>
+<div class="eudi-hlr__id">QES_14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL enable the User to explicitly authorise the creation of a qualified electronic signature or seal through their Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_15" markdown>
+<div class="eudi-hlr__id">QES_15<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+In remote signature creation scenarios, a Wallet Unit SHALL verify that the qualified electronic signature or seal creation device is part of a qualified service, which is carried out by a qualified trust service provider.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_16" markdown>
+<div class="eudi-hlr__id">QES_16<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHOULD support multiple-signing scenarios, where multiple signatories are required to sign the same document or data.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_17" markdown>
+<div class="eudi-hlr__id">QES_17<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL provide a signature creation confirmation upon the creation of a qualified electronic signature, informing the User about the outcome of the signature creation process.
+
+*Note: See also QES_17a.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_17a" markdown>
+<div class="eudi-hlr__id">QES_17a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the Signature Creation Application is external to the Wallet Unit, after the User authorises the usage of the private signing key, the Signature Creation Application SHALL return the outcome of the signature creation process to the Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_18" markdown>
+<div class="eudi-hlr__id">QES_18<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL configure at least one default qualified signing service in the Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_19" markdown>
+<div class="eudi-hlr__id">QES_19<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that, where the Signature Creation Application is implemented as part of the Wallet Unit, a Wallet Unit supports [ETSI TS 119 101] when using signing keys managed by the QSCD, whether locally, externally, or remotely in relation to the Wallet Instance.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_20" markdown>
+<div class="eudi-hlr__id">QES_20</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_21" markdown>
+<div class="eudi-hlr__id">QES_21</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_22" markdown>
+<div class="eudi-hlr__id">QES_22</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 ##### B. Requirements for QTSPs <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| QES_23 | QTSPs providing the remote QES part of a Wallet Solution SHALL support: 1. [ETSI TS 119 431-1] , 2. [ETSI TS 119 431-2] , 3. [ETSI TS 119 432]. Wallet Providers and QTSPs providing the remote QES part of a Wallet Solution SHALL comply with Sole Control Assurance Level (SCAL) 2 as defined in [CEN EN 419 241-1] . |
-| QES_24 | QTSPs providing the Signature Creation Application as part of the remote QES part of a Wallet Solution SHALL support [ETSI TS 119 101]. |
+<div class="eudi-hlr" id="QES_23" markdown>
+<div class="eudi-hlr__id">QES_23<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+QTSPs providing the remote QES part of a Wallet Solution SHALL support: 1. [ETSI TS 119 431-1] , 2. [ETSI TS 119 431-2] , 3. [ETSI TS 119 432]. Wallet Providers and QTSPs providing the remote QES part of a Wallet Solution SHALL comply with Sole Control Assurance Level (SCAL) 2 as defined in [CEN EN 419 241-1] .
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_24" markdown>
+<div class="eudi-hlr__id">QES_24<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+QTSPs providing the Signature Creation Application as part of the remote QES part of a Wallet Solution SHALL support [ETSI TS 119 101].
+
+</div>
+</div>
+
 
 ##### C. Requirements for Relying Parties <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| QES_24a | Relying Parties providing the Signature Creation Application in a Relying Party-centric flow SHALL support [ETSI TS 119 101]. |
+<div class="eudi-hlr" id="QES_24a" markdown>
+<div class="eudi-hlr__id">QES_24a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Relying Parties providing the Signature Creation Application in a Relying Party-centric flow SHALL support [ETSI TS 119 101].
+
+</div>
+</div>
+
 
 ##### D. Requirements for the Commission <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| QES_25 | Empty |
-| QES_26 | Empty |
+<div class="eudi-hlr" id="QES_25" markdown>
+<div class="eudi-hlr__id">QES_25</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QES_26" markdown>
+<div class="eudi-hlr__id">QES_26</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 #### A.2.3.11 Topic 18 - Combined presentations of attributes
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ACP_01 | A Cryptographic Binding of Attestations scheme SHALL enable a WSCA/WSCD or keystore to prove that it manages two or more private keys, paired with two or more public keys provided to it by the Wallet Unit. *Note: a)These public keys may be included in WIAs and KAs, PIDs, attestations, or pseudonyms. b) The proof may be transitive, so a proof that two keys are stored/managed in the same WSCA/WSCD or keystore may be done by proving these keys relate to each other via a third key (also stored in the WSCA/WSCD or keystore).* |
-| ACP_02 | A Cryptographic Binding of Attestations scheme SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0]. |
-| ACP_03 | A Cryptographic Binding of Attestations scheme SHOULD be implemented using a Zero-Knowledge Proof mechanism that satisfies the requirements specified in [Topic 53](./annex-2.02-high-level-requirements-by-topic.md#a2331-topic-53-zero-knowledge-proofs). |
-| ACP_04 | A Cryptographic Binding of Attestations scheme SHALL be compatible with the requirements for attestation issuance in this document, in particular [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), as well as with requirements for both remote and proximity presentation flows in this document, in particular [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit) and [Topic 24](./annex-2.02-high-level-requirements-by-topic.md#a2314-topic-24-user-identification-in-proximity-scenarios). |
-| ACP_05 | A Cryptographic Binding of Attestations scheme SHALL enable an Attestation Provider, during the issuance of an attestation, to request and obtain proof that the private key for the new attestation is managed by the same WSCA/WSCD or keystore as the private key of a PID or another attestation already existing on the Wallet Unit. *Note: ACP_05 and ACP_06 may require an addition to the common OpenID4VCI protocol referenced in requirement ISSU_01, or an extension or profile thereof.* |
-| ACP_06 | Empty |
-| ACP_07 | Before making a request according to ACP_05, an Attestation Provider SHALL verify that the new attestation indeed belongs to the User of the existing PID or attestation. |
+<div class="eudi-hlr" id="ACP_01" markdown>
+<div class="eudi-hlr__id">ACP_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Cryptographic Binding of Attestations scheme SHALL enable a WSCA/WSCD or keystore to prove that it manages two or more private keys, paired with two or more public keys provided to it by the Wallet Unit.
+
+*Note: a)These public keys may be included in WIAs and KAs, PIDs, attestations, or pseudonyms. b) The proof may be transitive, so a proof that two keys are stored/managed in the same WSCA/WSCD or keystore may be done by proving these keys relate to each other via a third key (also stored in the WSCA/WSCD or keystore).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ACP_02" markdown>
+<div class="eudi-hlr__id">ACP_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Cryptographic Binding of Attestations scheme SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ACP_03" markdown>
+<div class="eudi-hlr__id">ACP_03<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Cryptographic Binding of Attestations scheme SHOULD be implemented using a Zero-Knowledge Proof mechanism that satisfies the requirements specified in [Topic 53](./annex-2.02-high-level-requirements-by-topic.md#a2331-topic-53-zero-knowledge-proofs).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ACP_04" markdown>
+<div class="eudi-hlr__id">ACP_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Cryptographic Binding of Attestations scheme SHALL be compatible with the requirements for attestation issuance in this document, in particular [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), as well as with requirements for both remote and proximity presentation flows in this document, in particular [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit) and [Topic 24](./annex-2.02-high-level-requirements-by-topic.md#a2314-topic-24-user-identification-in-proximity-scenarios).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ACP_05" markdown>
+<div class="eudi-hlr__id">ACP_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Cryptographic Binding of Attestations scheme SHALL enable an Attestation Provider, during the issuance of an attestation, to request and obtain proof that the private key for the new attestation is managed by the same WSCA/WSCD or keystore as the private key of a PID or another attestation already existing on the Wallet Unit.
+
+*Note: ACP_05 and ACP_06 may require an addition to the common OpenID4VCI protocol referenced in requirement ISSU_01, or an extension or profile thereof.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ACP_06" markdown>
+<div class="eudi-hlr__id">ACP_06</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ACP_07" markdown>
+<div class="eudi-hlr__id">ACP_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before making a request according to ACP_05, an Attestation Provider SHALL verify that the new attestation indeed belongs to the User of the existing PID or attestation.
+
+</div>
+</div>
+
 
 #### A.2.3.12 Topic 19 - User navigation requirements (Dashboard logs for transparency)
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| DASH_01 | A Wallet Unit SHALL provide a user-friendly dashboard functionality to its User. |
-| DASH_02 | The Wallet Unit SHALL log all transactions executed through the Wallet Unit, including any transactions that were not completed successfully. This log SHALL include all types of transaction executed through the Wallet Unit: a) PID or attestation issuance and re-issuance transactions, b) PID or attestation presentation transactions, c) Wallet-to-Wallet transactions (see [Topic 30](./annex-2.02-high-level-requirements-by-topic.md#a2319-topic-30-interaction-between-wallet-units)), d) pseudonym registration or presentation transactions, e) signature or seal creation transactions (see [Topic 16](./annex-2.02-high-level-requirements-by-topic.md#a2310-topic-16-signing-documents-with-a-wallet-unit)), f) data deletion requests sent to a Relying Party (see [Topic 48](./annex-2.02-high-level-requirements-by-topic.md#a2327-topic-48-blueprint-for-requesting-data-deletion-to-relying-parties)), g) reports sent to a Data Protection Authority (see [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data)), h) PID or attestation deletions by the User. *Note: For the data to be logged for a data deletion request to a Relying Party or a report sent to a DPA, see Topic 48 and Topic 50, respectively. For other types of transaction, the data to be logged is specified in the requirements in this Topic.* |
-| DASH_02a | The Wallet Unit SHALL retain transactions in the log at least for the minimum retention period specified in applicable legislation. If the Wallet Unit must delete transactions from the log, for instance because of size limitations, the Wallet Unit SHALL notify the User via the dashboard before doing so, indicating the potential consequences for the User's data protection rights, and SHALL instruct the User how to export the transactions that are about to be deleted. See DASH_07. |
-| DASH_02b | The dashboard SHALL include a functionality to display to the User an overview of all transactions in the log. |
-| DASH_02c | The transaction log meant in DASH_02 SHALL comply with all relevant requirement in [Technical Specification 10](../../technical-specifications/ts10-data-portability-and-download-(export).md), including measures to ensure and/or verify its confidentiality, integrity, and authenticity. |
-| DASH_03 | For a PID or attestation presentation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the name and unique identifier of the corresponding Relying Party, and the Member State in which that Relying Party is established, c) the name, contact details (if available), and unique identifier of the intermediary, if an intermediary is involved in the transaction, d) the attestation type(s) and the identifier(s) of the attribute(s) that were requested, as well as those that were presented, e) in the case of non-completed transactions, the reason for such non-completion, f) the URL of the online service of the Relying Party's Registrar. g) the web form URL (if available), e-mail address (if available), and telephone number (if available) provided by the Relying Party for sending data deletion requests, see requirement RPRC_11 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), h) the name and country of the Data Protection Authority supervising the Relying Party, as well as the web form URL (if available), e-mail address (if available), and telephone number (if available) provided by this DPA for reporting suspicious attribute presentation requests. i) information on the intended use and the URL to the applicable privacy policy (if available). *Note: The information in points g), h), and i) may be retrieved from the registration certificate or from the Registrar's online service (see [Topic 44](../annex-2/annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)).* |
-| DASH_03a | For a PID or attestation presentation transaction or a Wallet-to-Wallet transaction executed through the Wallet Unit, the log SHALL NOT contain the value of any attributes presented to the Relying Party or the Verifier Wallet Unit. |
-| DASH_03b | For a Wallet-to-Wallet transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the role of the Wallet Unit (Holder Wallet Unit or Verifier Wallet Unit), c) the attestation type(s) and the identifier(s) of the attribute(s) that were requested, as well as those that were presented, d) in the case of non-completed transactions, the reason for such non-completion. |
-| DASH_03c | For a pseudonym registration or presentation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) identifying information about the Relying Party, if known to the Wallet Unit, c) whether it is a pseudonym registration or pseudonym presentation transaction, d) in the case of non-completed transactions, the reason for such non-completion. *Note: Regarding point b), see PA_20 in [Topic 11](./annex-2.02-high-level-requirements-by-topic.md#a238-topic-11-pseudonyms).* |
-| DASH_03d | If a presentation request contains transactional data, the Wallet Unit SHALL log the value of this transactional data only to the extent explicitly required by the applicable Technical Specification associated with the requested SUA attestation, and in accordance with data minimisation principles. If the applicable Technical Specification does not explicitly specify that transactional data shall be logged, the Wallet Unit SHALL NOT log the value of any transactional data. *Note: a) For the concepts of transactional data and SUA attestations and their related Technical Specifications, see [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments). b) For example, for PSD2 Strong Customer Authentication transactions, the scope of transactional data to be included in the transaction log is defined in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md) and includes the payment transaction identifier and merchant name.* |
-| DASH_04 | For a signature or seal creation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the document or data signed or sealed (if available to the Wallet Unit), c) in the case of non-completed transactions, the reason for such non-completion. |
-| DASH_05 | For a PID or attestation issuance or re-issuance transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the name, contact details (if available), and unique identifier of the corresponding PID Provider or Attestation Provider, c) the attestation type requested, as well as the attestation type issued, d) the number of attestations requested and issued (i.e., the size of the batch in case of batch issuance), e) in the case of non-completed transactions, the reason for such non-completion. f) for a re-issuance transaction, whether it was triggered by the User or by the Wallet Unit without involvement of the User, g) the URL of the associated Registrar's online service. *Note: Regarding point g): this URL can be retrieved from the access certificate.* |
-| DASH_05a | For the deletion of a PID or attestation by the User, the log SHALL contain at least: a) the date and time of the deletion event, b) the attestation type of the deleted PID or attestation. c) The name and unique identifier of the corresponding PID Provider or Attestation Provider. *Note: This requirement is not about deletion of transactions from the log, as per DASH_06a.* |
-| DASH_06 | The Wallet Provider SHALL ensure the confidentiality, integrity, and authenticity of all transactions included in the log. |
-| DASH_06a | Via the dashboard, the Wallet Unit SHALL enable the User to delete any transaction in the log. Before deleting any transactions, the Wallet Unit SHALL indicate to the User the potential consequences for the User's data protection rights. *Note: This requirement applies even in case the minimum retention period specified in applicable legislation (see DASH_02a) is not yet over.* |
-| DASH_06b | The Wallet Unit SHALL ensure that no entity other than the User can delete transactions from the log, except possibly for the reason mentioned in DASH_02a. |
-| DASH_07 | The dashboard SHALL allow the User to export the details of one or more transactions in the log to a file, using the common format specified according to DASH_02c, while ensuring their confidentiality, authenticity and integrity. The file SHALL be stored in an external storage or remote storage location of the User's choice, from among the storage options supported by the Wallet Unit and SHALL use the common format and security measures specified according to DASH_02c. |
-| DASH_08 | For a natural-person User, a Wallet Instance SHALL provide a User interface. |
-| DASH_09 | The User interface referred to in DASH_08 SHALL provide a view with - the EU Digital Identity Wallet Trust Mark, - accompanying general information on the certification of Wallet Solutions, - links to the certification status information as defined in the [Technical Specification 1](../../technical-specifications/ts1-eudi-wallet-trust-mark.md). |
-| DASH_09a | Positioning of the view meant in DASH_09 in the Wallet UI navigation SHALL follow design guidelines provided by the European Commission. |
-| DASH_09b | Wallet Providers and Wallet Units SHALL comply with all relevant requirements in [Technical Specification 1](../../technical-specifications/ts1-eudi-wallet-trust-mark.md) for the EUDI Wallet Trust Mark. |
-| DASH_10 | Empty. *Note: See requirement WIAM_12a in [Topic 40](./annex-2.02-high-level-requirements-by-topic.md#a2323-topic-40-wallet-instance-installation-and-wallet-unit-activation-and-management).* |
-| DASH_11 | Empty |
-| DASH_12 | The User interface referred to in DASH_08 SHALL enable the User, for each presentation transaction in the log, to easily request the Relying Party to delete any or all attributes presented to it in that transaction, or to send a report about that particular transaction to a DPA. |
+<div class="eudi-hlr" id="DASH_01" markdown>
+<div class="eudi-hlr__id">DASH_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL provide a user-friendly dashboard functionality to its User.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_02" markdown>
+<div class="eudi-hlr__id">DASH_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL log all transactions executed through the Wallet Unit, including any transactions that were not completed successfully. This log SHALL include all types of transaction executed through the Wallet Unit: a) PID or attestation issuance and re-issuance transactions, b) PID or attestation presentation transactions, c) Wallet-to-Wallet transactions (see [Topic 30](./annex-2.02-high-level-requirements-by-topic.md#a2319-topic-30-interaction-between-wallet-units)), d) pseudonym registration or presentation transactions, e) signature or seal creation transactions (see [Topic 16](./annex-2.02-high-level-requirements-by-topic.md#a2310-topic-16-signing-documents-with-a-wallet-unit)), f) data deletion requests sent to a Relying Party (see [Topic 48](./annex-2.02-high-level-requirements-by-topic.md#a2327-topic-48-blueprint-for-requesting-data-deletion-to-relying-parties)), g) reports sent to a Data Protection Authority (see [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data)), h) PID or attestation deletions by the User.
+
+*Note: For the data to be logged for a data deletion request to a Relying Party or a report sent to a DPA, see Topic 48 and Topic 50, respectively. For other types of transaction, the data to be logged is specified in the requirements in this Topic.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_02a" markdown>
+<div class="eudi-hlr__id">DASH_02a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL retain transactions in the log at least for the minimum retention period specified in applicable legislation. If the Wallet Unit must delete transactions from the log, for instance because of size limitations, the Wallet Unit SHALL notify the User via the dashboard before doing so, indicating the potential consequences for the User's data protection rights, and SHALL instruct the User how to export the transactions that are about to be deleted. See DASH_07.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_02b" markdown>
+<div class="eudi-hlr__id">DASH_02b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The dashboard SHALL include a functionality to display to the User an overview of all transactions in the log.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_02c" markdown>
+<div class="eudi-hlr__id">DASH_02c<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The transaction log meant in DASH_02 SHALL comply with all relevant requirement in [Technical Specification 10](../../technical-specifications/ts10-data-portability-and-download-(export).md), including measures to ensure and/or verify its confidentiality, integrity, and authenticity.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_03" markdown>
+<div class="eudi-hlr__id">DASH_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For a PID or attestation presentation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the name and unique identifier of the corresponding Relying Party, and the Member State in which that Relying Party is established, c) the name, contact details (if available), and unique identifier of the intermediary, if an intermediary is involved in the transaction, d) the attestation type(s) and the identifier(s) of the attribute(s) that were requested, as well as those that were presented, e) in the case of non-completed transactions, the reason for such non-completion, f) the URL of the online service of the Relying Party's Registrar. g) the web form URL (if available), e-mail address (if available), and telephone number (if available) provided by the Relying Party for sending data deletion requests, see requirement RPRC_11 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), h) the name and country of the Data Protection Authority supervising the Relying Party, as well as the web form URL (if available), e-mail address (if available), and telephone number (if available) provided by this DPA for reporting suspicious attribute presentation requests. i) information on the intended use and the URL to the applicable privacy policy (if available).
+
+*Note: The information in points g), h), and i) may be retrieved from the registration certificate or from the Registrar's online service (see [Topic 44](../annex-2/annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_03a" markdown>
+<div class="eudi-hlr__id">DASH_03a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For a PID or attestation presentation transaction or a Wallet-to-Wallet transaction executed through the Wallet Unit, the log SHALL NOT contain the value of any attributes presented to the Relying Party or the Verifier Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_03b" markdown>
+<div class="eudi-hlr__id">DASH_03b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For a Wallet-to-Wallet transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the role of the Wallet Unit (Holder Wallet Unit or Verifier Wallet Unit), c) the attestation type(s) and the identifier(s) of the attribute(s) that were requested, as well as those that were presented, d) in the case of non-completed transactions, the reason for such non-completion.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_03c" markdown>
+<div class="eudi-hlr__id">DASH_03c<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For a pseudonym registration or presentation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) identifying information about the Relying Party, if known to the Wallet Unit, c) whether it is a pseudonym registration or pseudonym presentation transaction, d) in the case of non-completed transactions, the reason for such non-completion.
+
+*Note: Regarding point b), see PA_20 in [Topic 11](./annex-2.02-high-level-requirements-by-topic.md#a238-topic-11-pseudonyms).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_03d" markdown>
+<div class="eudi-hlr__id">DASH_03d<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a presentation request contains transactional data, the Wallet Unit SHALL log the value of this transactional data only to the extent explicitly required by the applicable Technical Specification associated with the requested SUA attestation, and in accordance with data minimisation principles. If the applicable Technical Specification does not explicitly specify that transactional data shall be logged, the Wallet Unit SHALL NOT log the value of any transactional data.
+
+*Note: a) For the concepts of transactional data and SUA attestations and their related Technical Specifications, see [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments). b) For example, for PSD2 Strong Customer Authentication transactions, the scope of transactional data to be included in the transaction log is defined in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md) and includes the payment transaction identifier and merchant name.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_04" markdown>
+<div class="eudi-hlr__id">DASH_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For a signature or seal creation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the document or data signed or sealed (if available to the Wallet Unit), c) in the case of non-completed transactions, the reason for such non-completion.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_05" markdown>
+<div class="eudi-hlr__id">DASH_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For a PID or attestation issuance or re-issuance transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the name, contact details (if available), and unique identifier of the corresponding PID Provider or Attestation Provider, c) the attestation type requested, as well as the attestation type issued, d) the number of attestations requested and issued (i.e., the size of the batch in case of batch issuance), e) in the case of non-completed transactions, the reason for such non-completion. f) for a re-issuance transaction, whether it was triggered by the User or by the Wallet Unit without involvement of the User, g) the URL of the associated Registrar's online service.
+
+*Note: Regarding point g): this URL can be retrieved from the access certificate.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_05a" markdown>
+<div class="eudi-hlr__id">DASH_05a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the deletion of a PID or attestation by the User, the log SHALL contain at least: a) the date and time of the deletion event, b) the attestation type of the deleted PID or attestation. c) The name and unique identifier of the corresponding PID Provider or Attestation Provider.
+
+*Note: This requirement is not about deletion of transactions from the log, as per DASH_06a.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_06" markdown>
+<div class="eudi-hlr__id">DASH_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Provider SHALL ensure the confidentiality, integrity, and authenticity of all transactions included in the log.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_06a" markdown>
+<div class="eudi-hlr__id">DASH_06a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Via the dashboard, the Wallet Unit SHALL enable the User to delete any transaction in the log. Before deleting any transactions, the Wallet Unit SHALL indicate to the User the potential consequences for the User's data protection rights.
+
+*Note: This requirement applies even in case the minimum retention period specified in applicable legislation (see DASH_02a) is not yet over.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_06b" markdown>
+<div class="eudi-hlr__id">DASH_06b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL ensure that no entity other than the User can delete transactions from the log, except possibly for the reason mentioned in DASH_02a.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_07" markdown>
+<div class="eudi-hlr__id">DASH_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The dashboard SHALL allow the User to export the details of one or more transactions in the log to a file, using the common format specified according to DASH_02c, while ensuring their confidentiality, authenticity and integrity. The file SHALL be stored in an external storage or remote storage location of the User's choice, from among the storage options supported by the Wallet Unit and SHALL use the common format and security measures specified according to DASH_02c.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_08" markdown>
+<div class="eudi-hlr__id">DASH_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For a natural-person User, a Wallet Instance SHALL provide a User interface.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_09" markdown>
+<div class="eudi-hlr__id">DASH_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The User interface referred to in DASH_08 SHALL provide a view with - the EU Digital Identity Wallet Trust Mark, - accompanying general information on the certification of Wallet Solutions, - links to the certification status information as defined in the [Technical Specification 1](../../technical-specifications/ts1-eudi-wallet-trust-mark.md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_09a" markdown>
+<div class="eudi-hlr__id">DASH_09a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Positioning of the view meant in DASH_09 in the Wallet UI navigation SHALL follow design guidelines provided by the European Commission.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_09b" markdown>
+<div class="eudi-hlr__id">DASH_09b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers and Wallet Units SHALL comply with all relevant requirements in [Technical Specification 1](../../technical-specifications/ts1-eudi-wallet-trust-mark.md) for the EUDI Wallet Trust Mark.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_10" markdown>
+<div class="eudi-hlr__id">DASH_10</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty.
+
+*Note: See requirement WIAM_12a in [Topic 40](./annex-2.02-high-level-requirements-by-topic.md#a2323-topic-40-wallet-instance-installation-and-wallet-unit-activation-and-management).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_11" markdown>
+<div class="eudi-hlr__id">DASH_11</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DASH_12" markdown>
+<div class="eudi-hlr__id">DASH_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The User interface referred to in DASH_08 SHALL enable the User, for each presentation transaction in the log, to easily request the Relying Party to delete any or all attributes presented to it in that transaction, or to send a report about that particular transaction to a DPA.
+
+</div>
+</div>
+
 
 #### A.2.3.13 Topic 20 - Strong User authentication for electronic payments
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| SUA_01 | A Wallet Unit SHALL be able to process the transactional data included in a presentation request for the SUA attestation(s) specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md), according to all requirements in that Technical Specification. *Note: Technical Specification 12 specifies a SUA attestation intended for performing SCA as specified in the PSD2 Regulation. The related Rulebook is called "SCA Attestation Rulebook".* |
-| SUA_02 | Scheme Providers MAY specify Attestation Rulebooks (see [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)) and associated technical specifications for SUA attestations other that the ones specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md)). The Attestation Rulebook or the technical specification of such of a SUA attestation SHALL specify the syntax and semantics of the transactional data associated with that attestation. |
-| SUA_02a | The Technical Specification associated with a given SUA attestation SHALL specify all necessary requirements for Wallet Units to process transactional data intended for this SUA attestation, at least regarding a) rendering and displaying the data to the User when obtaining approval for presentation, b) processing (e.g., hashing) the data for inclusion in the device binding signature, and c) the scope of information to be logged about a SUA attestation presentation transaction by a Wallet Unit. |
-| SUA_03 | The Attestation Provider of a SUA attestation other than the one(s) specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md) SHALL NOT issue such an attestation to a Wallet Unit that does not comply with all relevant requirements in the SUA Attestation Rulebook and the technical specification for that attestation. |
-| SUA_04 | In the response to a presentation request for a SUA attestation that includes transactional data, a Wallet Unit SHALL include (a representation of) that data, according to requirements included in the associated technical specification or Attestation Rulebook or in information provided to the Wallet Unit in the presentation request. In the latter case, the rules to interpret such information SHALL be included in the associated technical specification or Attestation Rulebook. *Note: This requirement, as well as SUA_05, only applies if the requested SUA attestation is present on the Wallet Unit and if the User consents to signing the transactional data and presenting the requested attributes.* |
-| SUA_05 | The Wallet Unit SHALL include (a representation of) the transactional data received in a presentation request in the signature creation process used for device binding, using the private key of the requested SUA attestation and the mechanisms specified for key binding in [SD-JWT-VC] or mdoc authentication in [ISO/IEC 18013-5], as applicable. For this process, the Wallet Unit SHALL comply with the applicable requirements in the technical specification and the Attestation Rulebook for the requested SUA attestation, see SUA_01 or SUA_02. *Note: a) The resulting signature value constitutes a proof of transaction. This signature value, possibly in combination with other protocols items, fulfils the requirements for the authentication code required in [PSD2]. b) See also requirement OIA_02 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit).* |
-| SUA_06 | The Wallet Unit SHALL render or adapt the dialogue message(s) displayed to the User (like font size and colour, background colour, text position, labels in the buttons to 'approve' or 'reject' a transaction), according to requirements in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md). |
-| SUA_07 | Upon receiving a presentation request with transactional data, the Wallet Unit SHALL validate if the transactional data is intended for the given attestation and that the transactional data conforms to the related technical specification and/or Attestation Rulebook. In case the validation result is positive, the Wallet Unit SHALL process the transactional data in compliance with the related technical specification. |
+<div class="eudi-hlr" id="SUA_01" markdown>
+<div class="eudi-hlr__id">SUA_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL be able to process the transactional data included in a presentation request for the SUA attestation(s) specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md), according to all requirements in that Technical Specification.
+
+*Note: Technical Specification 12 specifies a SUA attestation intended for performing SCA as specified in the PSD2 Regulation. The related Rulebook is called "SCA Attestation Rulebook".*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="SUA_02" markdown>
+<div class="eudi-hlr__id">SUA_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Scheme Providers MAY specify Attestation Rulebooks (see [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)) and associated technical specifications for SUA attestations other that the ones specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md)). The Attestation Rulebook or the technical specification of such of a SUA attestation SHALL specify the syntax and semantics of the transactional data associated with that attestation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="SUA_02a" markdown>
+<div class="eudi-hlr__id">SUA_02a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Technical Specification associated with a given SUA attestation SHALL specify all necessary requirements for Wallet Units to process transactional data intended for this SUA attestation, at least regarding a) rendering and displaying the data to the User when obtaining approval for presentation, b) processing (e.g., hashing) the data for inclusion in the device binding signature, and c) the scope of information to be logged about a SUA attestation presentation transaction by a Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="SUA_03" markdown>
+<div class="eudi-hlr__id">SUA_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Attestation Provider of a SUA attestation other than the one(s) specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md) SHALL NOT issue such an attestation to a Wallet Unit that does not comply with all relevant requirements in the SUA Attestation Rulebook and the technical specification for that attestation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="SUA_04" markdown>
+<div class="eudi-hlr__id">SUA_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+In the response to a presentation request for a SUA attestation that includes transactional data, a Wallet Unit SHALL include (a representation of) that data, according to requirements included in the associated technical specification or Attestation Rulebook or in information provided to the Wallet Unit in the presentation request. In the latter case, the rules to interpret such information SHALL be included in the associated technical specification or Attestation Rulebook.
+
+*Note: This requirement, as well as SUA_05, only applies if the requested SUA attestation is present on the Wallet Unit and if the User consents to signing the transactional data and presenting the requested attributes.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="SUA_05" markdown>
+<div class="eudi-hlr__id">SUA_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL include (a representation of) the transactional data received in a presentation request in the signature creation process used for device binding, using the private key of the requested SUA attestation and the mechanisms specified for key binding in [SD-JWT-VC] or mdoc authentication in [ISO/IEC 18013-5], as applicable. For this process, the Wallet Unit SHALL comply with the applicable requirements in the technical specification and the Attestation Rulebook for the requested SUA attestation, see SUA_01 or SUA_02.
+
+*Note: a) The resulting signature value constitutes a proof of transaction. This signature value, possibly in combination with other protocols items, fulfils the requirements for the authentication code required in [PSD2]. b) See also requirement OIA_02 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="SUA_06" markdown>
+<div class="eudi-hlr__id">SUA_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL render or adapt the dialogue message(s) displayed to the User (like font size and colour, background colour, text position, labels in the buttons to 'approve' or 'reject' a transaction), according to requirements in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="SUA_07" markdown>
+<div class="eudi-hlr__id">SUA_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Upon receiving a presentation request with transactional data, the Wallet Unit SHALL validate if the transactional data is intended for the given attestation and that the transactional data conforms to the related technical specification and/or Attestation Rulebook. In case the validation result is positive, the Wallet Unit SHALL process the transactional data in compliance with the related technical specification.
+
+</div>
+</div>
+
 
 #### A.2.3.14 Topic 24 - User identification in proximity scenarios
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ProxId_01 | To enable identification using proximity flows, Wallet Units SHALL support device retrieval as specified in ISO/IEC 18013-5 for presenting PID or attestation attributes. Wallet Units SHALL comply with the requirements for mDLs and mdocs ISO/IEC 18013-5. *Note: Nominally, ISO/IEC 18013-5 is intended only for mDLs and mDL readers. The corresponding standard for mobile documents in general (including Wallet Units with the EUDI Wallet ecosystem) will be ISO/IEC 23220-4, which is based on ISO/IEC 18013-5. However, the latter standard is not finished yet and therefore cannot be referenced at the moment. To guarantee interoperability between Wallet Units and Relying Party Instances in proximity scenarios, it is necessary to make choices from among the possibilities specified in ISO/IEC 18013-5. Making the same choices as for mDLs ensure this.* |
-| ProxId_01a | If a Relying Party supports using proximity flows, its Relying Party Instances SHALL support device retrieval as specified in ISO/IEC 18013-5 for requesting PID or attestation attributes. Such Relying Party Instances SHALL comply with the requirements for mDL readers and mdoc readers in ISO/IEC 18013-5. *Note: See note to ProxId_01. Support for proximity flows by Relying Parties is not mandatory.* |
-| ProxId_02 | Wallet Units, PID Providers, Attestation Providers, Wallet Providers, and Relying Parties SHALL NOT support server retrieval as specified in ISO/IEC 18013-5 for requesting and presenting PID or attestation attributes. *Note: Using server retrieval, a Relying Party would request User attributes directly from a PID Provider or Attestation Provider, after having received an authentication and/or authorisation token from the User's Wallet Unit.* |
-| ProxId_03 | A Wallet Unit SHALL present the presentation request and the identity of the Relying Party to the User when processing the request. |
-| ProxId_04 | A Wallet Unit SHALL request its User to approve the presentation of attributes from their Wallet Unit for proximity identification before presenting them to the Relying Party or Verifier Wallet Unit. |
-| ProxId_05 | A Wallet Unit SHALL transmit the requested User attributes to the requesting Relying Party Instance securely in accordance with ISO/IEC 18013-5 for proximity flows. |
-| ProxId_06 | Empty |
+<div class="eudi-hlr" id="ProxId_01" markdown>
+<div class="eudi-hlr__id">ProxId_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+To enable identification using proximity flows, Wallet Units SHALL support device retrieval as specified in ISO/IEC 18013-5 for presenting PID or attestation attributes. Wallet Units SHALL comply with the requirements for mDLs and mdocs ISO/IEC 18013-5.
+
+*Note: Nominally, ISO/IEC 18013-5 is intended only for mDLs and mDL readers. The corresponding standard for mobile documents in general (including Wallet Units with the EUDI Wallet ecosystem) will be ISO/IEC 23220-4, which is based on ISO/IEC 18013-5. However, the latter standard is not finished yet and therefore cannot be referenced at the moment. To guarantee interoperability between Wallet Units and Relying Party Instances in proximity scenarios, it is necessary to make choices from among the possibilities specified in ISO/IEC 18013-5. Making the same choices as for mDLs ensure this.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ProxId_01a" markdown>
+<div class="eudi-hlr__id">ProxId_01a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Relying Party supports using proximity flows, its Relying Party Instances SHALL support device retrieval as specified in ISO/IEC 18013-5 for requesting PID or attestation attributes. Such Relying Party Instances SHALL comply with the requirements for mDL readers and mdoc readers in ISO/IEC 18013-5.
+
+*Note: See note to ProxId_01. Support for proximity flows by Relying Parties is not mandatory.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ProxId_02" markdown>
+<div class="eudi-hlr__id">ProxId_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Units, PID Providers, Attestation Providers, Wallet Providers, and Relying Parties SHALL NOT support server retrieval as specified in ISO/IEC 18013-5 for requesting and presenting PID or attestation attributes.
+
+*Note: Using server retrieval, a Relying Party would request User attributes directly from a PID Provider or Attestation Provider, after having received an authentication and/or authorisation token from the User's Wallet Unit.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ProxId_03" markdown>
+<div class="eudi-hlr__id">ProxId_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL present the presentation request and the identity of the Relying Party to the User when processing the request.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ProxId_04" markdown>
+<div class="eudi-hlr__id">ProxId_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL request its User to approve the presentation of attributes from their Wallet Unit for proximity identification before presenting them to the Relying Party or Verifier Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ProxId_05" markdown>
+<div class="eudi-hlr__id">ProxId_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL transmit the requested User attributes to the requesting Relying Party Instance securely in accordance with ISO/IEC 18013-5 for proximity flows.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ProxId_06" markdown>
+<div class="eudi-hlr__id">ProxId_06</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 #### A.2.3.15 Topic 25 - Unified definition and controlled vocabularies for attributes
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| CAT_01 | Empty |
-| CAT_01a | Empty |
-| CAT_01b | Empty |
-| CAT_02 | Empty |
-| CAT_03 | Empty |
-| CAT_03b | Empty |
-| CAT_04 | A request to include or to modify an attribute in the catalogue of attributes SHALL indicate how a QTSP can use the verification point for that attribute. *Note: This could be, for instance, in the form of (a reference to) an endpoint description text.* |
+<div class="eudi-hlr" id="CAT_01" markdown>
+<div class="eudi-hlr__id">CAT_01</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="CAT_01a" markdown>
+<div class="eudi-hlr__id">CAT_01a</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="CAT_01b" markdown>
+<div class="eudi-hlr__id">CAT_01b</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="CAT_02" markdown>
+<div class="eudi-hlr__id">CAT_02</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="CAT_03" markdown>
+<div class="eudi-hlr__id">CAT_03</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="CAT_03b" markdown>
+<div class="eudi-hlr__id">CAT_03b</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="CAT_04" markdown>
+<div class="eudi-hlr__id">CAT_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A request to include or to modify an attribute in the catalogue of attributes SHALL indicate how a QTSP can use the verification point for that attribute.
+
+*Note: This could be, for instance, in the form of (a reference to) an endpoint description text.*
+
+</div>
+</div>
+
 
 #### A.2.3.16 Topic 27 - Registration of PID Providers, Providers of QEAAs, PuB-EAAs, and non-qualified EAAs, and Relying Parties
 
 ##### A. General requirements for Member State registration processes <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| Reg_01 | Member States SHALL provide processes and mechanisms for PID Providers, QEAA Providers, PuB-EAA Providers, non-qualified EAA Providers, and Relying Parties to register in a registry. *Note: Member States may choose to implement a single registry for all these roles, or a separate registry for each of these roles.* |
-| Reg_01a | Member States SHALL register a common set of data about a) PID Providers, b) QEAA Providers, c) PuB-EAA Providers, d) non-qualified EAA Providers. and e) Relying Parties, according to the relevant requirements in [Technical Specification 6](../../technical-specifications/ts6-common-set-of-rp-information-to-be-registered.md). *Note: For PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers, the common set of data specified in [Technical Specification 6] include the attestation type(s) that the provider intends to issue to Wallet Units.* |
-| Reg_01b | Empty |
-| Reg_02 | Member States SHALL make publicly available all necessary details and documentation about the registration processes for their registry. |
-| Reg_03 | Member States SHALL publish the registry entries online, in a sealed or signed machine-readable common format suitable for automated processing, according to the relevant requirements in [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md), for the purpose of transparency to Users and other stakeholders. |
-| Reg_04 | Member States SHALL make the registry entries available online, in a human-readable format. The website used for this purpose SHALL use a secure channel protecting the authenticity and integrity of the information in the registry during transport. Member States SHALL NOT require authentication or prior registration and authorisation of any person wishing to retrieve the information in the registry. |
-| Reg_05 | Empty |
-| Reg_06 | Member States SHALL support the common API specified in [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md) for to enable automated retrieval of registry entries from the Member States' registries. *Note: [Technical Specification 5] specifies the use of a secure channel protecting the authenticity and integrity of the information in the registry during transport, and does not require authentication or prior registration and authorisation of any entity wishing to retrieve the information in the registry.* |
-| Reg_07 | A Member State SHALL enable a registered PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party to update the information registered on it, using a process comparable to the original registration process. For Relying Parties, this SHALL be possible using the API or user interface mentioned in Reg_24. |
-| Reg_08 | A registered PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party SHALL make any updates necessary to ensure the continued correctness of the registered information without undue delay. |
-| Reg_09 | Member States SHALL log all changes made on the information registered regarding a PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party, including at least initial registration, updates, deletion of information, and suspension or cancellation. |
+<div class="eudi-hlr" id="Reg_01" markdown>
+<div class="eudi-hlr__id">Reg_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Member States SHALL provide processes and mechanisms for PID Providers, QEAA Providers, PuB-EAA Providers, non-qualified EAA Providers, and Relying Parties to register in a registry.
+
+*Note: Member States may choose to implement a single registry for all these roles, or a separate registry for each of these roles.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_01a" markdown>
+<div class="eudi-hlr__id">Reg_01a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Member States SHALL register a common set of data about a) PID Providers, b) QEAA Providers, c) PuB-EAA Providers, d) non-qualified EAA Providers. and e) Relying Parties, according to the relevant requirements in [Technical Specification 6](../../technical-specifications/ts6-common-set-of-rp-information-to-be-registered.md).
+
+*Note: For PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers, the common set of data specified in [Technical Specification 6] include the attestation type(s) that the provider intends to issue to Wallet Units.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_01b" markdown>
+<div class="eudi-hlr__id">Reg_01b</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_02" markdown>
+<div class="eudi-hlr__id">Reg_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Member States SHALL make publicly available all necessary details and documentation about the registration processes for their registry.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_03" markdown>
+<div class="eudi-hlr__id">Reg_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Member States SHALL publish the registry entries online, in a sealed or signed machine-readable common format suitable for automated processing, according to the relevant requirements in [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md), for the purpose of transparency to Users and other stakeholders.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_04" markdown>
+<div class="eudi-hlr__id">Reg_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Member States SHALL make the registry entries available online, in a human-readable format. The website used for this purpose SHALL use a secure channel protecting the authenticity and integrity of the information in the registry during transport. Member States SHALL NOT require authentication or prior registration and authorisation of any person wishing to retrieve the information in the registry.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_05" markdown>
+<div class="eudi-hlr__id">Reg_05</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_06" markdown>
+<div class="eudi-hlr__id">Reg_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Member States SHALL support the common API specified in [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md) for to enable automated retrieval of registry entries from the Member States' registries.
+
+*Note: [Technical Specification 5] specifies the use of a secure channel protecting the authenticity and integrity of the information in the registry during transport, and does not require authentication or prior registration and authorisation of any entity wishing to retrieve the information in the registry.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_07" markdown>
+<div class="eudi-hlr__id">Reg_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State SHALL enable a registered PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party to update the information registered on it, using a process comparable to the original registration process. For Relying Parties, this SHALL be possible using the API or user interface mentioned in Reg_24.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_08" markdown>
+<div class="eudi-hlr__id">Reg_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A registered PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party SHALL make any updates necessary to ensure the continued correctness of the registered information without undue delay.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_09" markdown>
+<div class="eudi-hlr__id">Reg_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Member States SHALL log all changes made on the information registered regarding a PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party, including at least initial registration, updates, deletion of information, and suspension or cancellation.
+
+</div>
+</div>
+
 
 ##### B. General requirements for the issuance of access certificates <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| Reg_10 | A Member State SHALL ensure that an Access Certificate Authority notified according to [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)] issues an access certificate to all PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers registered in one of the Member State's registries. |
-| Reg_10a | A Member State SHALL ensure that an Access Certificate Authority notified according to [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)] issues one or more access certificates to all Relying Parties registered in one of the Member State's registries. A Relying Party SHALL receive a separate access certificate for each of its Relying Party Instances. |
-| Reg_11 | A Member State SHALL ensure that the issuance process of access certificates by their notified Access Certificate Authority(s) complies with [ETSI TS 119 411-8]. In addition, the Access Certificate Authority(s) SHALL comply with at least the normalised certificate policy (‘NCP’) requirements as specified in [ETSI EN 319 411-1]. |
-| Reg_12 | Empty |
-| Reg_13 | Empty |
-| Reg_14 | Empty |
-| Reg_15 | Empty |
-| Reg_16 | Empty |
-| Reg_17 | Empty |
-| Reg_18 | Empty |
+<div class="eudi-hlr" id="Reg_10" markdown>
+<div class="eudi-hlr__id">Reg_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State SHALL ensure that an Access Certificate Authority notified according to [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)] issues an access certificate to all PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers registered in one of the Member State's registries.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_10a" markdown>
+<div class="eudi-hlr__id">Reg_10a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State SHALL ensure that an Access Certificate Authority notified according to [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)] issues one or more access certificates to all Relying Parties registered in one of the Member State's registries. A Relying Party SHALL receive a separate access certificate for each of its Relying Party Instances.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_11" markdown>
+<div class="eudi-hlr__id">Reg_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State SHALL ensure that the issuance process of access certificates by their notified Access Certificate Authority(s) complies with [ETSI TS 119 411-8]. In addition, the Access Certificate Authority(s) SHALL comply with at least the normalised certificate policy (‘NCP’) requirements as specified in [ETSI EN 319 411-1].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_12" markdown>
+<div class="eudi-hlr__id">Reg_12</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_13" markdown>
+<div class="eudi-hlr__id">Reg_13</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_14" markdown>
+<div class="eudi-hlr__id">Reg_14</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_15" markdown>
+<div class="eudi-hlr__id">Reg_15</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_16" markdown>
+<div class="eudi-hlr__id">Reg_16</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_17" markdown>
+<div class="eudi-hlr__id">Reg_17</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_18" markdown>
+<div class="eudi-hlr__id">Reg_18</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 ##### C. Requirements for the registration of PID Providers <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| Reg_19 | A Member State SHALL approve a PID Provider according to a well-defined policy before including it in its PID Provider Registry. To that end, a Member State SHALL define specific vetting processes and rules of acceptance for inclusion of PID Providers in its Registry. |
-| Reg_20 | A Member State SHALL identify PID Providers at a level of confidence proportionate to the risk arising from the potential harm a fraudulent PID Provider could cause to Users and other stakeholders in the EUDI Wallet ecosystem. |
-| Reg_20a | A Registrar SHALL provide a method to suspend or cancel a registered PID Provider. |
-| Reg_20b | A Registrar SHALL have a policy for the suspension or cancellation of a registered PID Provider, which SHALL specify that a PID Provider is suspended or cancelled at least on request of the PID Provider or of a competent national authority. |
+<div class="eudi-hlr" id="Reg_19" markdown>
+<div class="eudi-hlr__id">Reg_19<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State SHALL approve a PID Provider according to a well-defined policy before including it in its PID Provider Registry. To that end, a Member State SHALL define specific vetting processes and rules of acceptance for inclusion of PID Providers in its Registry.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_20" markdown>
+<div class="eudi-hlr__id">Reg_20<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State SHALL identify PID Providers at a level of confidence proportionate to the risk arising from the potential harm a fraudulent PID Provider could cause to Users and other stakeholders in the EUDI Wallet ecosystem.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_20a" markdown>
+<div class="eudi-hlr__id">Reg_20a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Registrar SHALL provide a method to suspend or cancel a registered PID Provider.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_20b" markdown>
+<div class="eudi-hlr__id">Reg_20b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Registrar SHALL have a policy for the suspension or cancellation of a registered PID Provider, which SHALL specify that a PID Provider is suspended or cancelled at least on request of the PID Provider or of a competent national authority.
+
+</div>
+</div>
+
 
 ##### D. Requirements for the registration of Attestation Providers <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| Reg_21 | A Member State SHALL approve an Attestation Provider according to a well-defined policy before including it in its Attestation Provider Registry. To that end, a Member State SHALL define specific vetting processes and rules of acceptance for inclusion of Attestation Providers in its Registry. These processes and rules SHOULD consider any relevant differences between QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers. |
-| Reg_22 | A Member State SHALL identify Attestation Providers (i.e., QEAA Providers, PuB-EAA Providers and non-qualified EAA Providers) at a level of confidence proportionate to the risk arising from the potential harm a fraudulent Attestation Provider could cause to Users and other stakeholders in the EUDI Wallet ecosystem. |
-| Reg_22a | A Registrar SHALL provide a method to suspend or cancel a registered Attestation Provider. |
-| Reg_22b | A Registrar SHALL have a policy for the suspension or cancellation of a registered Attestation Provider, which SHALL specify that an Attestation Provider is suspended or cancelled at least on request of the Attestation Provider or of a competent national authority. |
+<div class="eudi-hlr" id="Reg_21" markdown>
+<div class="eudi-hlr__id">Reg_21<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State SHALL approve an Attestation Provider according to a well-defined policy before including it in its Attestation Provider Registry. To that end, a Member State SHALL define specific vetting processes and rules of acceptance for inclusion of Attestation Providers in its Registry. These processes and rules SHOULD consider any relevant differences between QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_22" markdown>
+<div class="eudi-hlr__id">Reg_22<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State SHALL identify Attestation Providers (i.e., QEAA Providers, PuB-EAA Providers and non-qualified EAA Providers) at a level of confidence proportionate to the risk arising from the potential harm a fraudulent Attestation Provider could cause to Users and other stakeholders in the EUDI Wallet ecosystem.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_22a" markdown>
+<div class="eudi-hlr__id">Reg_22a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Registrar SHALL provide a method to suspend or cancel a registered Attestation Provider.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_22b" markdown>
+<div class="eudi-hlr__id">Reg_22b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Registrar SHALL have a policy for the suspension or cancellation of a registered Attestation Provider, which SHALL specify that an Attestation Provider is suspended or cancelled at least on request of the Attestation Provider or of a competent national authority.
+
+</div>
+</div>
+
 
 ##### E. Requirements for the registration of Relying Parties <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| Reg_23 | Empty |
-| Reg_24 | A Member State SHALL enable a Relying Party to register remotely, using an API or user interface. |
-| Reg_25 | A Member State SHALL identify a Relying Party at a level of confidence proportionate to the risk arising from the potential harm a fraudulent Relying Party could cause to Users and other stakeholders in the EUDI Wallet ecosystem. |
-| Reg_26 | With respect to Reg_25, a Member State SHALL consider whether a registering entity intends to act as an intermediary. *Note: According to the [European Digital Identity Regulation], an intermediary is a Relying Party.* |
-| Reg_27 | Empty |
-| Reg_28 | Empty |
-| Reg_29 | A Member State SHALL have a policy for the cancellation of a registered Relying Party, which SHALL specify that a Relying Party is cancelled at least on request of the Relying Party or of a competent national authority. |
-| Reg_30 | Empty |
+<div class="eudi-hlr" id="Reg_23" markdown>
+<div class="eudi-hlr__id">Reg_23</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_24" markdown>
+<div class="eudi-hlr__id">Reg_24<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State SHALL enable a Relying Party to register remotely, using an API or user interface.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_25" markdown>
+<div class="eudi-hlr__id">Reg_25<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State SHALL identify a Relying Party at a level of confidence proportionate to the risk arising from the potential harm a fraudulent Relying Party could cause to Users and other stakeholders in the EUDI Wallet ecosystem.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_26" markdown>
+<div class="eudi-hlr__id">Reg_26<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+With respect to Reg_25, a Member State SHALL consider whether a registering entity intends to act as an intermediary.
+
+*Note: According to the [European Digital Identity Regulation], an intermediary is a Relying Party.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_27" markdown>
+<div class="eudi-hlr__id">Reg_27</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_28" markdown>
+<div class="eudi-hlr__id">Reg_28</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_29" markdown>
+<div class="eudi-hlr__id">Reg_29<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State SHALL have a policy for the cancellation of a registered Relying Party, which SHALL specify that a Relying Party is cancelled at least on request of the Relying Party or of a competent national authority.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_30" markdown>
+<div class="eudi-hlr__id">Reg_30</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 ##### F. Requirements for the contents of access certificates <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| Reg_31 | An access certificate SHALL contain a name for the entity (i.e., the PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party), in a format suitable for presenting to a User. This name SHALL be identical to the name for the entity registered according to [Technical Specification 6] and included in the entity's registration certificate(s) (if present) according to RPRC_06. |
-| Reg_32 | An access certificate SHALL contain an EU-wide unique identifier for the entity (i.e., the PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party), which SHALL be identical to the identifier for the entity registered according to [Technical Specification 6] and included in the entity's registration certificate(s) (if present) according to RPRC_07. |
-| Reg_33 | Empty |
+<div class="eudi-hlr" id="Reg_31" markdown>
+<div class="eudi-hlr__id">Reg_31<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An access certificate SHALL contain a name for the entity (i.e., the PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party), in a format suitable for presenting to a User. This name SHALL be identical to the name for the entity registered according to [Technical Specification 6] and included in the entity's registration certificate(s) (if present) according to RPRC_06.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_32" markdown>
+<div class="eudi-hlr__id">Reg_32<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An access certificate SHALL contain an EU-wide unique identifier for the entity (i.e., the PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party), which SHALL be identical to the identifier for the entity registered according to [Technical Specification 6] and included in the entity's registration certificate(s) (if present) according to RPRC_07.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Reg_33" markdown>
+<div class="eudi-hlr__id">Reg_33</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 #### A.2.3.17 Topic 28 - Wallet Unit for legal persons
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| LP_01 | Empty |
-| LP_02 | Empty |
-| LP_03 | Empty |
+<div class="eudi-hlr" id="LP_01" markdown>
+<div class="eudi-hlr__id">LP_01</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="LP_02" markdown>
+<div class="eudi-hlr__id">LP_02</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="LP_03" markdown>
+<div class="eudi-hlr__id">LP_03</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 #### A.2.3.18 Topic 29 - Representation paradigm
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| RP_01 | Attestation Scheme Providers MAY create one or multiple Attestation Rulebooks for representation attestations issued to a natural person representing another natural person. Each Rulebook SHALL specify the unique attestation type of these representation attestations. The Rulebook SHALL also specify attributes used for defining a validity period, the nature of the representation, and the operations the representative is authorised to perform, thereby limiting the scope of its authorisation. |
-| RP_02 | An Attestation Provider issuing representation attestations to a natural person representing another natural person SHALL ensure that either the attestations are short-lived or that all entities which, according to applicable law, must have the ability to request revocation of such attestations, are able to do so. |
+<div class="eudi-hlr" id="RP_01" markdown>
+<div class="eudi-hlr__id">RP_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Attestation Scheme Providers MAY create one or multiple Attestation Rulebooks for representation attestations issued to a natural person representing another natural person. Each Rulebook SHALL specify the unique attestation type of these representation attestations. The Rulebook SHALL also specify attributes used for defining a validity period, the nature of the representation, and the operations the representative is authorised to perform, thereby limiting the scope of its authorisation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RP_02" markdown>
+<div class="eudi-hlr__id">RP_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attestation Provider issuing representation attestations to a natural person representing another natural person SHALL ensure that either the attestations are short-lived or that all entities which, according to applicable law, must have the ability to request revocation of such attestations, are able to do so.
+
+</div>
+</div>
+
 
 #### A.2.3.19 Topic 30 - Interaction between Wallet Units
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| W2W_01 | A Wallet Unit SHALL be able to act as a Holder Wallet Unit, in accordance with all requirements in this Topic. |
-| W2W_02 | When acting as a Holder Wallet Unit, if there is a contradiction between a requirement for Holder Wallet Units in this Topic and any requirement for Wallet Units in other Topics in this document, the requirement in this Topic SHALL take precedence. However, when acting as a Holder Wallet Unit, a Wallet Unit SHALL comply with all requirements for Wallet Units in other Topics in this document that do not contradict any requirement in this Topic. |
-| W2W_03 | A Wallet Unit SHALL be able to act as a Verifier Wallet Unit, in accordance with all requirements in this Topic. |
-| W2W_04 | When acting as a Verifier Wallet Unit, a Wallet Unit SHALL NOT comply with any requirement for Wallet Units in other Topics in this document. |
-| W2W_05 | A Wallet Unit SHALL act as a Holder Wallet Unit only if the User selects a 'Holder Wallet Unit mode'. If the User closes the Wallet Unit, or after a period of non-activity, the Wallet Unit SHALL return to 'normal' mode. |
-| W2W_06 | When entering the Holder Wallet Unit mode, a Wallet Unit SHALL inform its User that this mode should only be used for interactions with natural persons using a Wallet Unit, and that the User should not proceed if they are in fact interacting with a Relying Party. |
-| W2W_07 | A Wallet Unit SHALL act as a Verifier Wallet Unit only if the User selects a 'Verifier Wallet Unit mode'. If the User closes the Wallet Unit, or after a period of non-activity, the Wallet Unit SHALL return to 'normal' mode. |
-| W2W_08 | A Verifier Wallet Unit and a Holder Wallet Unit SHALL support attestation presentation only in proximity, meaning they SHALL support only [ISO/IEC 18013-5] to communicate. |
-| W2W_09 | Holder Wallet Units SHALL comply with the requirements for mDLs and for mdocs in ISO/IEC 18013-5, unless specified differently in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md). |
-| W2W_10 | Verifier Wallet Units SHALL comply with the requirements for mDL readers and for mdoc readers in ISO/IEC 18013-5, unless specified differently in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md). |
-| W2W_11 | A Holder Wallet Unit SHOULD provide the Holder, through a user-friendly UI, with the option to inform the Verifier Wallet Unit about the attributes which the Verifier should include in the presentation request, by sending a presentation offer. If the Holder creates a presentation offer, the Holder Wallet Unit SHALL transfer it to the Verifier Wallet Unit as specified in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md). *Note: TS9 specifies an extension of the device engagement structure specified in ISO/IEC 18013-5.* |
-| W2W_12 | A Holder Wallet Unit SHALL recommend the Holder to create a presentation offer, as this will increase the chance of success of the use case. |
-| W2W_13 | A Verifier Wallet Unit SHALL provide the Verifier, through a user-friendly UI, with the possibility to select the attributes that will be included in the presentation request. |
-| W2W_14 | For the purposes of W2W_07, if the Verifier Wallet Unit received a presentation offer, it SHALL present this offer to the Verifier, and enable the Verifier to include one or more of the attributes in the offer into the presentation request. However, the Verifier Wallet Unit SHALL NOT allow the Verifier to include any attribute not present in the offer. |
-| W2W_15 | For the purposes of W2W_07, if the Verifier Wallet Unit did not receive a presentation offer, it SHALL present the Verifier with a list of attributes that can be included in the presentation request. The Verifier Wallet Unit MAY ask the Verifier some questions about the purpose of the use case to narrow down the list. |
-| W2W_16 | A Verifier Wallet Unit SHALL authenticate the Verifier and SHALL obtain the Verifier's approval prior to sending a presentation request to a Holder Wallet Unit. |
-| W2W_17 | A Verifier Wallet Unit SHALL implement measures to limit the number of presentation requests it can send per unit of time, to prevent abuse of the Wallet-to-Wallet functionality by Relying Parties. The limitation strategy, for instance exponential backoff time between subsequent presentation requests or hard limits for the number of requests, SHALL be decided by the Wallet Provider, based on applicable requirements in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md). |
-| W2W_18 | Empty |
-| W2W_19 | When receiving a presentation response, a Verifier Wallet SHALL verify the received attestation according to requirements OIA_12 - OIA_15 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit). |
-| W2W_20 | A Verifier Wallet Unit SHALL display all verified attributes to the Verifier. |
-| W2W_21 | A Verifier Wallet Unit SHALL NOT persistently store any attestations or attributes received. A Verifier Wallet Unit SHOULD minimise the time the received presentation is stored in memory. A Verifier Wallet Unit SHALL comply with OIA_16 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit). |
-| W2W_22 | Wallet Providers SHOULD take measures to prevent a User from taking screenshots while their Wallet Unit is acting as a Verifier Wallet Unit. |
+<div class="eudi-hlr" id="W2W_01" markdown>
+<div class="eudi-hlr__id">W2W_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL be able to act as a Holder Wallet Unit, in accordance with all requirements in this Topic.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_02" markdown>
+<div class="eudi-hlr__id">W2W_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When acting as a Holder Wallet Unit, if there is a contradiction between a requirement for Holder Wallet Units in this Topic and any requirement for Wallet Units in other Topics in this document, the requirement in this Topic SHALL take precedence. However, when acting as a Holder Wallet Unit, a Wallet Unit SHALL comply with all requirements for Wallet Units in other Topics in this document that do not contradict any requirement in this Topic.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_03" markdown>
+<div class="eudi-hlr__id">W2W_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL be able to act as a Verifier Wallet Unit, in accordance with all requirements in this Topic.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_04" markdown>
+<div class="eudi-hlr__id">W2W_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When acting as a Verifier Wallet Unit, a Wallet Unit SHALL NOT comply with any requirement for Wallet Units in other Topics in this document.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_05" markdown>
+<div class="eudi-hlr__id">W2W_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL act as a Holder Wallet Unit only if the User selects a 'Holder Wallet Unit mode'. If the User closes the Wallet Unit, or after a period of non-activity, the Wallet Unit SHALL return to 'normal' mode.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_06" markdown>
+<div class="eudi-hlr__id">W2W_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When entering the Holder Wallet Unit mode, a Wallet Unit SHALL inform its User that this mode should only be used for interactions with natural persons using a Wallet Unit, and that the User should not proceed if they are in fact interacting with a Relying Party.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_07" markdown>
+<div class="eudi-hlr__id">W2W_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL act as a Verifier Wallet Unit only if the User selects a 'Verifier Wallet Unit mode'. If the User closes the Wallet Unit, or after a period of non-activity, the Wallet Unit SHALL return to 'normal' mode.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_08" markdown>
+<div class="eudi-hlr__id">W2W_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Verifier Wallet Unit and a Holder Wallet Unit SHALL support attestation presentation only in proximity, meaning they SHALL support only [ISO/IEC 18013-5] to communicate.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_09" markdown>
+<div class="eudi-hlr__id">W2W_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Holder Wallet Units SHALL comply with the requirements for mDLs and for mdocs in ISO/IEC 18013-5, unless specified differently in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_10" markdown>
+<div class="eudi-hlr__id">W2W_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Verifier Wallet Units SHALL comply with the requirements for mDL readers and for mdoc readers in ISO/IEC 18013-5, unless specified differently in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_11" markdown>
+<div class="eudi-hlr__id">W2W_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Holder Wallet Unit SHOULD provide the Holder, through a user-friendly UI, with the option to inform the Verifier Wallet Unit about the attributes which the Verifier should include in the presentation request, by sending a presentation offer. If the Holder creates a presentation offer, the Holder Wallet Unit SHALL transfer it to the Verifier Wallet Unit as specified in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).
+
+*Note: TS9 specifies an extension of the device engagement structure specified in ISO/IEC 18013-5.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_12" markdown>
+<div class="eudi-hlr__id">W2W_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Holder Wallet Unit SHALL recommend the Holder to create a presentation offer, as this will increase the chance of success of the use case.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_13" markdown>
+<div class="eudi-hlr__id">W2W_13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Verifier Wallet Unit SHALL provide the Verifier, through a user-friendly UI, with the possibility to select the attributes that will be included in the presentation request.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_14" markdown>
+<div class="eudi-hlr__id">W2W_14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the purposes of W2W_07, if the Verifier Wallet Unit received a presentation offer, it SHALL present this offer to the Verifier, and enable the Verifier to include one or more of the attributes in the offer into the presentation request. However, the Verifier Wallet Unit SHALL NOT allow the Verifier to include any attribute not present in the offer.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_15" markdown>
+<div class="eudi-hlr__id">W2W_15<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the purposes of W2W_07, if the Verifier Wallet Unit did not receive a presentation offer, it SHALL present the Verifier with a list of attributes that can be included in the presentation request. The Verifier Wallet Unit MAY ask the Verifier some questions about the purpose of the use case to narrow down the list.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_16" markdown>
+<div class="eudi-hlr__id">W2W_16<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Verifier Wallet Unit SHALL authenticate the Verifier and SHALL obtain the Verifier's approval prior to sending a presentation request to a Holder Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_17" markdown>
+<div class="eudi-hlr__id">W2W_17<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Verifier Wallet Unit SHALL implement measures to limit the number of presentation requests it can send per unit of time, to prevent abuse of the Wallet-to-Wallet functionality by Relying Parties. The limitation strategy, for instance exponential backoff time between subsequent presentation requests or hard limits for the number of requests, SHALL be decided by the Wallet Provider, based on applicable requirements in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_18" markdown>
+<div class="eudi-hlr__id">W2W_18</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_19" markdown>
+<div class="eudi-hlr__id">W2W_19<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When receiving a presentation response, a Verifier Wallet SHALL verify the received attestation according to requirements OIA_12 - OIA_15 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_20" markdown>
+<div class="eudi-hlr__id">W2W_20<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Verifier Wallet Unit SHALL display all verified attributes to the Verifier.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_21" markdown>
+<div class="eudi-hlr__id">W2W_21<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Verifier Wallet Unit SHALL NOT persistently store any attestations or attributes received. A Verifier Wallet Unit SHOULD minimise the time the received presentation is stored in memory. A Verifier Wallet Unit SHALL comply with OIA_16 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="W2W_22" markdown>
+<div class="eudi-hlr__id">W2W_22<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHOULD take measures to prevent a User from taking screenshots while their Wallet Unit is acting as a Verifier Wallet Unit.
+
+</div>
+</div>
+
 
 #### A.2.3.20 Topic 31 - Notification and publication of PID Provider, Wallet Provider, Attestation Provider, Access Certificate Authority, and Provider of registration certificates
 
 ##### A. Generic requirements for notification <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| GenNot_01 | Member States SHALL notify all PID Providers, PuB-EAA Providers, Wallet Providers, Access Certificate Authorities, and Providers of registration certificates to the European Commission, using a common system provided by the Commission, complying with all relevant requirements in[Technical Specification 2](../../technical-specifications/ts2-notification-publication-provider-information.md). |
-| GenNot_02 | In addition to [Technical Specification 2] referred to in GenNot_01, the European Commission SHALL establish standard operating procedures for the notification of a PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority, or Provider of registration certificates to the Commission. *Note: The outcome of the notification procedure is the publication of the information notified by the Member State according to [Article 5a](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e1347-1-1) (18) in a machine and human readable manner using the common system mentioned in Section H, TLPub_01.* |
-| GenNot_03 | The common system mentioned in GenNot_01 SHALL enable: - A secure notification channel between Member States and the Commission for all notifications. - A notification, verification, and publication process and associated validation steps (with follow-up and monitoring) at the Commission side. - Collected data to be processed, consolidated, signed or sealed, and published in both a machine-processable Trusted List or LoTE and in a human-readable format, manually and/or automatically using e.g. a web service and/or API. |
-| GenNot_04 | Empty |
-| GenNot_05 | In addition to [Technical Specification 2] referred to in GenNot_01, the European Commission SHALL establish standard operating procedures for the suspension or cancellation of a PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority, or Provider of registration certificates. These operating procedures SHALL include unambiguous conditions for suspension or cancellation. As an outcome of the suspension or cancellation procedure, the status of the suspended or cancelled PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority or Provider of registration certificates in the respective LoTE or Trusted List SHALL be changed to Invalid. |
+<div class="eudi-hlr" id="GenNot_01" markdown>
+<div class="eudi-hlr__id">GenNot_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Member States SHALL notify all PID Providers, PuB-EAA Providers, Wallet Providers, Access Certificate Authorities, and Providers of registration certificates to the European Commission, using a common system provided by the Commission, complying with all relevant requirements in[Technical Specification 2](../../technical-specifications/ts2-notification-publication-provider-information.md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="GenNot_02" markdown>
+<div class="eudi-hlr__id">GenNot_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+In addition to [Technical Specification 2] referred to in GenNot_01, the European Commission SHALL establish standard operating procedures for the notification of a PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority, or Provider of registration certificates to the Commission.
+
+*Note: The outcome of the notification procedure is the publication of the information notified by the Member State according to [Article 5a](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e1347-1-1) (18) in a machine and human readable manner using the common system mentioned in Section H, TLPub_01.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="GenNot_03" markdown>
+<div class="eudi-hlr__id">GenNot_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The common system mentioned in GenNot_01 SHALL enable: - A secure notification channel between Member States and the Commission for all notifications. - A notification, verification, and publication process and associated validation steps (with follow-up and monitoring) at the Commission side. - Collected data to be processed, consolidated, signed or sealed, and published in both a machine-processable Trusted List or LoTE and in a human-readable format, manually and/or automatically using e.g. a web service and/or API.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="GenNot_04" markdown>
+<div class="eudi-hlr__id">GenNot_04</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="GenNot_05" markdown>
+<div class="eudi-hlr__id">GenNot_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+In addition to [Technical Specification 2] referred to in GenNot_01, the European Commission SHALL establish standard operating procedures for the suspension or cancellation of a PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority, or Provider of registration certificates. These operating procedures SHALL include unambiguous conditions for suspension or cancellation. As an outcome of the suspension or cancellation procedure, the status of the suspended or cancelled PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority or Provider of registration certificates in the respective LoTE or Trusted List SHALL be changed to Invalid.
+
+</div>
+</div>
+
 
 ##### B. Requirements for the notification of PID Providers <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| PPNot_01 | Empty |
-| PPNot_02 | The common set of information to be notified about a PID Provider SHALL include at least: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. A business registration number from an official record, b. Identification data from that official record. 2. PID Provider trust anchors, i.e., public keys and name as per point 1) ii) above, supporting the authentication of PIDs issued by the PID Provider, 3. Trust anchors of Access Certificate Authorities for PID Providers, i.e., public keys and CA name, supporting the authentication of the PID Provider by Wallet Units at the service supply point(s) listed per point 4. below. 4. Service supply point(s), i.e., the URL(s) at which a Wallet Unit can start the process of requesting and obtaining a PID. *Note: a) Relating to point 3. above: PID Provider Access Certificate Authority trust anchors are notified separately from the Access Certificate Authority for Relying Parties (see Section G below), since PID Providers are -legally speaking- not Relying Parties. b) For the concept of an Access Certificate Authority, see also [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)] and [Section 6.3.2 of the ARF main document](../../architecture-and-reference-framework-main.md#632-pid-provider-or-attestation-provider-registration-and-notification).* |
-| PPNot_03 | PID Providers SHALL ensure that all PIDs they issue can be authenticated using the PID Provider trust anchors notified to the Commission. |
-| PPNot_04 | PID Providers SHALL ensure that their access certificates can be authenticated using the applicable Access Certificate Authority trust anchors notified to the Commission. *Note: [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] describes how access certificates will be used.* |
-| PPNot_05 | Wallet Units, Relying Parties, and other relevant actors SHALL accept PID Provider trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled PID Provider LoTE, which is sealed by the Commission. |
-| PPNot_06 | Wallet Units and other relevant actors SHALL accept Access Certificate Authority trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled LoTE, which is signed or sealed by the Commission. |
-| PPNot_07 | The format of a PID Provider LoTE SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex D. |
+<div class="eudi-hlr" id="PPNot_01" markdown>
+<div class="eudi-hlr__id">PPNot_01</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PPNot_02" markdown>
+<div class="eudi-hlr__id">PPNot_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The common set of information to be notified about a PID Provider SHALL include at least: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. A business registration number from an official record, b. Identification data from that official record. 2. PID Provider trust anchors, i.e., public keys and name as per point 1) ii) above, supporting the authentication of PIDs issued by the PID Provider, 3. Trust anchors of Access Certificate Authorities for PID Providers, i.e., public keys and CA name, supporting the authentication of the PID Provider by Wallet Units at the service supply point(s) listed per point 4. below. 4. Service supply point(s), i.e., the URL(s) at which a Wallet Unit can start the process of requesting and obtaining a PID.
+
+*Note: a) Relating to point 3. above: PID Provider Access Certificate Authority trust anchors are notified separately from the Access Certificate Authority for Relying Parties (see Section G below), since PID Providers are -legally speaking- not Relying Parties. b) For the concept of an Access Certificate Authority, see also [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)] and [Section 6.3.2 of the ARF main document](../../architecture-and-reference-framework-main.md#632-pid-provider-or-attestation-provider-registration-and-notification).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PPNot_03" markdown>
+<div class="eudi-hlr__id">PPNot_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+PID Providers SHALL ensure that all PIDs they issue can be authenticated using the PID Provider trust anchors notified to the Commission.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PPNot_04" markdown>
+<div class="eudi-hlr__id">PPNot_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+PID Providers SHALL ensure that their access certificates can be authenticated using the applicable Access Certificate Authority trust anchors notified to the Commission.
+
+*Note: [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] describes how access certificates will be used.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PPNot_05" markdown>
+<div class="eudi-hlr__id">PPNot_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Units, Relying Parties, and other relevant actors SHALL accept PID Provider trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled PID Provider LoTE, which is sealed by the Commission.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PPNot_06" markdown>
+<div class="eudi-hlr__id">PPNot_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Units and other relevant actors SHALL accept Access Certificate Authority trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled LoTE, which is signed or sealed by the Commission.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PPNot_07" markdown>
+<div class="eudi-hlr__id">PPNot_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The format of a PID Provider LoTE SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex D.
+
+</div>
+</div>
+
 
 ##### C. Requirements for the notification of Wallet Providers <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WPNot_01 | Empty |
-| WPNot_02 | The common set of information to be notified about a Wallet Provider SHALL include: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. Business registration number from an official record, and b. Identification data from the official record. 2. Wallet Provider trust anchors, i.e., public keys and name as per point 1. b. above, supporting the authentication of Key Attestations and Wallet Instance Attestations issued by the Wallet Provider. 3. Name and reference number of the certified Wallet Solution(s) provided by the Wallet Provider. *Note: a) See [[Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)] and [[Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation)] for the definition of the KA and WIA. b) A Wallet Provider does not need an access certificate to interact with Wallet Units.* |
-| WPNot_03 | Wallet Providers SHALL ensure that all WIAs and KAs they issue can be authenticated using the trust anchors notified to the Commission. |
-| WPNot_04 | PID Providers, Attestation Providers and other relevant actors SHALL accept Wallet Provider trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled Wallet Provider LoTE, which is sealed by the Commission. |
-| WPNot_05 | The format of a Wallet Provider LoTE SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex E. |
-| WPNot_06 | If a Wallet Provider is cancelled (see requirement GenNot_05 above), that Wallet Provider SHALL immediately revoke all of its Wallet Instances and all associated WSCDs and keystores, in accordance with the requirements in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation). If a Wallet Provider is suspended, that Wallet Provider and the Member State SHALL agree on the necessary precautionary measures that need to be taken, which MAY include the immediate revocation of the Wallet Instances and WSCDs or keystores for all or some of its valid Wallet Units. |
+<div class="eudi-hlr" id="WPNot_01" markdown>
+<div class="eudi-hlr__id">WPNot_01</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WPNot_02" markdown>
+<div class="eudi-hlr__id">WPNot_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The common set of information to be notified about a Wallet Provider SHALL include: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. Business registration number from an official record, and b. Identification data from the official record. 2. Wallet Provider trust anchors, i.e., public keys and name as per point 1. b. above, supporting the authentication of Key Attestations and Wallet Instance Attestations issued by the Wallet Provider. 3. Name and reference number of the certified Wallet Solution(s) provided by the Wallet Provider.
+
+*Note: a) See [[Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)] and [[Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation)] for the definition of the KA and WIA. b) A Wallet Provider does not need an access certificate to interact with Wallet Units.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WPNot_03" markdown>
+<div class="eudi-hlr__id">WPNot_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that all WIAs and KAs they issue can be authenticated using the trust anchors notified to the Commission.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WPNot_04" markdown>
+<div class="eudi-hlr__id">WPNot_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+PID Providers, Attestation Providers and other relevant actors SHALL accept Wallet Provider trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled Wallet Provider LoTE, which is sealed by the Commission.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WPNot_05" markdown>
+<div class="eudi-hlr__id">WPNot_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The format of a Wallet Provider LoTE SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex E.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WPNot_06" markdown>
+<div class="eudi-hlr__id">WPNot_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Provider is cancelled (see requirement GenNot_05 above), that Wallet Provider SHALL immediately revoke all of its Wallet Instances and all associated WSCDs and keystores, in accordance with the requirements in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation). If a Wallet Provider is suspended, that Wallet Provider and the Member State SHALL agree on the necessary precautionary measures that need to be taken, which MAY include the immediate revocation of the Wallet Instances and WSCDs or keystores for all or some of its valid Wallet Units.
+
+</div>
+</div>
+
 
 ##### D. Requirements for the notification of PuB-EAA Providers <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| PuBPNot_01 | Empty |
-| PuBPNot_02 | The common set of information to be notified by Member States about PuB-EAA Providers SHALL include at least: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. Registration number as in official record, and b. Official record identification data. iv. Identification data of the Union or national law under which a. Either the PuB-EAA Provider is established as the responsible body for the Authentic Source based on which the electronic attestation of attributes is issued, or b. The PuB-EAA Provider is the body designated to act on behalf of the responsible body referred to in point 1. iv. a. v.The conformity assessment report issued by a conformity assessment body, confirming that the requirements set out in paragraphs 1, 2 and 6 of [Article 45f](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e3902-1-1) are met. 2. PuB-EAA Provider trust anchors, i.e., public keys and name as per point 1) ii) above, supporting the authentication of PuB-EAAs issued by the PuB-EAA Provider, 3. Service supply point(s), i.e., the URL(s) at which a Wallet Unit can start the process of requesting and obtaining a PuB-EAA from the PuB-EAA Provider. |
-| PuBPNot_03 | The format of the PuB-EAA Provider Trusted List SHALL comply with [ETSI TS 119 612] v2.1.1. |
+<div class="eudi-hlr" id="PuBPNot_01" markdown>
+<div class="eudi-hlr__id">PuBPNot_01</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PuBPNot_02" markdown>
+<div class="eudi-hlr__id">PuBPNot_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The common set of information to be notified by Member States about PuB-EAA Providers SHALL include at least: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. Registration number as in official record, and b. Official record identification data. iv. Identification data of the Union or national law under which a. Either the PuB-EAA Provider is established as the responsible body for the Authentic Source based on which the electronic attestation of attributes is issued, or b. The PuB-EAA Provider is the body designated to act on behalf of the responsible body referred to in point 1. iv. a. v.The conformity assessment report issued by a conformity assessment body, confirming that the requirements set out in paragraphs 1, 2 and 6 of [Article 45f](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e3902-1-1) are met. 2. PuB-EAA Provider trust anchors, i.e., public keys and name as per point 1) ii) above, supporting the authentication of PuB-EAAs issued by the PuB-EAA Provider, 3. Service supply point(s), i.e., the URL(s) at which a Wallet Unit can start the process of requesting and obtaining a PuB-EAA from the PuB-EAA Provider.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PuBPNot_03" markdown>
+<div class="eudi-hlr__id">PuBPNot_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The format of the PuB-EAA Provider Trusted List SHALL comply with [ETSI TS 119 612] v2.1.1.
+
+</div>
+</div>
+
 
 ##### E. Requirements for the notification of Access Certificate Authorities and Providers of registration certificates <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| RPACANot_01 | Empty |
-| RPACANot_02 | The common set of information to be notified about an Access Certificate Authority or a Provider of registration certificates SHALL include: 1. Identification data: i) Member State or country of establishment, ii) Name as registered in an official record, iii) Where applicable: - A business registration number from an official record, - Identification data from that official record. 2. Trust anchors of the Access Certificate Authority or Provider of registration certificates, i.e., public keys and name as per point 1) ii), supporting the authentication of access certificates and registration certificates by Wallet Units. |
-| RPACANot_03 | Relying Parties, PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers SHALL ensure that their access certificates can be authenticated using the trust anchors of an Access Certificate Authority notified to the Commission. |
-| RPACANot_03a | Relying Parties, PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers SHALL ensure that their registration certificates, if issued to them, can be authenticated using the trust anchors of a Provider of registration certificates notified to the Commission. |
-| RPACANot_04 | The trust anchors of Access Certificate Authorities and Providers of registration certificates SHALL be accepted because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled LoTEs, which are signed or sealed by the Commission. |
-| RPACANot_05 | The format of a LoTE for Access Certificate Authorities SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex F. |
-| RPACANot_05a | The format of a LoTE for Providers of registration certificates SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex G. |
-| RPACANot_06 | If an Access Certificate Authority is suspended or cancelled (see requirement GenNot_05 above), that Access Certificate Authority SHALL immediately revoke all of its temporally valid access certificates. *Note: This implies that if an intermediary obtained its access certificates from an Access Certificate Authority that is suspended or cancelled, any intermediated Relying Party depending on that intermediary will not be able to request attributes from Wallet Units, even though its registration is still valid. Such an intermediated Relying Party will either have to transit to another intermediary (which has access certificates issued by an active Access Certification Authority) or wait until the original intermediary obtains new access certificates either from another Access CA or from the original one, once that CA can continue its operations.* |
-| RPACANot_07 | If a Provider of registration certificates is suspended or cancelled (see requirement GenNot_05 above), that Provider SHALL immediately revoke all of its valid registration certificates (if any). Moreover, the corresponding Registrar SHALL prohibit all access to the registry entries published online per Reg_03 and Reg_04. |
+<div class="eudi-hlr" id="RPACANot_01" markdown>
+<div class="eudi-hlr__id">RPACANot_01</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPACANot_02" markdown>
+<div class="eudi-hlr__id">RPACANot_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The common set of information to be notified about an Access Certificate Authority or a Provider of registration certificates SHALL include: 1. Identification data: i) Member State or country of establishment, ii) Name as registered in an official record, iii) Where applicable: - A business registration number from an official record, - Identification data from that official record. 2. Trust anchors of the Access Certificate Authority or Provider of registration certificates, i.e., public keys and name as per point 1) ii), supporting the authentication of access certificates and registration certificates by Wallet Units.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPACANot_03" markdown>
+<div class="eudi-hlr__id">RPACANot_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Relying Parties, PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers SHALL ensure that their access certificates can be authenticated using the trust anchors of an Access Certificate Authority notified to the Commission.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPACANot_03a" markdown>
+<div class="eudi-hlr__id">RPACANot_03a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Relying Parties, PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers SHALL ensure that their registration certificates, if issued to them, can be authenticated using the trust anchors of a Provider of registration certificates notified to the Commission.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPACANot_04" markdown>
+<div class="eudi-hlr__id">RPACANot_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The trust anchors of Access Certificate Authorities and Providers of registration certificates SHALL be accepted because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled LoTEs, which are signed or sealed by the Commission.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPACANot_05" markdown>
+<div class="eudi-hlr__id">RPACANot_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The format of a LoTE for Access Certificate Authorities SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex F.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPACANot_05a" markdown>
+<div class="eudi-hlr__id">RPACANot_05a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The format of a LoTE for Providers of registration certificates SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex G.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPACANot_06" markdown>
+<div class="eudi-hlr__id">RPACANot_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If an Access Certificate Authority is suspended or cancelled (see requirement GenNot_05 above), that Access Certificate Authority SHALL immediately revoke all of its temporally valid access certificates.
+
+*Note: This implies that if an intermediary obtained its access certificates from an Access Certificate Authority that is suspended or cancelled, any intermediated Relying Party depending on that intermediary will not be able to request attributes from Wallet Units, even though its registration is still valid. Such an intermediated Relying Party will either have to transit to another intermediary (which has access certificates issued by an active Access Certification Authority) or wait until the original intermediary obtains new access certificates either from another Access CA or from the original one, once that CA can continue its operations.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPACANot_07" markdown>
+<div class="eudi-hlr__id">RPACANot_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Provider of registration certificates is suspended or cancelled (see requirement GenNot_05 above), that Provider SHALL immediately revoke all of its valid registration certificates (if any). Moreover, the corresponding Registrar SHALL prohibit all access to the registry entries published online per Reg_03 and Reg_04.
+
+</div>
+</div>
+
 
 ##### F. Requirements for the publication of Trusted Lists and LoTEs compiled by the Commission <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| TLPub_01 | The European Commission SHALL establish technical specifications for the system enabling the publication by the Commission of the information notified by the Member States regarding PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities, and Providers of registration certificates. |
-| TLPub_02 | The European Commission SHALL establish technical specifications for the set of information to be published about PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities and Providers of registration certificates, based on the information notified by the Member States. *Note: The information to be published MAY be different from the information to be notified for each of these entities.* |
-| TLPub_03 | The publication of the information referred to in TLPub_01 SHALL take place over a secure channel protecting the authenticity and integrity of the published information. |
-| TLPub_04 | The technical system mentioned in TLPub_01 SHALL NOT require authentication or prior registration and authorisation of any entity wishing to retrieve the published information. |
-| TLPub_05 | The information referred to in TLPub_01 SHALL be published in an electronically signed or sealed form that is suitable for automated processing, and in a human-readable format, e.g., through introspection and display facilities, over an authenticated channel. |
-| TLPub_06 | The Commission SHALL publish in the OJEU the locations of the LoTEs for PID Providers, Wallet Providers, Access Certificate Authorities, and Providers of registration certificates, as well as the location of the Trusted List(s) of PuB-EAA Providers. |
-| TLPub_07 | The Commission SHALL publish in the OJEU the trust anchors to be used for verifying the signature or seal mentioned in TLPub_05. |
+<div class="eudi-hlr" id="TLPub_01" markdown>
+<div class="eudi-hlr__id">TLPub_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The European Commission SHALL establish technical specifications for the system enabling the publication by the Commission of the information notified by the Member States regarding PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities, and Providers of registration certificates.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="TLPub_02" markdown>
+<div class="eudi-hlr__id">TLPub_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The European Commission SHALL establish technical specifications for the set of information to be published about PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities and Providers of registration certificates, based on the information notified by the Member States.
+
+*Note: The information to be published MAY be different from the information to be notified for each of these entities.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="TLPub_03" markdown>
+<div class="eudi-hlr__id">TLPub_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The publication of the information referred to in TLPub_01 SHALL take place over a secure channel protecting the authenticity and integrity of the published information.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="TLPub_04" markdown>
+<div class="eudi-hlr__id">TLPub_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The technical system mentioned in TLPub_01 SHALL NOT require authentication or prior registration and authorisation of any entity wishing to retrieve the published information.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="TLPub_05" markdown>
+<div class="eudi-hlr__id">TLPub_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The information referred to in TLPub_01 SHALL be published in an electronically signed or sealed form that is suitable for automated processing, and in a human-readable format, e.g., through introspection and display facilities, over an authenticated channel.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="TLPub_06" markdown>
+<div class="eudi-hlr__id">TLPub_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Commission SHALL publish in the OJEU the locations of the LoTEs for PID Providers, Wallet Providers, Access Certificate Authorities, and Providers of registration certificates, as well as the location of the Trusted List(s) of PuB-EAA Providers.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="TLPub_07" markdown>
+<div class="eudi-hlr__id">TLPub_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Commission SHALL publish in the OJEU the trust anchors to be used for verifying the signature or seal mentioned in TLPub_05.
+
+</div>
+</div>
+
 
 ##### G. Requirements for the publication of Trusted Lists compiled by the Commission <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| TLPub_08 | As part of the specifications referred to in TLPub_01, the European Commission SHALL establish technical specifications for ensuring the availability and authenticity of the full history regarding the information notified about PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities, and Providers of registration certificates. |
+<div class="eudi-hlr" id="TLPub_08" markdown>
+<div class="eudi-hlr__id">TLPub_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+As part of the specifications referred to in TLPub_01, the European Commission SHALL establish technical specifications for ensuring the availability and authenticity of the full history regarding the information notified about PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities, and Providers of registration certificates.
+
+</div>
+</div>
+
 
 #### A.2.3.21 Topic 34 - Migrate to a different Wallet Solution
 
 ##### A. Back-up requirements <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| Mig_01 | A Wallet Unit SHALL include and keep up-to-date a Migration Object, containing the following information: - The contents of the log for all transactions executed through the Wallet Unit, as listed in requirement DASH_02. - A list of PIDs and attestations (except Key Attestations and Wallet Instance Attestations) present in the Wallet Unit, according to the requirements in this Topic. |
-| Mig_02 | The Migration Object SHALL comply with all requirements in [Technical Specification 10](../../technical-specifications/ts10-data-portability-and-download-(export).md). |
-| Mig_03 | For each PID or device-bound attestation that is issued to it, a Wallet Unit SHALL add to the Migration Object all data necessary to request issuance of that PID or attestation once again. This SHALL include at least the attestation type and the PID Provider or Attestation Provider that issued the PID or attestation, as well as their service supply points. However, the Migration Object SHALL NOT contain attribute identifiers or attribute values, and SHALL NOT contain any private keys of the PID or device-bound attestation. |
-| Mig_03a | For each non-device-bound attestation that is issued to it, a Wallet Unit SHALL add to the Migration Object one of the following: either all data necessary to request issuance of that attestation once again, as listed in Mig_03, or all data necessary to transfer the attestation to a new device without involvement of the Attestation Provider, including attribute identifiers and attribute values. The Wallet Unit SHALL enable the User to indicate if they want to store attribute identifiers and values in the Migration Object. |
-| Mig_03b | If the User deletes a PID or attestation from their Wallet Unit, the Wallet Unit SHALL delete the corresponding entry from the Migration Object. |
-| Mig_04 | The Wallet Unit SHALL store the Migration Object in an external storage or remote storage location of the User's choice, from among the storage options supported by the Wallet Unit, in such a way that the User can still retrieve the object from a new Wallet Unit in case the existing Wallet Unit becomes unavailable. *Note: a) It is up to the Wallet Provider to decide which external storage options or remote storage locations the Wallet Unit supports for storing the Migration Object. b) The new Wallet Unit may be either an instance of the same Wallet Solution as the old one, or an instance of a different Wallet Solution.* |
-| Mig_05 | The Wallet Unit SHALL store the Migration Object in such a way that its confidentiality, integrity, and authenticity is protected and that it is protected against use by others than the User. *Note: This could be done, for example, by using password-based cryptography to encrypt the object.* |
+<div class="eudi-hlr" id="Mig_01" markdown>
+<div class="eudi-hlr__id">Mig_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL include and keep up-to-date a Migration Object, containing the following information: - The contents of the log for all transactions executed through the Wallet Unit, as listed in requirement DASH_02. - A list of PIDs and attestations (except Key Attestations and Wallet Instance Attestations) present in the Wallet Unit, according to the requirements in this Topic.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_02" markdown>
+<div class="eudi-hlr__id">Mig_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Migration Object SHALL comply with all requirements in [Technical Specification 10](../../technical-specifications/ts10-data-portability-and-download-(export).md).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_03" markdown>
+<div class="eudi-hlr__id">Mig_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For each PID or device-bound attestation that is issued to it, a Wallet Unit SHALL add to the Migration Object all data necessary to request issuance of that PID or attestation once again. This SHALL include at least the attestation type and the PID Provider or Attestation Provider that issued the PID or attestation, as well as their service supply points. However, the Migration Object SHALL NOT contain attribute identifiers or attribute values, and SHALL NOT contain any private keys of the PID or device-bound attestation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_03a" markdown>
+<div class="eudi-hlr__id">Mig_03a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For each non-device-bound attestation that is issued to it, a Wallet Unit SHALL add to the Migration Object one of the following: either all data necessary to request issuance of that attestation once again, as listed in Mig_03, or all data necessary to transfer the attestation to a new device without involvement of the Attestation Provider, including attribute identifiers and attribute values. The Wallet Unit SHALL enable the User to indicate if they want to store attribute identifiers and values in the Migration Object.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_03b" markdown>
+<div class="eudi-hlr__id">Mig_03b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the User deletes a PID or attestation from their Wallet Unit, the Wallet Unit SHALL delete the corresponding entry from the Migration Object.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_04" markdown>
+<div class="eudi-hlr__id">Mig_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL store the Migration Object in an external storage or remote storage location of the User's choice, from among the storage options supported by the Wallet Unit, in such a way that the User can still retrieve the object from a new Wallet Unit in case the existing Wallet Unit becomes unavailable.
+
+*Note: a) It is up to the Wallet Provider to decide which external storage options or remote storage locations the Wallet Unit supports for storing the Migration Object. b) The new Wallet Unit may be either an instance of the same Wallet Solution as the old one, or an instance of a different Wallet Solution.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_05" markdown>
+<div class="eudi-hlr__id">Mig_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL store the Migration Object in such a way that its confidentiality, integrity, and authenticity is protected and that it is protected against use by others than the User.
+
+*Note: This could be done, for example, by using password-based cryptography to encrypt the object.*
+
+</div>
+</div>
+
 
 ##### B. Restore Requirements <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| Mig_06 | Directly after installation of a new Wallet Instance, the Wallet Instance SHALL enable the User to import a Migration Object from an external storage or remote storage location indicated by the User, from among the storage options supported by the Wallet Unit. |
-| Mig_07 | When importing a Migration Object, for each PID and device-bound attestation listed in the Migration Object, the Wallet Unit SHALL enable the User to select that PID or attestation. When a PID or device-bound attestation is selected, the Wallet Unit SHALL request the respective PID Provider or Attestation Provider to issue a new PID or attestation of the same type  to the new Wallet Unit. If the User selects a PID, the Wallet Unit SHALL request issuance of the PID first, before any of the other selected attestations. *Note: a) Since no refresh tokens (see ISSU_65) will be available on the new Wallet Unit, this is a new issuance process, which will include User authentication by the PID Provider or Attestation Provider. b) The rationale for the last requirement is to ensure that if other Attestation Providers want to use a PID to do User authentication, the PID is actually available.* |
-| Mig_07a | When importing a Migration Object, for each non-device-bound attestation listed in the Migration Object, the Wallet Unit SHALL enable the User to select that attestation. When an attestation is selected, the Wallet Unit SHALL, depending on whether the Migration Object contains attribute identifiers and attribute values (see Mig_03a), either restore the technical attestation directly from the Object or request the respective Attestation Provider to issue a new attestation of the same type to the new Wallet Unit. |
-| Mig_07b | When importing a Migration Object, the Wallet Unit SHALL ask the User whether they want to restore the log from the Migration Object. When the User agrees, the Wallet Unit SHALL restore the log, and SHALL append future transactions to this log according to the requirements in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency). |
-| Mig_08 | Empty |
-| Mig_09 | Empty |
-| Mig_10 | Empty |
-| Mig_11 | The processes and interfaces used for issuance of a PID or attestation as part of a migration process SHALL be the same as those used for a 'normal' issuance process, as specified in [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit). |
-| Mig_12 | Empty |
-| Mig_13 | Empty |
-| Mig_14 | Empty |
-| Mig_15 | Empty |
-| Mig_16 | Empty |
+<div class="eudi-hlr" id="Mig_06" markdown>
+<div class="eudi-hlr__id">Mig_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Directly after installation of a new Wallet Instance, the Wallet Instance SHALL enable the User to import a Migration Object from an external storage or remote storage location indicated by the User, from among the storage options supported by the Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_07" markdown>
+<div class="eudi-hlr__id">Mig_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When importing a Migration Object, for each PID and device-bound attestation listed in the Migration Object, the Wallet Unit SHALL enable the User to select that PID or attestation. When a PID or device-bound attestation is selected, the Wallet Unit SHALL request the respective PID Provider or Attestation Provider to issue a new PID or attestation of the same type  to the new Wallet Unit. If the User selects a PID, the Wallet Unit SHALL request issuance of the PID first, before any of the other selected attestations.
+
+*Note: a) Since no refresh tokens (see ISSU_65) will be available on the new Wallet Unit, this is a new issuance process, which will include User authentication by the PID Provider or Attestation Provider. b) The rationale for the last requirement is to ensure that if other Attestation Providers want to use a PID to do User authentication, the PID is actually available.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_07a" markdown>
+<div class="eudi-hlr__id">Mig_07a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When importing a Migration Object, for each non-device-bound attestation listed in the Migration Object, the Wallet Unit SHALL enable the User to select that attestation. When an attestation is selected, the Wallet Unit SHALL, depending on whether the Migration Object contains attribute identifiers and attribute values (see Mig_03a), either restore the technical attestation directly from the Object or request the respective Attestation Provider to issue a new attestation of the same type to the new Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_07b" markdown>
+<div class="eudi-hlr__id">Mig_07b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When importing a Migration Object, the Wallet Unit SHALL ask the User whether they want to restore the log from the Migration Object. When the User agrees, the Wallet Unit SHALL restore the log, and SHALL append future transactions to this log according to the requirements in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_08" markdown>
+<div class="eudi-hlr__id">Mig_08</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_09" markdown>
+<div class="eudi-hlr__id">Mig_09</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_10" markdown>
+<div class="eudi-hlr__id">Mig_10</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_11" markdown>
+<div class="eudi-hlr__id">Mig_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The processes and interfaces used for issuance of a PID or attestation as part of a migration process SHALL be the same as those used for a 'normal' issuance process, as specified in [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_12" markdown>
+<div class="eudi-hlr__id">Mig_12</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_13" markdown>
+<div class="eudi-hlr__id">Mig_13</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_14" markdown>
+<div class="eudi-hlr__id">Mig_14</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_15" markdown>
+<div class="eudi-hlr__id">Mig_15</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="Mig_16" markdown>
+<div class="eudi-hlr__id">Mig_16</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 #### A.2.3.22 Topic 38 - Wallet Unit revocation
 
 ##### A. Issuing a Wallet Unit Attestation <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WURevocation_01 | To enable a PID Provider or an Attestation Provider to verify the authenticity and the revocation status of a Wallet Unit it is interacting with, a Wallet Provider SHALL issue one or more Key Attestations (KA) and Wallet Instance Attestations (WIA) to the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation). *Note: The first of these KAs and WIAs will be issued during the activation phase of a Wallet Unit. During the lifetime of the Wallet Unit, the Wallet Provider will re-issue KAs and WIAs as needed.* |
-| WURevocation_02 | Empty |
-| WURevocation_03 | A Wallet Provider SHALL have a policy governing all aspects of WIA and KA issuance and management. The policy SHALL distinguish between WIAs, KAs for WSCA/WSCDs, and KAs for keystores. For KAs describing a WSCA/WSCD, the policy SHALL comply with at least the extended normalised certificate policy ('NCP+') requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of KAs rather than public key certificates. For KAs describing a keystore, the policy SHALL comply with at least the normalised certificate policy ('NCP') requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of KAs rather than public key certificates. |
-| WURevocation_04 | Empty |
-| WURevocation_05 | Empty |
+<div class="eudi-hlr" id="WURevocation_01" markdown>
+<div class="eudi-hlr__id">WURevocation_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+To enable a PID Provider or an Attestation Provider to verify the authenticity and the revocation status of a Wallet Unit it is interacting with, a Wallet Provider SHALL issue one or more Key Attestations (KA) and Wallet Instance Attestations (WIA) to the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation).
+
+*Note: The first of these KAs and WIAs will be issued during the activation phase of a Wallet Unit. During the lifetime of the Wallet Unit, the Wallet Provider will re-issue KAs and WIAs as needed.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_02" markdown>
+<div class="eudi-hlr__id">WURevocation_02</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_03" markdown>
+<div class="eudi-hlr__id">WURevocation_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL have a policy governing all aspects of WIA and KA issuance and management. The policy SHALL distinguish between WIAs, KAs for WSCA/WSCDs, and KAs for keystores. For KAs describing a WSCA/WSCD, the policy SHALL comply with at least the extended normalised certificate policy ('NCP+') requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of KAs rather than public key certificates. For KAs describing a keystore, the policy SHALL comply with at least the normalised certificate policy ('NCP') requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of KAs rather than public key certificates.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_04" markdown>
+<div class="eudi-hlr__id">WURevocation_04</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_05" markdown>
+<div class="eudi-hlr__id">WURevocation_05</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 ##### B. Revoking a Wallet Unit <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WURevocation_06 | Empty |
-| WURevocation_07 | To revoke the Wallet Instance of a Wallet Unit, a Wallet Provider SHALL, in the status list(s) for Wallet Instances, set the `revoked` status at all index positions mentioned in the WIAs issued to that Wallet Instance. |
-| WURevocation_07a | To revoke a WSCD or keystore of a Wallet Unit, the Wallet Provider SHALL, in the status list(s) for WSCDs and keystores, set the `revoked` status at all index positions mentioned in the KAs describing that WSCD or keystore. *Note: For this requirement, it does not matter whether each index in the status list(s) for WSCDs and keystores refers to a type of WSCD or keystore or to an individual WSCD or keystore.* |
-| WURevocation_08 | Empty |
-| WURevocation_09 | During the lifetime of a Wallet Unit, the Wallet Provider SHALL regularly verify that the security of the Wallet Unit is not breached or compromised. If the Wallet Provider detects a security breach or compromise, the Wallet Provider SHALL analyse its cause(s) and impact(s). If the breach or compromise affects the trustworthiness or reliability of the Wallet Unit, the Wallet Provider SHALL revoke the Wallet Unit by revoking the Wallet Instance according to WURevocation_07. The Wallet Provider SHALL do so at least in the following circumstances: - If the security of the Wallet Unit, or the security of the mobile device and OS on which the corresponding Wallet Instance is installed,  or the security of the WSCA/WSCD it uses for managing critical cryptographic assets, is breached or compromised in a manner that affects its trustworthiness or reliability. - If the security of the Wallet Solution is breached or compromised in a manner that affects the trustworthiness or reliability of all corresponding Wallet Units. - If the security of the common authentication and data protection mechanisms used by the Wallet Unit is breached or compromised in a manner that affects their trustworthiness or reliability. - If the security of the electronic identification scheme under which the Wallet Unit is provided is breached or compromised in a manner that affects its trustworthiness or reliability. *Note: The first bullet corresponds to a Critical or High Risk level security posture risk status according to the table in [Section 6.5.4.2 of the ARF main document](../../architecture-and-reference-framework-main.md#6542-wallet-unit-revocation), as analysed or detected for a Wallet Instance due to monitoring done according to WPSM_03.* |
-| WURevocation_09a | If  a breach or compromise detected per WURevocation_09 affects the trustworthiness or reliability of a (type of) WSCA/WSCD or keystore, the Wallet Provider SHALL revoke the corresponding (type of) WSCA/WSCD or keystore according to WURevocation_07a; see also WUA_28 and VCR_07e. *Note: Per WURevocation_09, a compromise of a type of WSCA/WSCD always leads to the revocation of both that type of WSCA/WSCD and of all Wallet Instances using a WSCA/WSCD of that type.* |
-| WURevocation_09b | Empty |
-| WURevocation_09c | If a Wallet Provider revokes a keystore of a Wallet Unit, it SHOULD also revoke the entire Wallet Unit by revoking the Wallet Instance. If the Wallet Provider decides to not revoke the Wallet Instance, it SHALL create a risk analysis showing that this does not lead to unacceptable risks to the User, PID Providers and Attestation Providers, Relying Parties, or the Wallet Provider itself. *Note: If the Wallet Provider does not revoke the Wallet Instance, only the attestations bound to the revoked keystore will be impacted. Other functionalities of the Wallet Unit, including the presentation of a PID, will remain available to the User.* |
-| WURevocation_10 | A Wallet Provider SHALL revoke a Wallet Unit upon the explicit request of the User registered during the Wallet Unit activation process, see [Topic 40](./annex-2.02-high-level-requirements-by-topic.md#a2323-topic-40-wallet-instance-installation-and-wallet-unit-activation-and-management). To do so, the Wallet Provider SHALL revoke the Wallet Instance (see WURevocation_07). The Wallet Provider SHALL authenticate the User before accepting a request to revoke the Wallet Unit. |
-| WURevocation_11 | A Wallet Provider SHALL revoke a Wallet Unit upon the explicit request of a PID Provider, in case the natural person using the Wallet Unit has died. To do so, the Wallet Provider SHALL revoke the Wallet Instance (see WURevocation_07). To identify the Wallet Unit that is to be revoked, the PID Provider SHALL use a Wallet Instance identifier provided by the Wallet Provider in the WIA during PID issuance. *Note: Under [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), the Wallet Instance identifier used for revocation is conveyed in the WIA (see WUA_08). See also the notes to WUA_08.* |
-| WURevocation_12 | Before revoking a Wallet Unit per WURevocation_11, the Wallet Provider SHALL verify that the party requesting revocation is indeed a valid PID Provider listed in the LoTE of PID Providers. |
-| WURevocation_13 | Before requesting a Wallet Provider to revoke a Wallet Unit per WURevocation_11, the PID Provider SHALL ensure that the revocation does not harm the interests of any of the stakeholders. The PID Provider SHALL include a documented policy ensuring that this is the case in the policy meant in WURevocation_03. |
+<div class="eudi-hlr" id="WURevocation_06" markdown>
+<div class="eudi-hlr__id">WURevocation_06</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_07" markdown>
+<div class="eudi-hlr__id">WURevocation_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+To revoke the Wallet Instance of a Wallet Unit, a Wallet Provider SHALL, in the status list(s) for Wallet Instances, set the `revoked` status at all index positions mentioned in the WIAs issued to that Wallet Instance.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_07a" markdown>
+<div class="eudi-hlr__id">WURevocation_07a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+To revoke a WSCD or keystore of a Wallet Unit, the Wallet Provider SHALL, in the status list(s) for WSCDs and keystores, set the `revoked` status at all index positions mentioned in the KAs describing that WSCD or keystore.
+
+*Note: For this requirement, it does not matter whether each index in the status list(s) for WSCDs and keystores refers to a type of WSCD or keystore or to an individual WSCD or keystore.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_08" markdown>
+<div class="eudi-hlr__id">WURevocation_08</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_09" markdown>
+<div class="eudi-hlr__id">WURevocation_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During the lifetime of a Wallet Unit, the Wallet Provider SHALL regularly verify that the security of the Wallet Unit is not breached or compromised. If the Wallet Provider detects a security breach or compromise, the Wallet Provider SHALL analyse its cause(s) and impact(s). If the breach or compromise affects the trustworthiness or reliability of the Wallet Unit, the Wallet Provider SHALL revoke the Wallet Unit by revoking the Wallet Instance according to WURevocation_07. The Wallet Provider SHALL do so at least in the following circumstances: - If the security of the Wallet Unit, or the security of the mobile device and OS on which the corresponding Wallet Instance is installed,  or the security of the WSCA/WSCD it uses for managing critical cryptographic assets, is breached or compromised in a manner that affects its trustworthiness or reliability. - If the security of the Wallet Solution is breached or compromised in a manner that affects the trustworthiness or reliability of all corresponding Wallet Units. - If the security of the common authentication and data protection mechanisms used by the Wallet Unit is breached or compromised in a manner that affects their trustworthiness or reliability. - If the security of the electronic identification scheme under which the Wallet Unit is provided is breached or compromised in a manner that affects its trustworthiness or reliability.
+
+*Note: The first bullet corresponds to a Critical or High Risk level security posture risk status according to the table in [Section 6.5.4.2 of the ARF main document](../../architecture-and-reference-framework-main.md#6542-wallet-unit-revocation), as analysed or detected for a Wallet Instance due to monitoring done according to WPSM_03.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_09a" markdown>
+<div class="eudi-hlr__id">WURevocation_09a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If  a breach or compromise detected per WURevocation_09 affects the trustworthiness or reliability of a (type of) WSCA/WSCD or keystore, the Wallet Provider SHALL revoke the corresponding (type of) WSCA/WSCD or keystore according to WURevocation_07a; see also WUA_28 and VCR_07e.
+
+*Note: Per WURevocation_09, a compromise of a type of WSCA/WSCD always leads to the revocation of both that type of WSCA/WSCD and of all Wallet Instances using a WSCA/WSCD of that type.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_09b" markdown>
+<div class="eudi-hlr__id">WURevocation_09b</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_09c" markdown>
+<div class="eudi-hlr__id">WURevocation_09c<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Provider revokes a keystore of a Wallet Unit, it SHOULD also revoke the entire Wallet Unit by revoking the Wallet Instance. If the Wallet Provider decides to not revoke the Wallet Instance, it SHALL create a risk analysis showing that this does not lead to unacceptable risks to the User, PID Providers and Attestation Providers, Relying Parties, or the Wallet Provider itself.
+
+*Note: If the Wallet Provider does not revoke the Wallet Instance, only the attestations bound to the revoked keystore will be impacted. Other functionalities of the Wallet Unit, including the presentation of a PID, will remain available to the User.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_10" markdown>
+<div class="eudi-hlr__id">WURevocation_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL revoke a Wallet Unit upon the explicit request of the User registered during the Wallet Unit activation process, see [Topic 40](./annex-2.02-high-level-requirements-by-topic.md#a2323-topic-40-wallet-instance-installation-and-wallet-unit-activation-and-management). To do so, the Wallet Provider SHALL revoke the Wallet Instance (see WURevocation_07). The Wallet Provider SHALL authenticate the User before accepting a request to revoke the Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_11" markdown>
+<div class="eudi-hlr__id">WURevocation_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL revoke a Wallet Unit upon the explicit request of a PID Provider, in case the natural person using the Wallet Unit has died. To do so, the Wallet Provider SHALL revoke the Wallet Instance (see WURevocation_07). To identify the Wallet Unit that is to be revoked, the PID Provider SHALL use a Wallet Instance identifier provided by the Wallet Provider in the WIA during PID issuance.
+
+*Note: Under [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), the Wallet Instance identifier used for revocation is conveyed in the WIA (see WUA_08). See also the notes to WUA_08.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_12" markdown>
+<div class="eudi-hlr__id">WURevocation_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before revoking a Wallet Unit per WURevocation_11, the Wallet Provider SHALL verify that the party requesting revocation is indeed a valid PID Provider listed in the LoTE of PID Providers.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_13" markdown>
+<div class="eudi-hlr__id">WURevocation_13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before requesting a Wallet Provider to revoke a Wallet Unit per WURevocation_11, the PID Provider SHALL ensure that the revocation does not harm the interests of any of the stakeholders. The PID Provider SHALL include a documented policy ensuring that this is the case in the policy meant in WURevocation_03.
+
+</div>
+</div>
+
 
 ##### C. Informing the User <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WURevocation_14 | A Wallet Provider SHALL inform a User without delay, and within 24 hours at most, in case the Wallet Provider decided to revoke the User's Wallet Unit. The Wallet Provider SHALL also inform the User about the reason(s) for the revocation. This information SHALL be understandable for the general public. It SHALL include (a reference to) technical details about any security breach if applicable. The Wallet Provider SHALL inform the User about the function(s) of the Wallet Unit that remain available to the User, if any, and functions that will not work any more. The Wallet Provider SHALL also inform the User about measures they can take to ensure they have a fully working Wallet Unit again as soon as possible, such as migrating to a different Wallet Solution. *Note: Functions that remain available to the User may include viewing their own attributes in their Wallet Unit and accessing their account at the Wallet Provider.* |
-| WURevocation_15 | Empty |
-| WURevocation_16 | To inform a User about the revocation of their Wallet Unit, the Wallet Provider SHALL use a communication channel that is independent of the Wallet Unit. In addition, the Wallet Provider MAY use the Wallet Unit itself to inform the User. |
+<div class="eudi-hlr" id="WURevocation_14" markdown>
+<div class="eudi-hlr__id">WURevocation_14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL inform a User without delay, and within 24 hours at most, in case the Wallet Provider decided to revoke the User's Wallet Unit. The Wallet Provider SHALL also inform the User about the reason(s) for the revocation. This information SHALL be understandable for the general public. It SHALL include (a reference to) technical details about any security breach if applicable. The Wallet Provider SHALL inform the User about the function(s) of the Wallet Unit that remain available to the User, if any, and functions that will not work any more. The Wallet Provider SHALL also inform the User about measures they can take to ensure they have a fully working Wallet Unit again as soon as possible, such as migrating to a different Wallet Solution.
+
+*Note: Functions that remain available to the User may include viewing their own attributes in their Wallet Unit and accessing their account at the Wallet Provider.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_15" markdown>
+<div class="eudi-hlr__id">WURevocation_15</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_16" markdown>
+<div class="eudi-hlr__id">WURevocation_16<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+To inform a User about the revocation of their Wallet Unit, the Wallet Provider SHALL use a communication channel that is independent of the Wallet Unit. In addition, the Wallet Provider MAY use the Wallet Unit itself to inform the User.
+
+</div>
+</div>
+
 
 ##### D. Verifying the revocation status of a Wallet Unit <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WURevocation_17 | Empty |
-| WURevocation_18 | A PID Provider issuing revocable PIDs SHALL, for each of its valid PIDs, regularly verify whether the Wallet Instance on which that PID is residing has been revoked and whether the associated WSCD  has been revoked, using the WIA and KA received during issuance of that PID. If either the Wallet Instance or the WSCD has been revoked, the PID Provider SHALL immediately revoke the respective PID. *Note: a) This requirement aligns with WUA_29, which requires PID Providers to check the revocation status of both the WIA and KA throughout the PID validity period. b) This is a consequence of the legal requirement in [CIR 2024/2977], Article 5, 4.(b). c) See [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) for how the PID Provider can do this verification.* |
-| WURevocation_19 | An Attestation Provider issuing revocable attestations MAY decide to revoke an attestation if the Wallet Provider revoked the Wallet Unit on which that attestation is residing, in the same manner as described in WURevocation_18. An Attestation Provider SHALL publish its policy in this regard. *Note: Publishing its policy regarding revocation allows a Relying Party to decide if it can put sufficient trust in the attestations issued by that Attestation Provider.* |
-| WURevocation_19a | Empty |
-| WURevocation_19b | Empty |
-| WURevocation_20 | Empty |
-| WURevocation_21 | Empty |
+<div class="eudi-hlr" id="WURevocation_17" markdown>
+<div class="eudi-hlr__id">WURevocation_17</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_18" markdown>
+<div class="eudi-hlr__id">WURevocation_18<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider issuing revocable PIDs SHALL, for each of its valid PIDs, regularly verify whether the Wallet Instance on which that PID is residing has been revoked and whether the associated WSCD  has been revoked, using the WIA and KA received during issuance of that PID. If either the Wallet Instance or the WSCD has been revoked, the PID Provider SHALL immediately revoke the respective PID.
+
+*Note: a) This requirement aligns with WUA_29, which requires PID Providers to check the revocation status of both the WIA and KA throughout the PID validity period. b) This is a consequence of the legal requirement in [CIR 2024/2977], Article 5, 4.(b). c) See [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) for how the PID Provider can do this verification.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_19" markdown>
+<div class="eudi-hlr__id">WURevocation_19<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attestation Provider issuing revocable attestations MAY decide to revoke an attestation if the Wallet Provider revoked the Wallet Unit on which that attestation is residing, in the same manner as described in WURevocation_18. An Attestation Provider SHALL publish its policy in this regard.
+
+*Note: Publishing its policy regarding revocation allows a Relying Party to decide if it can put sufficient trust in the attestations issued by that Attestation Provider.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_19a" markdown>
+<div class="eudi-hlr__id">WURevocation_19a</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_19b" markdown>
+<div class="eudi-hlr__id">WURevocation_19b</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_20" markdown>
+<div class="eudi-hlr__id">WURevocation_20</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WURevocation_21" markdown>
+<div class="eudi-hlr__id">WURevocation_21</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 #### A.2.3.23 Topic 40 - Wallet Instance installation and Wallet Unit activation and management
 
 ##### A. HLRs for Wallet Instance installation <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WIAM_01 | To ensure that the User can trust the Wallet Solution, a Wallet Provider SHOULD make its certified Wallet Solution available for installation only via the official app store of the relevant operating system (e.g., Android, iOS). *Note: This allows the operating system of the device to perform relevant checks regarding the authenticity of the Wallet Unit.* |
-| WIAM_02 | If a Wallet Provider makes its certified Wallet Solution available for installation through other means than the official OS app store, it SHALL implement a mechanism allowing the User to verify the authenticity of the Wallet Unit. Moreover, it SHALL provide clear instructions to the User on how to install the Wallet Instance, including at least: - instructions on the verification of the authenticity of the Wallet Instance to be installed, - instructions on bypassing of any operating system limitations on side-loading of apps, if applicable, and ensuring that these limitations are restored after the Wallet Instance has been installed. *Note: This requirement also applies for the installation of a Wallet Instance on a User device that is not a mobile device, and for which no official operating system app store may exist.* |
+<div class="eudi-hlr" id="WIAM_01" markdown>
+<div class="eudi-hlr__id">WIAM_01<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+To ensure that the User can trust the Wallet Solution, a Wallet Provider SHOULD make its certified Wallet Solution available for installation only via the official app store of the relevant operating system (e.g., Android, iOS).
+
+*Note: This allows the operating system of the device to perform relevant checks regarding the authenticity of the Wallet Unit.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_02" markdown>
+<div class="eudi-hlr__id">WIAM_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Provider makes its certified Wallet Solution available for installation through other means than the official OS app store, it SHALL implement a mechanism allowing the User to verify the authenticity of the Wallet Unit. Moreover, it SHALL provide clear instructions to the User on how to install the Wallet Instance, including at least: - instructions on the verification of the authenticity of the Wallet Instance to be installed, - instructions on bypassing of any operating system limitations on side-loading of apps, if applicable, and ensuring that these limitations are restored after the Wallet Instance has been installed.
+
+*Note: This requirement also applies for the installation of a Wallet Instance on a User device that is not a mobile device, and for which no official operating system app store may exist.*
+
+</div>
+</div>
+
 
 ##### B. HLRs for Wallet Unit activation <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WIAM_03 | A Wallet Provider SHALL ensure that a Wallet Instance starts a process to activate the new Wallet Unit with the Wallet Provider immediately after installation or when the User first opens the Wallet Instance. The Wallet Provider SHALL ensure that the Wallet Instance starts this process only with a secure backend of the Wallet Provider. |
-| WIAM_04 | During the activation process of a new Wallet Unit, the Wallet Provider SHALL verify that the new Wallet Instance is a genuine instance of its Wallet Solution. |
-| WIAM_05 | During the activation process of a new Wallet Unit, the Wallet Provider SHALL process information about the User device and the available WSCA/WSCD and keystore(s), as far as necessary to issue Key Attestations and Wallet Instance Attestations to the Wallet Unit conform all requirements in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation). The Wallet Provider MAY process additional information necessary for managing the Wallet Unit, but it SHALL NOT process more information than it reasonably needs for legitimate purposes. The Wallet Provider SHALL request User consent (through the Wallet Instance) for all information and data it will process, both during activation and throughout the lifetime of the Wallet Unit. The Wallet Provider SHALL inform the User about the purposes of data processing, in accordance with the General Data Protection Regulation. |
-| WIAM_06 | The Wallet Provider SHALL request the User, through the new Wallet Instance, to set up a User account at the Wallet Provider, or to log in to an existing account. The Wallet Provider SHALL explain to the User that this is necessary to enable the User to request revocation of the Wallet Unit in case of theft or loss. The Wallet Provider SHALL register one or more User authentication methods that the Wallet Provider will use to authenticate the User in the future. These methods SHALL be independent of the Wallet Unit and the User device. The Wallet Provider SHALL allow the User to register using an alias instead of true identity data. The Wallet Provider SHALL NOT use any registered User data for purposes other than User authentication, unless the User gives explicit consent to do so. The Wallet Provider SHALL register the relationship between the Wallet Unit and the corresponding User account. *Note: The User may already have an account at the Wallet Provider, for example because they use a Wallet Unit of this Wallet Provider already on another device, or if they are migrating to a new device.* |
-| WIAM_07 | A Wallet Provider SHALL activate a new Wallet Unit before a User can use it to have issued an PID or attestation. |
-| WIAM_08 | A Wallet Provider SHALL only activate a new Wallet Unit if it has verified that the Wallet Unit includes a WSCA/WSCD that is certified to be compliant with applicable requirements for Level of Assurance High. *Note: a) A WSCA/WSCD by definition complies with requirements for Level of Assurance High, see WIAM_14. b) In addition, the Wallet Unit can include one or more keystores.* |
-| WIAM_08a | If a Wallet Unit contains one or more keystores, the Wallet Provider SHALL assign a security level to every keystore, with the following possible values: `iso_18045_high`, `iso_18045_moderate`, `iso_18045_enhanced-basic`, `iso_18045_basic` or `none`, corresponding to the level of resistance for which the keystore was certified (respectively AVA_VAN.5, AVA_VAN.4, AVA_VAN.3, AVA_VAN.2 and no certification). *Note: For the definition of these security levels, also see [OpenID4VC]I Annex D.2* |
-| WIAM_09 | If a WSCA/WSCD or keystore contains cryptographic assets related to multiple Wallet Units, the Wallet Provider SHALL ensure that a Wallet Unit can only access assets that are related to that Wallet Unit. |
-| WIAM_10 | During the activation process of a new Wallet Unit, a Wallet Provider SHALL create and sign at least one Key Attestation for the WSCA/WSCD, at least one Key Attestation for each keystore, and at least one Wallet Instance Attestation, and issue them to the Wallet Unit. The Wallet Provider SHALL verify that the private key(s) corresponding to the public key(s) in each KA are protected by the respective WSCA/WSCD or keystore, under control of the User. The Wallet Provider SHALL take measures to verify the integrity of the Wallet Instance before issuing a Wallet Instance Attestation. |
-| WIAM_10a | During the activation process of a new Wallet Unit, the Wallet Provider SHALL offer the User a means to verify the formal certification information of their Wallet Solution. |
+<div class="eudi-hlr" id="WIAM_03" markdown>
+<div class="eudi-hlr__id">WIAM_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL ensure that a Wallet Instance starts a process to activate the new Wallet Unit with the Wallet Provider immediately after installation or when the User first opens the Wallet Instance. The Wallet Provider SHALL ensure that the Wallet Instance starts this process only with a secure backend of the Wallet Provider.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_04" markdown>
+<div class="eudi-hlr__id">WIAM_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During the activation process of a new Wallet Unit, the Wallet Provider SHALL verify that the new Wallet Instance is a genuine instance of its Wallet Solution.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_05" markdown>
+<div class="eudi-hlr__id">WIAM_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During the activation process of a new Wallet Unit, the Wallet Provider SHALL process information about the User device and the available WSCA/WSCD and keystore(s), as far as necessary to issue Key Attestations and Wallet Instance Attestations to the Wallet Unit conform all requirements in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation). The Wallet Provider MAY process additional information necessary for managing the Wallet Unit, but it SHALL NOT process more information than it reasonably needs for legitimate purposes. The Wallet Provider SHALL request User consent (through the Wallet Instance) for all information and data it will process, both during activation and throughout the lifetime of the Wallet Unit. The Wallet Provider SHALL inform the User about the purposes of data processing, in accordance with the General Data Protection Regulation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_06" markdown>
+<div class="eudi-hlr__id">WIAM_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Provider SHALL request the User, through the new Wallet Instance, to set up a User account at the Wallet Provider, or to log in to an existing account. The Wallet Provider SHALL explain to the User that this is necessary to enable the User to request revocation of the Wallet Unit in case of theft or loss. The Wallet Provider SHALL register one or more User authentication methods that the Wallet Provider will use to authenticate the User in the future. These methods SHALL be independent of the Wallet Unit and the User device. The Wallet Provider SHALL allow the User to register using an alias instead of true identity data. The Wallet Provider SHALL NOT use any registered User data for purposes other than User authentication, unless the User gives explicit consent to do so. The Wallet Provider SHALL register the relationship between the Wallet Unit and the corresponding User account.
+
+*Note: The User may already have an account at the Wallet Provider, for example because they use a Wallet Unit of this Wallet Provider already on another device, or if they are migrating to a new device.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_07" markdown>
+<div class="eudi-hlr__id">WIAM_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL activate a new Wallet Unit before a User can use it to have issued an PID or attestation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_08" markdown>
+<div class="eudi-hlr__id">WIAM_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL only activate a new Wallet Unit if it has verified that the Wallet Unit includes a WSCA/WSCD that is certified to be compliant with applicable requirements for Level of Assurance High.
+
+*Note: a) A WSCA/WSCD by definition complies with requirements for Level of Assurance High, see WIAM_14. b) In addition, the Wallet Unit can include one or more keystores.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_08a" markdown>
+<div class="eudi-hlr__id">WIAM_08a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Unit contains one or more keystores, the Wallet Provider SHALL assign a security level to every keystore, with the following possible values: `iso_18045_high`, `iso_18045_moderate`, `iso_18045_enhanced-basic`, `iso_18045_basic` or `none`, corresponding to the level of resistance for which the keystore was certified (respectively AVA_VAN.5, AVA_VAN.4, AVA_VAN.3, AVA_VAN.2 and no certification).
+
+*Note: For the definition of these security levels, also see [OpenID4VC]I Annex D.2*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_09" markdown>
+<div class="eudi-hlr__id">WIAM_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a WSCA/WSCD or keystore contains cryptographic assets related to multiple Wallet Units, the Wallet Provider SHALL ensure that a Wallet Unit can only access assets that are related to that Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_10" markdown>
+<div class="eudi-hlr__id">WIAM_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During the activation process of a new Wallet Unit, a Wallet Provider SHALL create and sign at least one Key Attestation for the WSCA/WSCD, at least one Key Attestation for each keystore, and at least one Wallet Instance Attestation, and issue them to the Wallet Unit. The Wallet Provider SHALL verify that the private key(s) corresponding to the public key(s) in each KA are protected by the respective WSCA/WSCD or keystore, under control of the User. The Wallet Provider SHALL take measures to verify the integrity of the Wallet Instance before issuing a Wallet Instance Attestation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_10a" markdown>
+<div class="eudi-hlr__id">WIAM_10a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During the activation process of a new Wallet Unit, the Wallet Provider SHALL offer the User a means to verify the formal certification information of their Wallet Solution.
+
+</div>
+</div>
+
 
 ##### C. HLRs for Wallet Unit management <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WIAM_11 | Empty |
-| WIAM_12 | All communication between the Wallet Provider and the Wallet Instance SHALL be mutually authenticated and SHOULD be encrypted. |
-| WIAM_12a | A Wallet Provider SHALL NOT access the contents of a Wallet Instance, in particular to learn a) which attestations are present on the Wallet Unit, b) the status of these attestations, c) the value of attributes in these attestations, and d) the contents of the Wallet Unit log meant in DASH_02. |
-| WIAM_12b | If the contents of a Wallet Unit specified in WIAM_12a are stored in a Wallet Instance on the User's device, the Wallet Instance SHALL ensure that the Wallet Provider cannot access the contents of the Wallet Unit. |
-| WIAM_12c | If the contents of a Wallet Unit specified in WIAM_12a are stored in a Wallet Unit Service on the Wallet Provider backend, the Wallet Provider SHALL specify and implement strict controls to limit access by the Wallet Provider to the contents of the Wallet Unit. *Note: In this situation, the Wallet Unit cannot fully prevent the Wallet Provider from accessing the Wallet Unit contents.* |
-| WIAM_13 | A Wallet Unit SHALL enable the User to 'factory reset' the Wallet Unit, which SHALL cause the deletion of all attestations, the log, and all other personal data, settings, and configurations from the Wallet Unit. If the User resets the Wallet Unit, the Wallet Instance SHALL request the associated WSCA/WSCD and keystore(s) to delete all cryptographic assets related to the Wallet Unit and to all PIDs and device-bound attestations on the Wallet Unit, if the WSCA/WSCD and the keystore(s) are connected to the User device. *Note:  a) The User can use this option, for instance, in preparation to the planned uninstallation of the Wallet Instance. b) Deletion of PID or KA cryptographic assets requires User authentication, as specified in requirement WIAM_14. c) The Wallet Unit does not necessarily inform the Wallet Provider about the factory reset. d) It may happen there is no connection to the WSCA/WSCD or to a keystore at the moment the User resets the Wallet Instance. For instance, in case the WSCA/WSCD is an external smart card and the User does not present that card to the User device. Another example occurs when the WSCA/WSCD is a remote HSM and the User device is offline at that moment. In such cases, the cryptographic assets will remain present on the WSCA/WSCD or on the keystore, even though they will never be used again. If needed, it is up to the Wallet Provider to define how the Wallet Unit should handle such situations. For example, an HSM manager could address such cases by deciding to delete cryptographic keys in the HSM that are too old or haven't been used for too long, while being aware of the risks in doing so.* |
-| WIAM_13a | If a Wallet Unit supports the [W3C Digital Credentials API] and the User resets the Wallet Unit, the Wallet Unit SHALL disclose the fact that it no longer stores any previously disclosed PID(s) or attestation(s) to the Digital Credentials API framework. |
-| WIAM_14 | A WSCA/WSCD managing the critical assets of a PID, such as private or secret cryptographic keys, SHALL authenticate the User at Level of Assurance High before performing any cryptographic operation involving any of these assets. *Note: a) [CIR 2024/2981], Annex IV, section 2 (3) states "As a prerequisite to the certification under national certification schemes, the WSCD shall be assessed against the requirements of assurance level high as set out in Implementing Regulation (EU) 2015/1502." Therefore, a WSCA/WSCD by legal definition complies with requirements of LoA High. b) Note to WIAM_14 - WIAM_14b: Many actions of the Wallet Unit, such as processing a Relying Party presentation request and presenting an attestation, require multiple cryptographic operations, for example ephemeral key generation followed by key agreement and presentation signing and encryption. These requirements does not imply that a separate User authentication is necessary before each of these operations. Rather, a successful User authentication will be valid for all cryptographic operations necessary for a Wallet Unit action. It is up to the Wallet Provider to determine what constitutes a 'Wallet Unit action', finding a balance between security (more User authentications) and User convenience (fewer User authentications). During certification of the Wallet Solution, it will be verified that the solution provides an adequate level of security.* |
-| WIAM_14a | A WSCA/WSCD managing the critical assets of a KA SHALL authenticate the User at Level of Assurance High before performing any cryptographic operation involving any of these assets. *Note: The WSCA/WSCD manages the private key(s) corresponding to the public key(s) attested in the KA.* |
-| WIAM_14b | A WSCA/WSCD managing the cryptographic assets of an attestation having a level of security High SHALL authenticate the User at level of security High before performing any cryptographic operation involving any of these assets. *Note: a) The term 'Level of Assurance', as used in the European Digital Identity Regulation and in Implementing Regulation (EU) 2015/1502, is only applicable to electronic identity means, which in the context of the EUDI Wallet means only the PID. For that reason, this requirement uses the term 'level of security'. Levels of security are defined in standards or specifications different from CIR 2024/1502, for instance ISO/IEC 18045. b) During issuance of an attestation, the Attestation Provider in its Credential Issuer metadata indicates the level of security it requires for the key storage and user authentication for this type of attestation. See [OpenID4VCI] section 12.2.4 and Appendix D.2.* |
-| WIAM_14c | A Wallet Unit SHALL use either the WSCA/WSCD or a keystore to manage any cryptographic assets that are not considered to be critical assets. *Note: a) The ARF uses the term 'keystore' to refer to a hardware-backed repository and service in which non-critical cryptographic assets are generated, stored, and used exclusively inside a dedicated hardware security boundary. b) Examples of non-critical cryptographic assets are private and secret keys of attestations having a level of security lower than High. c) As mentioned in WIAM_14 and WIAM_14b, the private and secret keys of PIDs and KAs are critical assets and therefore are stored in a WSCA/WSCD.* |
-| WIAM_15 | Before performing any operation, including allowing a User to view attestations and attribute values, a Wallet Instance SHALL securely authenticate the User using a multi-factor authentication mechanism provided by the User device. *Note: a) One of the authentication factors is the possession of the User device.* |
-| WIAM_15a | For the purpose of WIAM_15, the Wallet Instance SHALL enforce the activation of an OS-level User authentication mechanism with adequate security policies. *Note: Adequate' here means adequate for any operation excluding the issuance or presentation of PIDs, KAs, and potentially other attestations at level of security High. This includes but is not limited to generating pseudonyms, accessing the transaction log (dashboard), data export and migration, requesting the erasure of personal data by a Relying Party, and reporting a Relying Party to a DPA.* |
-| WIAM_15b | The Wallet Unit SHALL enable the User to use a Wallet Unit-specific authentication method for User authentication, in addition to the User authentication mechanism provided by the User device per WIAM_15. The Wallet Provider SHALL either make the use of this additional authentication method mandatory for all Users, or leave it to each User to decide if they want to use it. *Note: a) This authentication method may be implemented by the Wallet Instance, a (local) keystore, the WSCA/WSCD, or any other component of the Wallet Unit. b) As an optimisation to reduce the number of User authentication events, the Wallet Provider can choose to implement this additional authentication method in the WSCA/WSCD, in such a way that it complies with WIAM_14.* |
-| WIAM_15c | The Wallet Instance SHALL also use the User authentication mechanism provided by the User device (WIAM_15) and possibly the Wallet Unit-specific authentication method (WIAM_15b) to unlock the keystore mentioned in WIAM_14c, where applicable. *Note: Apart from using the same mechanism, the intent of this requirement is also to minimize the number of User authentications needed (after the initial authentication per WIAM_15a) to enable the issuance or presentation of (non-PID) attestations. However, see WIAM_16 and WIAM_16a; the Wallet Provider may request another authentication if this is necessary for security.* |
-| WIAM_16 | For the User authentication mechanism provided by the User device (WIAM_15), the Wallet Instance SHALL force the User device to enable a time-based control (e.g., a session timeout or re-authentication interval), to ensure that access is automatically revoked after a defined period of inactivity. *Note: It is assumed that re-authentication is required by the User device when the device is locked by the User.* |
-| WIAM_16a | For the Wallet Unit-specific User authentication method (WIAM_15b), the Wallet Provider SHALL define and implement conditions after which user authentication shall again be required, including at least an idle timeout. The Wallet Unit SHOULD provide the User with the option to set the idle timeout to a duration shorter than the default timeout set by the Wallet Provider. The Wallet Provider SHOULD also consider other factors, including the device being locked by the User and the Wallet Instance losing focus. |
-| WIAM_17 | The Wallet Provider SHALL ensure that the Wallet Unit requests the User, during  activation of the Wallet Unit, to set up the authentication factors for the User authentication mechanism implemented by the WSCA/WSCD meant in WIAM_14, the  authentication mechanism implemented by the User device meant in WIAM_15 and WIAM_15a,  and, if used,  the  Wallet Unit-specific authentication method meant in WIAM_15b. |
-| WIAM_18 | Empty |
-| WIAM_19 | A WSCA/WSCD and a keystore SHALL be able to prove possession of the private key corresponding to a public key on request of a Wallet Instance, for example by signing a challenge with that private key. |
-| WIAM_20 | A WSCA/WSCD SHALL protect a private key it generated during the entire lifetime of the key. This protection SHALL at least imply that the WSCA/WSCD prevents the private key from being extracted in the clear. If a WSCA/WSCD is able to export a private key in encrypted format, the resulting level of protection SHALL be equivalent to the protection level of the private key when stored in the WSCA/WSCD. |
-| WIAM_21 | Whenever the WSCA/WSCD successfully authenticated the User, the Wallet Unit SHOULD check if the WSCD contains cryptographic assets for technical PIDs or attestations that cannot be presented any longer to Relying Parties, for example because they have expired or because a once-only attestation (see [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), section D, method A) was presented to a Relying Party already. The Wallet Unit SHOULD then request the WSCA/WSCD to destroy all cryptographic assets related to these technical PIDs or attestations. However, the Wallet Unit SHOULD NOT request the destruction of the private key belonging to the last technical PID or attestation corresponding to a logical PID or attestation. *Note: a) The reason for this recommendation is that probably, Wallet Providers will want to prevent an accumulation of unused private keys in the WSCA/WSCD, given that such devices typically do not have much storage space. However, deletion of private keys (and potentially other cryptographic assets) is a cryptographic key operation and cannot be done without User authentication - see WIAM_14. At the same time, for usability reasons the User must not be involved in such 'cleaning up' processes, see also ISSU_42. The recommended solution is to take advantage of a User authentication event to also carry out any necessary cleaning operations.  b) Method A (once-only attestations, see ISSU_ 37) includes a potential fallback to Method B (limited-time attestations) in case no unused technical PIDs or attestations are left. To ensure that falling back to Method B is always possible when needed, a Wallet Unit should ensure that for every logical PID or attestation it has, it is always in possession of at least one technical PID or attestation.* |
+<div class="eudi-hlr" id="WIAM_11" markdown>
+<div class="eudi-hlr__id">WIAM_11</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_12" markdown>
+<div class="eudi-hlr__id">WIAM_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+All communication between the Wallet Provider and the Wallet Instance SHALL be mutually authenticated and SHOULD be encrypted.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_12a" markdown>
+<div class="eudi-hlr__id">WIAM_12a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL NOT access the contents of a Wallet Instance, in particular to learn a) which attestations are present on the Wallet Unit, b) the status of these attestations, c) the value of attributes in these attestations, and d) the contents of the Wallet Unit log meant in DASH_02.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_12b" markdown>
+<div class="eudi-hlr__id">WIAM_12b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the contents of a Wallet Unit specified in WIAM_12a are stored in a Wallet Instance on the User's device, the Wallet Instance SHALL ensure that the Wallet Provider cannot access the contents of the Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_12c" markdown>
+<div class="eudi-hlr__id">WIAM_12c<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the contents of a Wallet Unit specified in WIAM_12a are stored in a Wallet Unit Service on the Wallet Provider backend, the Wallet Provider SHALL specify and implement strict controls to limit access by the Wallet Provider to the contents of the Wallet Unit.
+
+*Note: In this situation, the Wallet Unit cannot fully prevent the Wallet Provider from accessing the Wallet Unit contents.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_13" markdown>
+<div class="eudi-hlr__id">WIAM_13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL enable the User to 'factory reset' the Wallet Unit, which SHALL cause the deletion of all attestations, the log, and all other personal data, settings, and configurations from the Wallet Unit. If the User resets the Wallet Unit, the Wallet Instance SHALL request the associated WSCA/WSCD and keystore(s) to delete all cryptographic assets related to the Wallet Unit and to all PIDs and device-bound attestations on the Wallet Unit, if the WSCA/WSCD and the keystore(s) are connected to the User device.
+
+*Note:  a) The User can use this option, for instance, in preparation to the planned uninstallation of the Wallet Instance. b) Deletion of PID or KA cryptographic assets requires User authentication, as specified in requirement WIAM_14. c) The Wallet Unit does not necessarily inform the Wallet Provider about the factory reset. d) It may happen there is no connection to the WSCA/WSCD or to a keystore at the moment the User resets the Wallet Instance. For instance, in case the WSCA/WSCD is an external smart card and the User does not present that card to the User device. Another example occurs when the WSCA/WSCD is a remote HSM and the User device is offline at that moment. In such cases, the cryptographic assets will remain present on the WSCA/WSCD or on the keystore, even though they will never be used again. If needed, it is up to the Wallet Provider to define how the Wallet Unit should handle such situations. For example, an HSM manager could address such cases by deciding to delete cryptographic keys in the HSM that are too old or haven't been used for too long, while being aware of the risks in doing so.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_13a" markdown>
+<div class="eudi-hlr__id">WIAM_13a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Unit supports the [W3C Digital Credentials API] and the User resets the Wallet Unit, the Wallet Unit SHALL disclose the fact that it no longer stores any previously disclosed PID(s) or attestation(s) to the Digital Credentials API framework.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_14" markdown>
+<div class="eudi-hlr__id">WIAM_14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A WSCA/WSCD managing the critical assets of a PID, such as private or secret cryptographic keys, SHALL authenticate the User at Level of Assurance High before performing any cryptographic operation involving any of these assets.
+
+*Note: a) [CIR 2024/2981], Annex IV, section 2 (3) states "As a prerequisite to the certification under national certification schemes, the WSCD shall be assessed against the requirements of assurance level high as set out in Implementing Regulation (EU) 2015/1502." Therefore, a WSCA/WSCD by legal definition complies with requirements of LoA High. b) Note to WIAM_14 - WIAM_14b: Many actions of the Wallet Unit, such as processing a Relying Party presentation request and presenting an attestation, require multiple cryptographic operations, for example ephemeral key generation followed by key agreement and presentation signing and encryption. These requirements does not imply that a separate User authentication is necessary before each of these operations. Rather, a successful User authentication will be valid for all cryptographic operations necessary for a Wallet Unit action. It is up to the Wallet Provider to determine what constitutes a 'Wallet Unit action', finding a balance between security (more User authentications) and User convenience (fewer User authentications). During certification of the Wallet Solution, it will be verified that the solution provides an adequate level of security.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_14a" markdown>
+<div class="eudi-hlr__id">WIAM_14a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A WSCA/WSCD managing the critical assets of a KA SHALL authenticate the User at Level of Assurance High before performing any cryptographic operation involving any of these assets.
+
+*Note: The WSCA/WSCD manages the private key(s) corresponding to the public key(s) attested in the KA.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_14b" markdown>
+<div class="eudi-hlr__id">WIAM_14b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A WSCA/WSCD managing the cryptographic assets of an attestation having a level of security High SHALL authenticate the User at level of security High before performing any cryptographic operation involving any of these assets.
+
+*Note: a) The term 'Level of Assurance', as used in the European Digital Identity Regulation and in Implementing Regulation (EU) 2015/1502, is only applicable to electronic identity means, which in the context of the EUDI Wallet means only the PID. For that reason, this requirement uses the term 'level of security'. Levels of security are defined in standards or specifications different from CIR 2024/1502, for instance ISO/IEC 18045. b) During issuance of an attestation, the Attestation Provider in its Credential Issuer metadata indicates the level of security it requires for the key storage and user authentication for this type of attestation. See [OpenID4VCI] section 12.2.4 and Appendix D.2.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_14c" markdown>
+<div class="eudi-hlr__id">WIAM_14c<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL use either the WSCA/WSCD or a keystore to manage any cryptographic assets that are not considered to be critical assets.
+
+*Note: a) The ARF uses the term 'keystore' to refer to a hardware-backed repository and service in which non-critical cryptographic assets are generated, stored, and used exclusively inside a dedicated hardware security boundary. b) Examples of non-critical cryptographic assets are private and secret keys of attestations having a level of security lower than High. c) As mentioned in WIAM_14 and WIAM_14b, the private and secret keys of PIDs and KAs are critical assets and therefore are stored in a WSCA/WSCD.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_15" markdown>
+<div class="eudi-hlr__id">WIAM_15<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before performing any operation, including allowing a User to view attestations and attribute values, a Wallet Instance SHALL securely authenticate the User using a multi-factor authentication mechanism provided by the User device.
+
+*Note: a) One of the authentication factors is the possession of the User device.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_15a" markdown>
+<div class="eudi-hlr__id">WIAM_15a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the purpose of WIAM_15, the Wallet Instance SHALL enforce the activation of an OS-level User authentication mechanism with adequate security policies.
+
+*Note: Adequate' here means adequate for any operation excluding the issuance or presentation of PIDs, KAs, and potentially other attestations at level of security High. This includes but is not limited to generating pseudonyms, accessing the transaction log (dashboard), data export and migration, requesting the erasure of personal data by a Relying Party, and reporting a Relying Party to a DPA.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_15b" markdown>
+<div class="eudi-hlr__id">WIAM_15b<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL enable the User to use a Wallet Unit-specific authentication method for User authentication, in addition to the User authentication mechanism provided by the User device per WIAM_15. The Wallet Provider SHALL either make the use of this additional authentication method mandatory for all Users, or leave it to each User to decide if they want to use it.
+
+*Note: a) This authentication method may be implemented by the Wallet Instance, a (local) keystore, the WSCA/WSCD, or any other component of the Wallet Unit. b) As an optimisation to reduce the number of User authentication events, the Wallet Provider can choose to implement this additional authentication method in the WSCA/WSCD, in such a way that it complies with WIAM_14.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_15c" markdown>
+<div class="eudi-hlr__id">WIAM_15c<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Instance SHALL also use the User authentication mechanism provided by the User device (WIAM_15) and possibly the Wallet Unit-specific authentication method (WIAM_15b) to unlock the keystore mentioned in WIAM_14c, where applicable.
+
+*Note: Apart from using the same mechanism, the intent of this requirement is also to minimize the number of User authentications needed (after the initial authentication per WIAM_15a) to enable the issuance or presentation of (non-PID) attestations. However, see WIAM_16 and WIAM_16a; the Wallet Provider may request another authentication if this is necessary for security.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_16" markdown>
+<div class="eudi-hlr__id">WIAM_16<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the User authentication mechanism provided by the User device (WIAM_15), the Wallet Instance SHALL force the User device to enable a time-based control (e.g., a session timeout or re-authentication interval), to ensure that access is automatically revoked after a defined period of inactivity.
+
+*Note: It is assumed that re-authentication is required by the User device when the device is locked by the User.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_16a" markdown>
+<div class="eudi-hlr__id">WIAM_16a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the Wallet Unit-specific User authentication method (WIAM_15b), the Wallet Provider SHALL define and implement conditions after which user authentication shall again be required, including at least an idle timeout. The Wallet Unit SHOULD provide the User with the option to set the idle timeout to a duration shorter than the default timeout set by the Wallet Provider. The Wallet Provider SHOULD also consider other factors, including the device being locked by the User and the Wallet Instance losing focus.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_17" markdown>
+<div class="eudi-hlr__id">WIAM_17<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Provider SHALL ensure that the Wallet Unit requests the User, during  activation of the Wallet Unit, to set up the authentication factors for the User authentication mechanism implemented by the WSCA/WSCD meant in WIAM_14, the  authentication mechanism implemented by the User device meant in WIAM_15 and WIAM_15a,  and, if used,  the  Wallet Unit-specific authentication method meant in WIAM_15b.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_18" markdown>
+<div class="eudi-hlr__id">WIAM_18</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_19" markdown>
+<div class="eudi-hlr__id">WIAM_19<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A WSCA/WSCD and a keystore SHALL be able to prove possession of the private key corresponding to a public key on request of a Wallet Instance, for example by signing a challenge with that private key.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_20" markdown>
+<div class="eudi-hlr__id">WIAM_20<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A WSCA/WSCD SHALL protect a private key it generated during the entire lifetime of the key. This protection SHALL at least imply that the WSCA/WSCD prevents the private key from being extracted in the clear. If a WSCA/WSCD is able to export a private key in encrypted format, the resulting level of protection SHALL be equivalent to the protection level of the private key when stored in the WSCA/WSCD.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WIAM_21" markdown>
+<div class="eudi-hlr__id">WIAM_21<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Whenever the WSCA/WSCD successfully authenticated the User, the Wallet Unit SHOULD check if the WSCD contains cryptographic assets for technical PIDs or attestations that cannot be presented any longer to Relying Parties, for example because they have expired or because a once-only attestation (see [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), section D, method A) was presented to a Relying Party already. The Wallet Unit SHOULD then request the WSCA/WSCD to destroy all cryptographic assets related to these technical PIDs or attestations. However, the Wallet Unit SHOULD NOT request the destruction of the private key belonging to the last technical PID or attestation corresponding to a logical PID or attestation.
+
+*Note: a) The reason for this recommendation is that probably, Wallet Providers will want to prevent an accumulation of unused private keys in the WSCA/WSCD, given that such devices typically do not have much storage space. However, deletion of private keys (and potentially other cryptographic assets) is a cryptographic key operation and cannot be done without User authentication - see WIAM_14. At the same time, for usability reasons the User must not be involved in such 'cleaning up' processes, see also ISSU_42. The recommended solution is to take advantage of a User authentication event to also carry out any necessary cleaning operations.  b) Method A (once-only attestations, see ISSU_ 37) includes a potential fallback to Method B (limited-time attestations) in case no unused technical PIDs or attestations are left. To ensure that falling back to Method B is always possible when needed, a Wallet Unit should ensure that for every logical PID or attestation it has, it is always in possession of at least one technical PID or attestation.*
+
+</div>
+</div>
+
 
 #### A.2.3.24 Topic 42 - Requirements for QTSPs to access Authentic Sources
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| QTSPAS_01 | In accordance with [ETSI TS 119 478] and [Technical Specification 11], Member States SHALL define: - discovery mechanisms that enable QTSPs to request information about Authentic Sources or designated intermediaries recognised at the national level. This includes information regarding the attributes of a natural or legal person for which the Authentic Source or designated intermediary is considered a primary source, or for which it is recognised as authentic in accordance with Union law or national law, including administrative practices. - procedures for QTSPs to request the verification of attributes from Authentic Sources. |
-| QTSPAS_02 | An Authentic Source in the public sector, or its designated intermediary, SHALL implement an interface complying with [ETSI TS 119 478] and [Technical Specification 11] for receiving verification requests and sending responses. For each received request, the Authentic Source SHALL - identify and authenticate the requestor in such a way that it can subsequently determine whether the requestor is a QTSP issuing qualified electronic attestation of attributes, for example by means of a lookup in the QTSP Trusted List. - authenticate the User and obtain their approval, if it is legally obliged to do so, in addition to the User authentication and approval already performed by the QTSP according to QTSPAS_08. - verify whether the attribute values claimed by the QTSP match the values held by the Authentic Source and, finally, - respond with one of the following for each attribute: +'match', if the attribute value held for this User by the Authentic Source is identical to the value claimed by the QTSP, + 'no match', if the attribute value held for this User by the Authentic Source is not identical to the value claimed by the QTSP, including if the Authentic Source is the authentic source for this attribute but does not hold a value for this User, +'unknown', if the Authentic Source is not the authentic source for this attribute. |
-| QTSPAS_03 | An Authentic Source or designated intermediary SHALL respond to a verification request for attributes by any QTSP issuing qualified electronic attestation of attributes. |
-| QTSPAS_04 | An Authentic Source or designated intermediary SHALL implement the technical specifications mentioned in QTSPAS_01, so that the QTSP will receive the result of the verification of the requested attributes as described in QTSPAS_02. If the verification is deferred, the response to the QTSP SHALL include the maximum time that it will take to verify the requested attributes, and a unique identifier that the QTSP SHALL use to obtain the result of the verification. |
-| QTSPAS_05 | A QTSP SHALL send an attribute verification request directly to the Authentic Source or designated intermediary recognised at national level, after discovering it using the mechanisms specified the technical specifications mentioned in QTSPAS_01. |
-| QTSPAS_06 | Member States SHALL specify the processes and mechanisms to designate the Authentic Sources or intermediaries recognised at national level in accordance with Union or national law, allowing these Authentic Sources or intermediaries to verify the attributes presented to them by QTSPs. |
-| QTSPAS_07 | Empty |
-| QTSPAS_07a | Empty |
-| QTSPAS_08 | A QTSP SHALL obtain approval from the User to verify the authenticity of the attributes, before requesting the verification of those attributes by the relevant Authentic Source or designated intermediary. |
+<div class="eudi-hlr" id="QTSPAS_01" markdown>
+<div class="eudi-hlr__id">QTSPAS_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+In accordance with [ETSI TS 119 478] and [Technical Specification 11], Member States SHALL define: - discovery mechanisms that enable QTSPs to request information about Authentic Sources or designated intermediaries recognised at the national level. This includes information regarding the attributes of a natural or legal person for which the Authentic Source or designated intermediary is considered a primary source, or for which it is recognised as authentic in accordance with Union law or national law, including administrative practices. - procedures for QTSPs to request the verification of attributes from Authentic Sources.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QTSPAS_02" markdown>
+<div class="eudi-hlr__id">QTSPAS_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Authentic Source in the public sector, or its designated intermediary, SHALL implement an interface complying with [ETSI TS 119 478] and [Technical Specification 11] for receiving verification requests and sending responses. For each received request, the Authentic Source SHALL - identify and authenticate the requestor in such a way that it can subsequently determine whether the requestor is a QTSP issuing qualified electronic attestation of attributes, for example by means of a lookup in the QTSP Trusted List. - authenticate the User and obtain their approval, if it is legally obliged to do so, in addition to the User authentication and approval already performed by the QTSP according to QTSPAS_08. - verify whether the attribute values claimed by the QTSP match the values held by the Authentic Source and, finally, - respond with one of the following for each attribute: +'match', if the attribute value held for this User by the Authentic Source is identical to the value claimed by the QTSP, + 'no match', if the attribute value held for this User by the Authentic Source is not identical to the value claimed by the QTSP, including if the Authentic Source is the authentic source for this attribute but does not hold a value for this User, +'unknown', if the Authentic Source is not the authentic source for this attribute.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QTSPAS_03" markdown>
+<div class="eudi-hlr__id">QTSPAS_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Authentic Source or designated intermediary SHALL respond to a verification request for attributes by any QTSP issuing qualified electronic attestation of attributes.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QTSPAS_04" markdown>
+<div class="eudi-hlr__id">QTSPAS_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Authentic Source or designated intermediary SHALL implement the technical specifications mentioned in QTSPAS_01, so that the QTSP will receive the result of the verification of the requested attributes as described in QTSPAS_02. If the verification is deferred, the response to the QTSP SHALL include the maximum time that it will take to verify the requested attributes, and a unique identifier that the QTSP SHALL use to obtain the result of the verification.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QTSPAS_05" markdown>
+<div class="eudi-hlr__id">QTSPAS_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A QTSP SHALL send an attribute verification request directly to the Authentic Source or designated intermediary recognised at national level, after discovering it using the mechanisms specified the technical specifications mentioned in QTSPAS_01.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QTSPAS_06" markdown>
+<div class="eudi-hlr__id">QTSPAS_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Member States SHALL specify the processes and mechanisms to designate the Authentic Sources or intermediaries recognised at national level in accordance with Union or national law, allowing these Authentic Sources or intermediaries to verify the attributes presented to them by QTSPs.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QTSPAS_07" markdown>
+<div class="eudi-hlr__id">QTSPAS_07</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QTSPAS_07a" markdown>
+<div class="eudi-hlr__id">QTSPAS_07a</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="QTSPAS_08" markdown>
+<div class="eudi-hlr__id">QTSPAS_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A QTSP SHALL obtain approval from the User to verify the authenticity of the attributes, before requesting the verification of those attributes by the relevant Authentic Source or designated intermediary.
+
+</div>
+</div>
+
 
 #### A.2.3.25 Topic 43 - Embedded disclosure policies
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| EDP_01 | A Wallet Unit SHALL enable an Attestation Provider to optionally express an embedded disclosure policy for a QEAA, PuB-EAA, or non-qualified EAA. *Note: The [European Digital Identity Regulation] does not contain a requirement for PIDs to be able to contain an embedded disclosure policy.* |
-| EDP_02 | A Wallet Unit SHALL support embedded disclosure policies implementing the 'Authorised relying parties only policy' described in Annex III of Implementing Regulation (EU) 2024/2979. If present, such an embedded disclosure policy SHALL contain a list of EU-wide unique identifiers of Relying Parties, as specified in Reg_32. The Wallet Unit SHALL retrieve the Relying Party identifier from the access certificate presented by the Relying Party, and compare it to the list of authorised identifiers in the policy, unless the Relying Party is an intermediary. If the Relying Party is an intermediary, the Wallet Unit SHALL retrieve the unique identifier of the intermediated Relying Party from the presentation request or from the registration certificate of the intermediated Relying Party and compare this identifier to the list of authorised identifiers in the policy. *Note: See RPI_07 for how the Wallet Unit can see if the Relying Party is an intermediary.* |
-| EDP_03 | A Wallet Unit SHALL support embedded disclosure policies implementing the 'Specific root of trust' policy described in Annex III of Implementing Regulation (EU) 2024/2979. If present, such an embedded disclosure policy SHALL contain a list of root or intermediate certificates used for signing Relying Party access certificates. The Wallet Unit SHALL compare the certificate chain that was used to sign the access certificate provided by the Relying Party to the list of authorised root or intermediate certificates in the policy, unless the Relying Party is an intermediary. If the Relying Party is an intermediary, the Wallet Unit SHALL retrieve the root certificate of the Provider of registration certificates of the intermediated Relying Party from the presentation request or from the Registrar's online service (as applicable) and compare this certificate to the list of authorised certificates in the policy. *Note: See RPI_07 for how the Wallet Unit can see if the Relying Party is an intermediary.* |
-| EDP_04 | Empty |
-| EDP_05 | An embedded disclosure policy SHOULD contain a link to a website of the Attestation Provider explaining the disclosure policy in layman's terms. If this is the case, the Wallet Unit SHALL display the link to the User and allow them to navigate to that website. |
-| EDP_06 | The Wallet Unit SHALL evaluate an embedded disclosure policy in conjunction with the information received from the requesting Relying Party, in order to determine if the Relying Party has permission from the Attestation Provider to access the requested attestation. |
-| EDP_07 | The Wallet Unit SHALL enable the User, based on the outcome of the evaluation of the applicable embedded disclosure policy(s), to deny or allow the presentation of the requested attestation to the Relying Party. |
-| EDP_08 | The Commission SHALL take measures to ensure a technical specification is created establishing common mechanisms for the specification of embedded disclosure policies by Attestation Providers, and for the evaluation of such policies by Wallet Units. |
-| EDP_09 | An Attestation Provider SHALL include an embedded disclosure policy (if any) by value in the Issuer metadata related to the attestation, in compliance with the [OpenID4VCI] issuance protocol or an extension thereof specified in the technical specification mentioned in EDP_08. |
-| EDP_10 | During attestation issuance, a Wallet Unit SHALL retrieve and store the corresponding embedded disclosure policy, if any. *Note: The intent of this requirement is that the Wallet Unit is able to evaluate an EDP during a presentation transaction, without needing to request it again from the Attestation Provider. This is necessary in particular during proximity presentations, which must be able to be done without an internet connection.* |
-| EDP_11 | An Attestation Provider SHALL revoke an attestation if a corresponding embedded disclosure policy is added, changed, or deleted. |
+<div class="eudi-hlr" id="EDP_01" markdown>
+<div class="eudi-hlr__id">EDP_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL enable an Attestation Provider to optionally express an embedded disclosure policy for a QEAA, PuB-EAA, or non-qualified EAA.
+
+*Note: The [European Digital Identity Regulation] does not contain a requirement for PIDs to be able to contain an embedded disclosure policy.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="EDP_02" markdown>
+<div class="eudi-hlr__id">EDP_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL support embedded disclosure policies implementing the 'Authorised relying parties only policy' described in Annex III of Implementing Regulation (EU) 2024/2979. If present, such an embedded disclosure policy SHALL contain a list of EU-wide unique identifiers of Relying Parties, as specified in Reg_32. The Wallet Unit SHALL retrieve the Relying Party identifier from the access certificate presented by the Relying Party, and compare it to the list of authorised identifiers in the policy, unless the Relying Party is an intermediary. If the Relying Party is an intermediary, the Wallet Unit SHALL retrieve the unique identifier of the intermediated Relying Party from the presentation request or from the registration certificate of the intermediated Relying Party and compare this identifier to the list of authorised identifiers in the policy.
+
+*Note: See RPI_07 for how the Wallet Unit can see if the Relying Party is an intermediary.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="EDP_03" markdown>
+<div class="eudi-hlr__id">EDP_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL support embedded disclosure policies implementing the 'Specific root of trust' policy described in Annex III of Implementing Regulation (EU) 2024/2979. If present, such an embedded disclosure policy SHALL contain a list of root or intermediate certificates used for signing Relying Party access certificates. The Wallet Unit SHALL compare the certificate chain that was used to sign the access certificate provided by the Relying Party to the list of authorised root or intermediate certificates in the policy, unless the Relying Party is an intermediary. If the Relying Party is an intermediary, the Wallet Unit SHALL retrieve the root certificate of the Provider of registration certificates of the intermediated Relying Party from the presentation request or from the Registrar's online service (as applicable) and compare this certificate to the list of authorised certificates in the policy.
+
+*Note: See RPI_07 for how the Wallet Unit can see if the Relying Party is an intermediary.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="EDP_04" markdown>
+<div class="eudi-hlr__id">EDP_04</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="EDP_05" markdown>
+<div class="eudi-hlr__id">EDP_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An embedded disclosure policy SHOULD contain a link to a website of the Attestation Provider explaining the disclosure policy in layman's terms. If this is the case, the Wallet Unit SHALL display the link to the User and allow them to navigate to that website.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="EDP_06" markdown>
+<div class="eudi-hlr__id">EDP_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL evaluate an embedded disclosure policy in conjunction with the information received from the requesting Relying Party, in order to determine if the Relying Party has permission from the Attestation Provider to access the requested attestation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="EDP_07" markdown>
+<div class="eudi-hlr__id">EDP_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL enable the User, based on the outcome of the evaluation of the applicable embedded disclosure policy(s), to deny or allow the presentation of the requested attestation to the Relying Party.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="EDP_08" markdown>
+<div class="eudi-hlr__id">EDP_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Commission SHALL take measures to ensure a technical specification is created establishing common mechanisms for the specification of embedded disclosure policies by Attestation Providers, and for the evaluation of such policies by Wallet Units.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="EDP_09" markdown>
+<div class="eudi-hlr__id">EDP_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attestation Provider SHALL include an embedded disclosure policy (if any) by value in the Issuer metadata related to the attestation, in compliance with the [OpenID4VCI] issuance protocol or an extension thereof specified in the technical specification mentioned in EDP_08.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="EDP_10" markdown>
+<div class="eudi-hlr__id">EDP_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During attestation issuance, a Wallet Unit SHALL retrieve and store the corresponding embedded disclosure policy, if any.
+
+*Note: The intent of this requirement is that the Wallet Unit is able to evaluate an EDP during a presentation transaction, without needing to request it again from the Attestation Provider. This is necessary in particular during proximity presentations, which must be able to be done without an internet connection.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="EDP_11" markdown>
+<div class="eudi-hlr__id">EDP_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Attestation Provider SHALL revoke an attestation if a corresponding embedded disclosure policy is added, changed, or deleted.
+
+</div>
+</div>
+
 
 #### A.2.3.26 Topic 44 - Registration certificates for PID Providers, Providers of QEAAs, PuB-EAAs, and non-qualified EAAs, and Relying Parties
 
 ##### A. Generic requirements on the specification and contents of registration certificates <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| RPRC_01 | Providers of registration certificates SHALL comply with all relevant requirements in [ETSI TS 119 475]. |
-| RPRC_02 | Empty |
-| RPRC_03 | The contents of a registration certificate SHALL include at least the information required in Annex V of the [CIR 2025/848](https://data.europa.eu/eli/reg_impl/2025/848/oj) regarding registration of wallet-relying parties. |
-| RPRC_04 | If the subject of the registration certificate uses the services of an intermediary (see [Topic 52](./annex-2.02-high-level-requirements-by-topic.md#a2330-topic-52-relying-party-intermediaries)), the 'association to the intermediary' mentioned in Annex I (15) of [CIR 2025/848] SHALL consist of the user-friendly name and unique identifier of this intermediary, as meant in requirements Reg_31 and Reg_32. *Note: This name and identifier are identical to those in the access certificate of the intermediary.* |
-| RPRC_04a | Empty |
-| RPRC_05 | If the subject of the registration certificate is not a Relying Party (i.e. in the terms of CIR 2025/848, a Service Provider), the certificate SHALL NOT contain the intended use as meant in Annex I (9) and (10) of CIR 2025/848. *Note: A PID Provider or Attestation Provider may request attributes from the Wallet Unit during issuance. If so, it registers as both a Service Provider and an Attestation Provider, and consequently its registration certificate contains its intended use.* |
-| RPRC_06 | The contents of a registration certificate SHALL include a name for the subject of the certificate, in a format suitable for presenting to a User. *Note: a) A Wallet Unit needs the name of a Relying Party at least when requesting User approval according to [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] b) This name is identical to the name in the access certificate(s) of the entity, see Reg_31.* |
-| RPRC_07 | The contents of a registration certificate SHALL include an EU-wide unique identifier for the subject of the certificate. *Note: a) A Wallet Unit needs an identifier for a Relying Party at least to allow the User to send a report of suspicious Relying Party presentation requests to a data protection authority according to [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data). b) The EU-wide unique identifier could, for example, be a concatenated list of one or more registered official Relying Party identifiers listed in Annex I(3) of the [CIR 2025/848](https://data.europa.eu/eli/reg_impl/2025/848/oj) regarding registration of Wallet Relying Parties, expressed in the semantic form defined in [ETSI EN 319 412-1] sections 5.1.4 or 5.1.5. c) This identifier is identical to the identifier in the access certificate(s) of the entity, see Reg_32.* |
-| RPRC_08 | The EU-wide unique identifier meant in RPRC_07 SHALL be identical in all registration certificates issued for a given entity. *Note: In case the registration certificates issued to an intermediated Relying Party are held and presented by an intermediary, the entity meant in this requirement is the intermediated Relying Party. An intermediary may obtain and hold registration certificates with a different unique identifier for other intermediated Relying Parties.* |
+<div class="eudi-hlr" id="RPRC_01" markdown>
+<div class="eudi-hlr__id">RPRC_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Providers of registration certificates SHALL comply with all relevant requirements in [ETSI TS 119 475].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_02" markdown>
+<div class="eudi-hlr__id">RPRC_02</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_03" markdown>
+<div class="eudi-hlr__id">RPRC_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The contents of a registration certificate SHALL include at least the information required in Annex V of the [CIR 2025/848](https://data.europa.eu/eli/reg_impl/2025/848/oj) regarding registration of wallet-relying parties.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_04" markdown>
+<div class="eudi-hlr__id">RPRC_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the subject of the registration certificate uses the services of an intermediary (see [Topic 52](./annex-2.02-high-level-requirements-by-topic.md#a2330-topic-52-relying-party-intermediaries)), the 'association to the intermediary' mentioned in Annex I (15) of [CIR 2025/848] SHALL consist of the user-friendly name and unique identifier of this intermediary, as meant in requirements Reg_31 and Reg_32.
+
+*Note: This name and identifier are identical to those in the access certificate of the intermediary.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_04a" markdown>
+<div class="eudi-hlr__id">RPRC_04a</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_05" markdown>
+<div class="eudi-hlr__id">RPRC_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the subject of the registration certificate is not a Relying Party (i.e. in the terms of CIR 2025/848, a Service Provider), the certificate SHALL NOT contain the intended use as meant in Annex I (9) and (10) of CIR 2025/848.
+
+*Note: A PID Provider or Attestation Provider may request attributes from the Wallet Unit during issuance. If so, it registers as both a Service Provider and an Attestation Provider, and consequently its registration certificate contains its intended use.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_06" markdown>
+<div class="eudi-hlr__id">RPRC_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The contents of a registration certificate SHALL include a name for the subject of the certificate, in a format suitable for presenting to a User.
+
+*Note: a) A Wallet Unit needs the name of a Relying Party at least when requesting User approval according to [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] b) This name is identical to the name in the access certificate(s) of the entity, see Reg_31.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_07" markdown>
+<div class="eudi-hlr__id">RPRC_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The contents of a registration certificate SHALL include an EU-wide unique identifier for the subject of the certificate.
+
+*Note: a) A Wallet Unit needs an identifier for a Relying Party at least to allow the User to send a report of suspicious Relying Party presentation requests to a data protection authority according to [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data). b) The EU-wide unique identifier could, for example, be a concatenated list of one or more registered official Relying Party identifiers listed in Annex I(3) of the [CIR 2025/848](https://data.europa.eu/eli/reg_impl/2025/848/oj) regarding registration of Wallet Relying Parties, expressed in the semantic form defined in [ETSI EN 319 412-1] sections 5.1.4 or 5.1.5. c) This identifier is identical to the identifier in the access certificate(s) of the entity, see Reg_32.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_08" markdown>
+<div class="eudi-hlr__id">RPRC_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The EU-wide unique identifier meant in RPRC_07 SHALL be identical in all registration certificates issued for a given entity.
+
+*Note: In case the registration certificates issued to an intermediated Relying Party are held and presented by an intermediary, the entity meant in this requirement is the intermediated Relying Party. An intermediary may obtain and hold registration certificates with a different unique identifier for other intermediated Relying Parties.*
+
+</div>
+</div>
+
 
 ##### B Requirements on the issuance of registration certificates to Relying Parties <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| RPRC_09 | A Member State Registrar MAY decide that, during the registration process for Relying Parties, as specified in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), a Provider of registration certificates associated to the Registrar must create and sign or seal one or more registration certificates. If the Registrar decides to do so, the Provider of registration certificates SHALL create and sign or seal a separate registration certificate for each intended use registered by each Relying Party, and issue it to the Relying Party. Each registration certificate SHALL comply with the requirements in the technical specification mentioned in RPRC_02. *Note: See also [Topic 52](./annex-2.02-high-level-requirements-by-topic.md#a2330-topic-52-relying-party-intermediaries).* |
-| RPRC_10 | If, during registration, a Relying Party received one or more registration certificates, it SHALL distribute these to all its Relying Party Instances. |
-| RPRC_11 | The contents of a registration certificate issued to a Relying Party SHALL at least one of the following: a) the URL of a web form provided by the Relying Party, which Users can use to send data deletion requests, b) an e-mail address of the Relying Party, on which the Relying Party is prepared to receive data deletion requests from Users, c) a telephone number of the Relying Party, on which the Relying Party is prepared to receive data deletion requests from Users. *Note: See [Topic 48](./annex-2.02-high-level-requirements-by-topic.md#a2327-topic-48-blueprint-for-requesting-data-deletion-to-relying-parties) for more information about data deletion requests.* |
-| RPRC_12 | The contents of a registration certificate issued to a Relying Party SHALL contain the name and country of the Data Protection Authority supervising the Relying Party. In addition, the registration certificate SHALL contain at least one of the following: a) the URL of a web form provided by the DPA, which Users can use to report suspicious attribute presentation requests. b) an e-mail address of the DPA, on which the DPA is prepared to receive reports about suspicious attribute presentation requests from Users, c) a telephone number of the DPA, on which the DPA is prepared to receive reports about suspicious attribute presentation requests from Users. *Note: See [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data) for more information about reporting suspicious attribute presentation requests.* |
+<div class="eudi-hlr" id="RPRC_09" markdown>
+<div class="eudi-hlr__id">RPRC_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Member State Registrar MAY decide that, during the registration process for Relying Parties, as specified in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), a Provider of registration certificates associated to the Registrar must create and sign or seal one or more registration certificates. If the Registrar decides to do so, the Provider of registration certificates SHALL create and sign or seal a separate registration certificate for each intended use registered by each Relying Party, and issue it to the Relying Party. Each registration certificate SHALL comply with the requirements in the technical specification mentioned in RPRC_02.
+
+*Note: See also [Topic 52](./annex-2.02-high-level-requirements-by-topic.md#a2330-topic-52-relying-party-intermediaries).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_10" markdown>
+<div class="eudi-hlr__id">RPRC_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If, during registration, a Relying Party received one or more registration certificates, it SHALL distribute these to all its Relying Party Instances.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_11" markdown>
+<div class="eudi-hlr__id">RPRC_11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The contents of a registration certificate issued to a Relying Party SHALL at least one of the following: a) the URL of a web form provided by the Relying Party, which Users can use to send data deletion requests, b) an e-mail address of the Relying Party, on which the Relying Party is prepared to receive data deletion requests from Users, c) a telephone number of the Relying Party, on which the Relying Party is prepared to receive data deletion requests from Users.
+
+*Note: See [Topic 48](./annex-2.02-high-level-requirements-by-topic.md#a2327-topic-48-blueprint-for-requesting-data-deletion-to-relying-parties) for more information about data deletion requests.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_12" markdown>
+<div class="eudi-hlr__id">RPRC_12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The contents of a registration certificate issued to a Relying Party SHALL contain the name and country of the Data Protection Authority supervising the Relying Party. In addition, the registration certificate SHALL contain at least one of the following: a) the URL of a web form provided by the DPA, which Users can use to report suspicious attribute presentation requests. b) an e-mail address of the DPA, on which the DPA is prepared to receive reports about suspicious attribute presentation requests from Users, c) a telephone number of the DPA, on which the DPA is prepared to receive reports about suspicious attribute presentation requests from Users.
+
+*Note: See [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data) for more information about reporting suspicious attribute presentation requests.*
+
+</div>
+</div>
+
 
 ##### C. Requirements on the issuance of registration certificates to PID Providers and Attestation Providers <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| RPRC_13 | A Registrar MAY decide that, during the registration process for PID Providers, QEAA Providers, PuB-EAA Provider, or non-qualified EAA Providers, as specified in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), a Provider of registration certificates associated to the Member State Registrar must create and sign or seal a registration certificate and issue it to the registering party. If so, that registration certificate SHALL comply with the requirements in the technical specification mentioned in RPRC_02. |
-| RPRC_14 | If, during registration, a PID Provider, QEAA Provider, PuB-EAA Provider, or non-qualified EAA Provider received a registration certificate, it SHALL distribute it to all its service supply points. *Note: A service supply point is a system at which a Wallet Unit can start the process of requesting and obtaining a PID or attestation.* |
-| RPRC_15 | The contents of a registration certificate issued to a PID Provider, a QEAA Provider, a PuB-EAA Provider, or a non-qualified EAA Provider SHALL contain the type(s) of attestation that this entity intends to issue to Wallet Units. |
+<div class="eudi-hlr" id="RPRC_13" markdown>
+<div class="eudi-hlr__id">RPRC_13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Registrar MAY decide that, during the registration process for PID Providers, QEAA Providers, PuB-EAA Provider, or non-qualified EAA Providers, as specified in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), a Provider of registration certificates associated to the Member State Registrar must create and sign or seal a registration certificate and issue it to the registering party. If so, that registration certificate SHALL comply with the requirements in the technical specification mentioned in RPRC_02.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_14" markdown>
+<div class="eudi-hlr__id">RPRC_14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If, during registration, a PID Provider, QEAA Provider, PuB-EAA Provider, or non-qualified EAA Provider received a registration certificate, it SHALL distribute it to all its service supply points.
+
+*Note: A service supply point is a system at which a Wallet Unit can start the process of requesting and obtaining a PID or attestation.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_15" markdown>
+<div class="eudi-hlr__id">RPRC_15<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The contents of a registration certificate issued to a PID Provider, a QEAA Provider, a PuB-EAA Provider, or a non-qualified EAA Provider SHALL contain the type(s) of attestation that this entity intends to issue to Wallet Units.
+
+</div>
+</div>
+
 
 ##### D. Requirements on the presentation and verification of registration certificates of Relying Parties <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| RPRC_16 | A Wallet Unit SHALL offer the User the possibility to indicate whether the User wants the Wallet Unit to go online to the competent Registrar if that is needed to verify the information registered about the Relying Party. The Wallet Unit SHALL inform the User that this implies that the Registrar learns about the User's interaction with the Relying Party. The Wallet Unit SHALL also inform the User that not requesting this information from the Registrar means that the Wallet Unit has no way to verify the information included by the Relying Party in the presentation request. *Note: a) The Wallet Unit can offer this choice to the User either during a presentation transaction in case no registration certificate was received, or as a general User setting. b) If the User indicates they don't want this, the Wallet Unit will not verify the registered information in case there is no registration certificate, see RPRC_18a. However, if there is a registration certificate, the Wallet Unit will always verify the information in the certificate, per RPRC_17.* |
-| RPRC_17 | If the Relying Party sends a registration certificate to the Wallet Unit in a presentation request, the Wallet Unit SHALL verify the authenticity and validity of the registration certificate according to the technical specification meant in RPRC_02. If the certificate is inauthentic or expired, the Wallet Unit SHALL, when asking for User approval according to RPA_07, notify the User that it could not obtain the information registered about the entity. |
-| RPRC_18 | If the User indicated that they want the Wallet Unit to go online to the competent Registrar if needed to verify the information registered about the Relying Party (see RPRC_16), and the Relying Party did not send a registration certificate to the Wallet Unit, the Wallet Unit SHALL connect to the URL of the online service of the Registrar to obtain this information. If the Wallet Unit cannot connect to this URL or if it cannot verify the authenticity and validity of the registered information, it SHALL, when asking for User approval according to RPA_07, notify the User that it could not obtain the information registered about the Relying Party. *Note: The URL of the Registrar is included in the extension of the presentation request, see RPRC_19a.* |
-| RPRC_18a | If the User indicated that they do not want the Wallet Unit to go online to the competent Registrar, the Wallet Unit SHALL NOT do so, even in case the Relying Party did not send a registration certificate to the Wallet Unit in the presentation request. *Note: This requirement is not applicable in case the Wallet Unit is interacting with a PID Provider or an Attestation Provider. If a PID Provider or an Attestation Provider does not provide a registration certificate, the Wallet Unit must verify their entitlements at the competent Registrar, see ISSU_24a and ISSU_34a.* |
-| RPRC_19 | If a Relying Party Instance received one or more registration certificates (see RPRC_10), it SHALL include a single registration certificate applicable for its current intended use in each presentation request to a Wallet Unit, according to the applicable standard's extension mentioned in RPRC_20. The registration certificate SHALL be included in the request by value, not by reference. The Relying Party Instance SHALL do so both in proximity and remote presentation flows. *Note:  This ensures that no external requests are necessary to validate the Relying Party.* |
-| RPRC_19a | A Relying Party Instance SHALL include in each presentation request the following information, according to the applicable standard's extension mentioned in RPRC_20a: a) the user-friendly name of the Relying Party, b) the unique identifier of the Relying Party, c) a User-friendly description of the intended use of the Relying Party, d) the URL of the Registrar of the Relying Party, and e) the identifier of the intended use of the Relying Party. *Note: Including items a) and b) enables the Wallet Unit to show to the User the name of the Relying Party. Including c) enables the Wallet Unit to inform the User about the intended use. Including c) and d) enables the Wallet Unit, if desired by the User, to request from the Registrar the attributes registered by the Relying Party for this intended use, as well as the corresponding privacy policy and other registered information. See [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md) for the definition of this information. Note that in case the Relying Party Instance is operated by an intermediary, items a) - e) pertain to the intermediated Relying Party, see also RPI_06.* |
-| RPRC_20 | Relying Party Instances and Wallet Units SHALL support the extension for [ISO/IEC 18013-5] or the extension for [OpenID4VP], as specified in [ETSI TS 119 472-2] and amended by a CIR in preparation, as applicable, for transferring a single Relying Party registration certificate from a Relying Party Instance to a Wallet Unit. *Note: The correct CIR will be referenced here when it is published.* |
-| RPRC_20a | Relying Party Instances and Wallet Units SHALL support the extension for [ISO/IEC 18013-5] or the extension for [OpenID4VP], as specified in [ETSI TS 119 472-2] and amended by a CIR in preparation, as applicable, for transferring the information listed in RPRC_19a from a Relying Party Instance to a Wallet Unit. *Note: The correct CIR will be referenced here when it is published.* |
-| RPRC_21 | If the User indicated that they want to verify the information registered about a Relying Party and the Wallet Unit retrieved this information either from the registration certificate or from the online service of the Registrar (see RPRC_16 - RPRC_18), it SHALL verify that all attributes requested in the presentation request are included in the list of attributes registered by the Registrar. If the outcome of the verification is negative, the Wallet Unit SHALL, when asking for User approval according to RPA_07, notify the User about the requested attributes that the Relying Party did not register. |
+<div class="eudi-hlr" id="RPRC_16" markdown>
+<div class="eudi-hlr__id">RPRC_16<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL offer the User the possibility to indicate whether the User wants the Wallet Unit to go online to the competent Registrar if that is needed to verify the information registered about the Relying Party. The Wallet Unit SHALL inform the User that this implies that the Registrar learns about the User's interaction with the Relying Party. The Wallet Unit SHALL also inform the User that not requesting this information from the Registrar means that the Wallet Unit has no way to verify the information included by the Relying Party in the presentation request.
+
+*Note: a) The Wallet Unit can offer this choice to the User either during a presentation transaction in case no registration certificate was received, or as a general User setting. b) If the User indicates they don't want this, the Wallet Unit will not verify the registered information in case there is no registration certificate, see RPRC_18a. However, if there is a registration certificate, the Wallet Unit will always verify the information in the certificate, per RPRC_17.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_17" markdown>
+<div class="eudi-hlr__id">RPRC_17<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the Relying Party sends a registration certificate to the Wallet Unit in a presentation request, the Wallet Unit SHALL verify the authenticity and validity of the registration certificate according to the technical specification meant in RPRC_02. If the certificate is inauthentic or expired, the Wallet Unit SHALL, when asking for User approval according to RPA_07, notify the User that it could not obtain the information registered about the entity.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_18" markdown>
+<div class="eudi-hlr__id">RPRC_18<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the User indicated that they want the Wallet Unit to go online to the competent Registrar if needed to verify the information registered about the Relying Party (see RPRC_16), and the Relying Party did not send a registration certificate to the Wallet Unit, the Wallet Unit SHALL connect to the URL of the online service of the Registrar to obtain this information. If the Wallet Unit cannot connect to this URL or if it cannot verify the authenticity and validity of the registered information, it SHALL, when asking for User approval according to RPA_07, notify the User that it could not obtain the information registered about the Relying Party.
+
+*Note: The URL of the Registrar is included in the extension of the presentation request, see RPRC_19a.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_18a" markdown>
+<div class="eudi-hlr__id">RPRC_18a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the User indicated that they do not want the Wallet Unit to go online to the competent Registrar, the Wallet Unit SHALL NOT do so, even in case the Relying Party did not send a registration certificate to the Wallet Unit in the presentation request.
+
+*Note: This requirement is not applicable in case the Wallet Unit is interacting with a PID Provider or an Attestation Provider. If a PID Provider or an Attestation Provider does not provide a registration certificate, the Wallet Unit must verify their entitlements at the competent Registrar, see ISSU_24a and ISSU_34a.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_19" markdown>
+<div class="eudi-hlr__id">RPRC_19<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Relying Party Instance received one or more registration certificates (see RPRC_10), it SHALL include a single registration certificate applicable for its current intended use in each presentation request to a Wallet Unit, according to the applicable standard's extension mentioned in RPRC_20. The registration certificate SHALL be included in the request by value, not by reference. The Relying Party Instance SHALL do so both in proximity and remote presentation flows.
+
+*Note:  This ensures that no external requests are necessary to validate the Relying Party.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_19a" markdown>
+<div class="eudi-hlr__id">RPRC_19a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Relying Party Instance SHALL include in each presentation request the following information, according to the applicable standard's extension mentioned in RPRC_20a: a) the user-friendly name of the Relying Party, b) the unique identifier of the Relying Party, c) a User-friendly description of the intended use of the Relying Party, d) the URL of the Registrar of the Relying Party, and e) the identifier of the intended use of the Relying Party.
+
+*Note: Including items a) and b) enables the Wallet Unit to show to the User the name of the Relying Party. Including c) enables the Wallet Unit to inform the User about the intended use. Including c) and d) enables the Wallet Unit, if desired by the User, to request from the Registrar the attributes registered by the Relying Party for this intended use, as well as the corresponding privacy policy and other registered information. See [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md) for the definition of this information. Note that in case the Relying Party Instance is operated by an intermediary, items a) - e) pertain to the intermediated Relying Party, see also RPI_06.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_20" markdown>
+<div class="eudi-hlr__id">RPRC_20<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Relying Party Instances and Wallet Units SHALL support the extension for [ISO/IEC 18013-5] or the extension for [OpenID4VP], as specified in [ETSI TS 119 472-2] and amended by a CIR in preparation, as applicable, for transferring a single Relying Party registration certificate from a Relying Party Instance to a Wallet Unit.
+
+*Note: The correct CIR will be referenced here when it is published.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_20a" markdown>
+<div class="eudi-hlr__id">RPRC_20a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Relying Party Instances and Wallet Units SHALL support the extension for [ISO/IEC 18013-5] or the extension for [OpenID4VP], as specified in [ETSI TS 119 472-2] and amended by a CIR in preparation, as applicable, for transferring the information listed in RPRC_19a from a Relying Party Instance to a Wallet Unit.
+
+*Note: The correct CIR will be referenced here when it is published.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_21" markdown>
+<div class="eudi-hlr__id">RPRC_21<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the User indicated that they want to verify the information registered about a Relying Party and the Wallet Unit retrieved this information either from the registration certificate or from the online service of the Registrar (see RPRC_16 - RPRC_18), it SHALL verify that all attributes requested in the presentation request are included in the list of attributes registered by the Registrar. If the outcome of the verification is negative, the Wallet Unit SHALL, when asking for User approval according to RPA_07, notify the User about the requested attributes that the Relying Party did not register.
+
+</div>
+</div>
+
 
 ##### E. Requirements on the presentation and verification of registration certificates of PID Providers and Attestation Providers <!-- omit from toc -->
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| RPRC_22 | If a PID Provider or Attestation Provider received a registration certificate (see RPRC_14), it SHALL include the registration certificate in its Credential Issuer metadata used in the common OpenID4VCI protocol referenced in ISSU_01 and the extension thereof in [ETSI TS 119 472-3]. The registration certificate SHALL be included in the metadata by value, not by reference. *Note: This ensures that no external requests are necessary to validate the PID Provider or Attestation Provider, and that issuance transactions are atomic and self-contained.* |
-| RPRC_22a | A PID Provider or Attestation Provider SHALL include the the following information in its Credential Issuer metadata used in the common OpenID4VCI protocol referenced in ISSU_01 and the extension thereof in [ETSI TS 119 472-3]: a) the user-friendly name of the PID Provider or Attestation Provider, b) the unique identifier of the PID Provider or Attestation Provider, c) a User-friendly description of the PID(s) or attestation(s) issued by this PID Provider or Attestation Provider, d) the URL of the Registrar of the PID Provider or Attestation Provider, and e) the attestation type(s) that the PID Provider or Attestation Provider intends to issue to Wallet Units. |
-| RPRC_23 | A Wallet Unit SHALL verify that the type of attestation it wants to request from the PID Provider or Attestation Provider is registered by the relevant Registrar, according to ISSU_24a for PID Providers and ISSU_34a for Attestation Providers. *Note: Unlike for Relying Parties, see RPRC_21, the Wallet Unit always carries out this verification, regardless of the preference of the User set as per RPRC_16.* |
+<div class="eudi-hlr" id="RPRC_22" markdown>
+<div class="eudi-hlr__id">RPRC_22<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a PID Provider or Attestation Provider received a registration certificate (see RPRC_14), it SHALL include the registration certificate in its Credential Issuer metadata used in the common OpenID4VCI protocol referenced in ISSU_01 and the extension thereof in [ETSI TS 119 472-3]. The registration certificate SHALL be included in the metadata by value, not by reference.
+
+*Note: This ensures that no external requests are necessary to validate the PID Provider or Attestation Provider, and that issuance transactions are atomic and self-contained.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_22a" markdown>
+<div class="eudi-hlr__id">RPRC_22a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A PID Provider or Attestation Provider SHALL include the the following information in its Credential Issuer metadata used in the common OpenID4VCI protocol referenced in ISSU_01 and the extension thereof in [ETSI TS 119 472-3]: a) the user-friendly name of the PID Provider or Attestation Provider, b) the unique identifier of the PID Provider or Attestation Provider, c) a User-friendly description of the PID(s) or attestation(s) issued by this PID Provider or Attestation Provider, d) the URL of the Registrar of the PID Provider or Attestation Provider, and e) the attestation type(s) that the PID Provider or Attestation Provider intends to issue to Wallet Units.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPRC_23" markdown>
+<div class="eudi-hlr__id">RPRC_23<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL verify that the type of attestation it wants to request from the PID Provider or Attestation Provider is registered by the relevant Registrar, according to ISSU_24a for PID Providers and ISSU_34a for Attestation Providers.
+
+*Note: Unlike for Relying Parties, see RPRC_21, the Wallet Unit always carries out this verification, regardless of the preference of the User set as per RPRC_16.*
+
+</div>
+</div>
+
 
 #### A.2.3.27 Topic 48 - Blueprint for requesting data deletion to Relying Parties
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| DATA_DLT_01 | A Wallet Unit SHALL support the possibilities mentioned in DATA_DLT_02, allowing a User to request from a Relying Party the erasure of their attributes that were presented by that Wallet Unit to that Relying Party, in accordance with Article 17 of Regulation (EU) 2016/679. |
-| DATA_DLT_02 | A Wallet Unit SHALL support at least the following possibilities to send a data erasure request to a Relying Party: a) Open a URL in an external browser to ask for the deletion of data in a web form provided by the Relying Party, b) Open an external mail client and start a draft e-mail to the Relying Party, with a suitable template text, c) open an external phone client and start a phone call. Depending on whether a Relying Party URL, e-mail address, and/or phone number was logged for the relevant attestation presentation transaction (see requirement DASH_03 in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency)), the Wallet Unit SHALL offer the User to use one or more of these possibilities. |
-| DATA_DLT_02a | If the User initiates sending a data erasure request for a particular attestation presentation transaction, but no Relying Party URL, e-mail address, or telephone number is available in the log for that transaction, the Wallet Unit SHALL connect to the URL of the online service of the Registrar indicated in the log to obtain this information. The Wallet Unit SHALL inform the User that it must connect to the Registrar to look up the contact information it needs to send a data deletion request. *Note: This situation may occur if there was no registration certificate in the presentation request and the User did not request the Wallet Unit to obtain the information registered about the Relying Party from the Registrar. See RPRC_16 - RPRC_18 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties).* |
-| DATA_DLT_03 | A Wallet Instance SHALL provide a function where the User may select one Relying Party to which a data deletion request must be submitted. |
-| DATA_DLT_04 | Empty |
-| DATA_DLT_05 | A Wallet Unit SHALL include the initiation of a data deletion request in a log, so it can be displayed to the User via the dashboard as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency). *Note: Because the request is sent by an external web browser, e-mail client, or phone client (see DATA_DLT_02), the Wallet Unit can only log the initiation of the request.* |
-| DATA_DLT_06 | For the initiation of a data deletion request, the log SHALL contain at least: - Date and time of the initiation of the request, - Name and unique identifier of the Relying Party to which the request was made, - Attributes requested to be deleted. |
-| DATA_DLT_07 | Before executing a data deletion request, a Relying Party SHALL authenticate the requesting User (or the request itself), using appropriate authentication mechanisms of its own choosing. The Relying Party SHOULD use the authentication or signature facilities offered by the User's Wallet Unit for this purpose. |
-| DATA_DLT_08 | Wallet Units, Relying Parties, and Registrars SHALL comply with the relevant requirements in [Technical Specification 7](../../technical-specifications/ts7-common-interface-for-data-deletion-request.md). |
+<div class="eudi-hlr" id="DATA_DLT_01" markdown>
+<div class="eudi-hlr__id">DATA_DLT_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL support the possibilities mentioned in DATA_DLT_02, allowing a User to request from a Relying Party the erasure of their attributes that were presented by that Wallet Unit to that Relying Party, in accordance with Article 17 of Regulation (EU) 2016/679.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DATA_DLT_02" markdown>
+<div class="eudi-hlr__id">DATA_DLT_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL support at least the following possibilities to send a data erasure request to a Relying Party: a) Open a URL in an external browser to ask for the deletion of data in a web form provided by the Relying Party, b) Open an external mail client and start a draft e-mail to the Relying Party, with a suitable template text, c) open an external phone client and start a phone call. Depending on whether a Relying Party URL, e-mail address, and/or phone number was logged for the relevant attestation presentation transaction (see requirement DASH_03 in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency)), the Wallet Unit SHALL offer the User to use one or more of these possibilities.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DATA_DLT_02a" markdown>
+<div class="eudi-hlr__id">DATA_DLT_02a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the User initiates sending a data erasure request for a particular attestation presentation transaction, but no Relying Party URL, e-mail address, or telephone number is available in the log for that transaction, the Wallet Unit SHALL connect to the URL of the online service of the Registrar indicated in the log to obtain this information. The Wallet Unit SHALL inform the User that it must connect to the Registrar to look up the contact information it needs to send a data deletion request.
+
+*Note: This situation may occur if there was no registration certificate in the presentation request and the User did not request the Wallet Unit to obtain the information registered about the Relying Party from the Registrar. See RPRC_16 - RPRC_18 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DATA_DLT_03" markdown>
+<div class="eudi-hlr__id">DATA_DLT_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Instance SHALL provide a function where the User may select one Relying Party to which a data deletion request must be submitted.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DATA_DLT_04" markdown>
+<div class="eudi-hlr__id">DATA_DLT_04</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DATA_DLT_05" markdown>
+<div class="eudi-hlr__id">DATA_DLT_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL include the initiation of a data deletion request in a log, so it can be displayed to the User via the dashboard as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+*Note: Because the request is sent by an external web browser, e-mail client, or phone client (see DATA_DLT_02), the Wallet Unit can only log the initiation of the request.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DATA_DLT_06" markdown>
+<div class="eudi-hlr__id">DATA_DLT_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For the initiation of a data deletion request, the log SHALL contain at least: - Date and time of the initiation of the request, - Name and unique identifier of the Relying Party to which the request was made, - Attributes requested to be deleted.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DATA_DLT_07" markdown>
+<div class="eudi-hlr__id">DATA_DLT_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Before executing a data deletion request, a Relying Party SHALL authenticate the requesting User (or the request itself), using appropriate authentication mechanisms of its own choosing. The Relying Party SHOULD use the authentication or signature facilities offered by the User's Wallet Unit for this purpose.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="DATA_DLT_08" markdown>
+<div class="eudi-hlr__id">DATA_DLT_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Units, Relying Parties, and Registrars SHALL comply with the relevant requirements in [Technical Specification 7](../../technical-specifications/ts7-common-interface-for-data-deletion-request.md).
+
+</div>
+</div>
+
 
 #### A.2.3.28 Topic 50 - Blueprint to report unlawful or suspicious request of data
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| RPT_DPA_01 | A Wallet Unit SHALL enable the User to start the process of reporting a suspicious presentation request to a DPA. When prompted by the User, a Wallet Unit SHALL provide the contact details of the DPA which supervises the Relying Party that made the suspicious request, if available in the log for that request (see DASH_03). If the contact details of the supervising DPA are not available in the log, the Wallet Unit SHALL provide the contact details of the DPA of the region in which the Wallet Provider is residing. In addition, the Wallet Unit MAY also provide the contact details of other DPAs, taken from the European Data Protection Board website (<https://www.edpb.europa.eu/about-edpb/about-edpb/members_en>). *Note: The DPA contact details may be unavailable in the log if there was no registration certificate in the presentation request and the User did not request the Wallet Unit to obtain the information registered about the Relying Party from the Registrar. See RPRC_16 - RPRC_18 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties).* |
-| RPT_DPA_02 | The Wallet Unit SHALL offer the User the option to report a suspicious request to a DPA via the transaction log presented in the dashboard, see [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency). |
-| RPT_DPA_02a | A Wallet Unit SHALL support at least the following possibilities to report a suspicious presentation request to a DPA, depending on what contact details are available for the DPA: a) Open a URL in an external browser to report the request in a web form provided by the DPA. b) Open an external e-mail client and start a draft e-mail to the DPA, with a suitable template text, c) open an external phone client and start a phone call. |
-| RPT_DPA_03 | Empty |
-| RPT_DPA_04 | A Wallet Provider SHALL ensure that a Wallet Unit allows its User to substantiate a report sent to a DPA, including by attaching relevant information to identify the Relying Party and the Users' claims in a machine-readable format. *Note: The log kept by the Wallet Unit is standardised in [Technical Standard 10](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts10-data-portability-and-download-(export).md) and is machine-readable in order to enable data portability. An excerpt from this log therefore can be used to substantiate the report.* |
-| RPT_DPA_05 | A Wallet Unit SHALL log the fact that it initiated the sending of a report to a DPA (see RPT_DPA_02a), as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency). |
-| RPT_DPA_05a | For a report sent to a DPA, the log SHALL contain at least: a) the date and time when the report was sent, b) the name and country of the DPA, and c) the channel and contact information used for initiating sending the report, i.e., the URL, e-mail address, or phone number of the DPA. |
-| RPT_DPA_06 | Wallet Units, Data Protection Authorities, and Registrars SHALL comply with the relevant requirements in [Technical Specification 8](../../technical-specifications/ts8-common-interface-for-reporting-of-wrp-to-dpa.md). |
+<div class="eudi-hlr" id="RPT_DPA_01" markdown>
+<div class="eudi-hlr__id">RPT_DPA_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL enable the User to start the process of reporting a suspicious presentation request to a DPA. When prompted by the User, a Wallet Unit SHALL provide the contact details of the DPA which supervises the Relying Party that made the suspicious request, if available in the log for that request (see DASH_03). If the contact details of the supervising DPA are not available in the log, the Wallet Unit SHALL provide the contact details of the DPA of the region in which the Wallet Provider is residing. In addition, the Wallet Unit MAY also provide the contact details of other DPAs, taken from the European Data Protection Board website (<https://www.edpb.europa.eu/about-edpb/about-edpb/members_en>).
+
+*Note: The DPA contact details may be unavailable in the log if there was no registration certificate in the presentation request and the User did not request the Wallet Unit to obtain the information registered about the Relying Party from the Registrar. See RPRC_16 - RPRC_18 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties).*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPT_DPA_02" markdown>
+<div class="eudi-hlr__id">RPT_DPA_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The Wallet Unit SHALL offer the User the option to report a suspicious request to a DPA via the transaction log presented in the dashboard, see [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPT_DPA_02a" markdown>
+<div class="eudi-hlr__id">RPT_DPA_02a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL support at least the following possibilities to report a suspicious presentation request to a DPA, depending on what contact details are available for the DPA: a) Open a URL in an external browser to report the request in a web form provided by the DPA. b) Open an external e-mail client and start a draft e-mail to the DPA, with a suitable template text, c) open an external phone client and start a phone call.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPT_DPA_03" markdown>
+<div class="eudi-hlr__id">RPT_DPA_03</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPT_DPA_04" markdown>
+<div class="eudi-hlr__id">RPT_DPA_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL ensure that a Wallet Unit allows its User to substantiate a report sent to a DPA, including by attaching relevant information to identify the Relying Party and the Users' claims in a machine-readable format.
+
+*Note: The log kept by the Wallet Unit is standardised in [Technical Standard 10](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts10-data-portability-and-download-(export).md) and is machine-readable in order to enable data portability. An excerpt from this log therefore can be used to substantiate the report.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPT_DPA_05" markdown>
+<div class="eudi-hlr__id">RPT_DPA_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL log the fact that it initiated the sending of a report to a DPA (see RPT_DPA_02a), as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPT_DPA_05a" markdown>
+<div class="eudi-hlr__id">RPT_DPA_05a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+For a report sent to a DPA, the log SHALL contain at least: a) the date and time when the report was sent, b) the name and country of the DPA, and c) the channel and contact information used for initiating sending the report, i.e., the URL, e-mail address, or phone number of the DPA.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPT_DPA_06" markdown>
+<div class="eudi-hlr__id">RPT_DPA_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Units, Data Protection Authorities, and Registrars SHALL comply with the relevant requirements in [Technical Specification 8](../../technical-specifications/ts8-common-interface-for-reporting-of-wrp-to-dpa.md).
+
+</div>
+</div>
+
 
 #### A.2.3.29 Topic 51 - PID or attestation deletion
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| PAD_01 | A Wallet Unit SHALL at any time enable the User to delete any PID or attestation from their Wallet Unit. |
-| PAD_02 | If the User indicates that a logical PID or attestation must be deleted, and the Wallet Unit contains multiple physical PIDs or attestations corresponding to that logical PID or attestation, a Wallet Unit SHALL delete all of these physical PIDs and attestations simultaneously. *Note: a) This situation may occur if the PID Provider or Attestation Provider issued a batch of physical PIDs or attestations to the Wallet Unit, rather than a single one. b) Physical PIDs or attestations correspond to a logical one if they have not only the same attestation type and Provider, but also the same attribute values. In principle, the same Provider can issue two attestations of the same type to the same Wallet Unit, for example two diplomas from the same university. This corresponds to the notion of a Credential Dataset in OpenID4VCI.* |
-| PAD_03 | If the Wallet Unit deletes a PID or attestation on the User's request, the Wallet Unit SHALL NOT notify the respective PID Provider or Attestation Provider. *Note: This is a matter of User privacy.* |
-| PAD_04 | If the Wallet Unit deletes a PID or device-bound attestation on the User's request, the Wallet Unit SHALL ensure that all cryptographic assets in the WSCA/WSCD or keystores related to this PID or attestation are securely destroyed. *Note: Key deletion for a PID key is a cryptographic key operation and requires User authentication, as specified in requirement WIAM_14.* |
-| PAD_05 | If a Wallet Unit supports the [W3C Digital Credentials API] and it deletes, on the User's request, a PID or attestation previously disclosed to the Digital Credentials API framework, the Wallet Instance SHALL disclose the fact that it no longer stores this PID or attestation to the Digital Credentials API framework. |
-| PAD_06 | Empty |
+<div class="eudi-hlr" id="PAD_01" markdown>
+<div class="eudi-hlr__id">PAD_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Unit SHALL at any time enable the User to delete any PID or attestation from their Wallet Unit.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PAD_02" markdown>
+<div class="eudi-hlr__id">PAD_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the User indicates that a logical PID or attestation must be deleted, and the Wallet Unit contains multiple physical PIDs or attestations corresponding to that logical PID or attestation, a Wallet Unit SHALL delete all of these physical PIDs and attestations simultaneously.
+
+*Note: a) This situation may occur if the PID Provider or Attestation Provider issued a batch of physical PIDs or attestations to the Wallet Unit, rather than a single one. b) Physical PIDs or attestations correspond to a logical one if they have not only the same attestation type and Provider, but also the same attribute values. In principle, the same Provider can issue two attestations of the same type to the same Wallet Unit, for example two diplomas from the same university. This corresponds to the notion of a Credential Dataset in OpenID4VCI.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PAD_03" markdown>
+<div class="eudi-hlr__id">PAD_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the Wallet Unit deletes a PID or attestation on the User's request, the Wallet Unit SHALL NOT notify the respective PID Provider or Attestation Provider.
+
+*Note: This is a matter of User privacy.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PAD_04" markdown>
+<div class="eudi-hlr__id">PAD_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If the Wallet Unit deletes a PID or device-bound attestation on the User's request, the Wallet Unit SHALL ensure that all cryptographic assets in the WSCA/WSCD or keystores related to this PID or attestation are securely destroyed.
+
+*Note: Key deletion for a PID key is a cryptographic key operation and requires User authentication, as specified in requirement WIAM_14.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PAD_05" markdown>
+<div class="eudi-hlr__id">PAD_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If a Wallet Unit supports the [W3C Digital Credentials API] and it deletes, on the User's request, a PID or attestation previously disclosed to the Digital Credentials API framework, the Wallet Instance SHALL disclose the fact that it no longer stores this PID or attestation to the Digital Credentials API framework.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="PAD_06" markdown>
+<div class="eudi-hlr__id">PAD_06</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
 
 #### A.2.3.30 Topic 52 - Relying Party intermediaries
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| RPI_01 | An intermediary SHALL register as a Relying Party, in accordance with all requirements in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), while indicating it intends to act as an intermediary. *Note: a) This implies that an intermediary obtains an access certificate containing its own name and unique Relying Party identifier. b) An intermediary may also obtain a registration certificate according to [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), but this certificate will not be used for intermediated transactions. c) An entity that registered as an intermediary may also register as a Relying Party in its own capacity. In such a case, it will receive one or more registration certificates for its intended use(s), and will use one of these certificates when interacting with a Wallet Unit.* |
-| RPI_02 | Empty |
-| RPI_03 | An intermediary SHALL register each intermediated Relying Party it is acting on behalf of at a Registrar in the Member State where the intermediated Relying Party is established, according all requirements in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties). If a Provider of registration certificates associated with the Registrar issues registration certificates, the intermediary SHALL receive a registration certificate for each of the registered intended uses of the intermediated Relying Party. |
-| RPI_04 | When registering an intermediated Relying Party, an intermediary SHALL provide legally valid evidence that this Relying Party will indeed use the services of this intermediary to interact with Wallet Units. The Registrar SHALL verify this evidence, and, if it is found to be correct, SHALL register the relationship between the intermediary and the intermediated Relying Party. *Note: Such evidence may, for instance, be a contract between the intermediary and the intermediated Relying Party.* |
-| RPI_05 | When an intermediated Relying Party asks its intermediary to request some attributes from a Wallet Unit, it SHALL specify a) its user-friendly name, b) its unique identifier, c) the URL of its Registrar, d) the identifier of its intended use, e) a User-friendly description of its intended use. In addition, if the intermediated Relying Party has registration certificates, it SHALL indicate which single registration certificate the intermediary must include in the presentation request. *Note: a) See RPRC_19a for why the intermediary needs this information. b) Since a), b) and c) will not change for each request, specification of this information can be done once. The same is true for d) and e) if the intermediated Relying Party has only one registered intended use.* |
-| RPI_06 | When requested by an intermediated Relying Party, an intermediary SHALL request a presentation of attributes from a specific Wallet Unit. In the request, the intermediary SHALL include the intermediary's access certificate meant in requirement RPI_01 and the registration certificate of the Relying Party, as meant in RPI_03, if available. In addition, whether or not a registration certificate is available, the intermediary SHALL include in the request the information about the intermediated Relying Party required in RPRC_19a. |
-| RPI_06a | Empty |
-| RPI_07 | In case a Wallet Unit receives a presentation request from an intermediary on behalf of an intermediated Relying Party, it SHALL display the trade names of the intermediary and the intermediary Service to the User when asking for User approval, as described in RPA_07. *Note: a) This is in addition to the trade names of the intermediated Relying Party and its Service, which are required per RPA_06. b) In this case, the trade names of the intermediary and its Service are included in the access certificate presented by the Relying Party Instance, whereas the trade names of the intermediated Relying Party and its Service are included in the extension of the presentation request (see RPRC_19a), and in the registration certificate if available. If these names are different from those in the access certificate, the Wallet Unit knows that the presentation request is from an intermediary on behalf of an intermediated Relying Party.* |
-| RPI_07a | In case a Wallet Unit receives a presentation request from an intermediary on behalf of an intermediated Relying Party, and if the User indicated that they want to verify the information registered about this Relying Party (according to RPRC_16), the Wallet Unit SHALL verify that that the contractual relationship between the Relying Party and the intermediary is indeed registered by the responsible Registrar according to RPI_04, see also RPRC_04. If this verification fails, the Wallet Unit SHALL notify the User when asking for User consent. *Note: The Wallet Unit can either do this by inspecting the registration certificate (if available) or by querying the Registrar.* |
-| RPI_07b | Empty |
-| RPI_08 | When a Wallet Unit presents to an intermediary any User attributes from a PID or attestation, the intermediary SHALL, after successfully carrying out the verifications in RPI_09, forward these attributes (only) to the Relying Party on behalf of which the presentation request was made. If any of the verifications in RPI_09 fail, the intermediary SHALL NOT forward any attributes to the Relying Party. |
-| RPI_09 | When a Wallet Unit presents to an intermediary any attributes from a PID or attestation, the intermediary SHALL verify the authenticity of the PID or attestation, its revocation status, device binding and User binding, as well as any combined presentation of attributes, if applicable, as specified in this ARF and if agreed with the Relying Party. *Note: This ARF does not mandate that a Relying Party must carry out all of these verifications. Therefore, the intermediary and any Relying Party using its services must agree on what verifications the intermediary will carry out.* |
-| RPI_10 | The intermediary SHALL delete any PIDs or attestations it obtained from the Wallet Unit, including any User attributes, completely and immediately after it has sent the User attributes to the intermediated Relying Party. If the intermediary does not send any User attributes to the intermediated Relying Party, for example because one of the verifications in RPI_09 failed, the intermediary SHALL delete the PIDs or attestations completely and immediately as soon as it has completed all necessary verifications. |
+<div class="eudi-hlr" id="RPI_01" markdown>
+<div class="eudi-hlr__id">RPI_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An intermediary SHALL register as a Relying Party, in accordance with all requirements in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), while indicating it intends to act as an intermediary.
+
+*Note: a) This implies that an intermediary obtains an access certificate containing its own name and unique Relying Party identifier. b) An intermediary may also obtain a registration certificate according to [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), but this certificate will not be used for intermediated transactions. c) An entity that registered as an intermediary may also register as a Relying Party in its own capacity. In such a case, it will receive one or more registration certificates for its intended use(s), and will use one of these certificates when interacting with a Wallet Unit.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_02" markdown>
+<div class="eudi-hlr__id">RPI_02</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_03" markdown>
+<div class="eudi-hlr__id">RPI_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An intermediary SHALL register each intermediated Relying Party it is acting on behalf of at a Registrar in the Member State where the intermediated Relying Party is established, according all requirements in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties). If a Provider of registration certificates associated with the Registrar issues registration certificates, the intermediary SHALL receive a registration certificate for each of the registered intended uses of the intermediated Relying Party.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_04" markdown>
+<div class="eudi-hlr__id">RPI_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When registering an intermediated Relying Party, an intermediary SHALL provide legally valid evidence that this Relying Party will indeed use the services of this intermediary to interact with Wallet Units. The Registrar SHALL verify this evidence, and, if it is found to be correct, SHALL register the relationship between the intermediary and the intermediated Relying Party.
+
+*Note: Such evidence may, for instance, be a contract between the intermediary and the intermediated Relying Party.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_05" markdown>
+<div class="eudi-hlr__id">RPI_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When an intermediated Relying Party asks its intermediary to request some attributes from a Wallet Unit, it SHALL specify a) its user-friendly name, b) its unique identifier, c) the URL of its Registrar, d) the identifier of its intended use, e) a User-friendly description of its intended use. In addition, if the intermediated Relying Party has registration certificates, it SHALL indicate which single registration certificate the intermediary must include in the presentation request.
+
+*Note: a) See RPRC_19a for why the intermediary needs this information. b) Since a), b) and c) will not change for each request, specification of this information can be done once. The same is true for d) and e) if the intermediated Relying Party has only one registered intended use.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_06" markdown>
+<div class="eudi-hlr__id">RPI_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When requested by an intermediated Relying Party, an intermediary SHALL request a presentation of attributes from a specific Wallet Unit. In the request, the intermediary SHALL include the intermediary's access certificate meant in requirement RPI_01 and the registration certificate of the Relying Party, as meant in RPI_03, if available. In addition, whether or not a registration certificate is available, the intermediary SHALL include in the request the information about the intermediated Relying Party required in RPRC_19a.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_06a" markdown>
+<div class="eudi-hlr__id">RPI_06a</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_07" markdown>
+<div class="eudi-hlr__id">RPI_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+In case a Wallet Unit receives a presentation request from an intermediary on behalf of an intermediated Relying Party, it SHALL display the trade names of the intermediary and the intermediary Service to the User when asking for User approval, as described in RPA_07.
+
+*Note: a) This is in addition to the trade names of the intermediated Relying Party and its Service, which are required per RPA_06. b) In this case, the trade names of the intermediary and its Service are included in the access certificate presented by the Relying Party Instance, whereas the trade names of the intermediated Relying Party and its Service are included in the extension of the presentation request (see RPRC_19a), and in the registration certificate if available. If these names are different from those in the access certificate, the Wallet Unit knows that the presentation request is from an intermediary on behalf of an intermediated Relying Party.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_07a" markdown>
+<div class="eudi-hlr__id">RPI_07a<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+In case a Wallet Unit receives a presentation request from an intermediary on behalf of an intermediated Relying Party, and if the User indicated that they want to verify the information registered about this Relying Party (according to RPRC_16), the Wallet Unit SHALL verify that that the contractual relationship between the Relying Party and the intermediary is indeed registered by the responsible Registrar according to RPI_04, see also RPRC_04. If this verification fails, the Wallet Unit SHALL notify the User when asking for User consent.
+
+*Note: The Wallet Unit can either do this by inspecting the registration certificate (if available) or by querying the Registrar.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_07b" markdown>
+<div class="eudi-hlr__id">RPI_07b</div>
+<div class="eudi-hlr__body" markdown>
+
+Empty
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_08" markdown>
+<div class="eudi-hlr__id">RPI_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When a Wallet Unit presents to an intermediary any User attributes from a PID or attestation, the intermediary SHALL, after successfully carrying out the verifications in RPI_09, forward these attributes (only) to the Relying Party on behalf of which the presentation request was made. If any of the verifications in RPI_09 fail, the intermediary SHALL NOT forward any attributes to the Relying Party.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_09" markdown>
+<div class="eudi-hlr__id">RPI_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When a Wallet Unit presents to an intermediary any attributes from a PID or attestation, the intermediary SHALL verify the authenticity of the PID or attestation, its revocation status, device binding and User binding, as well as any combined presentation of attributes, if applicable, as specified in this ARF and if agreed with the Relying Party.
+
+*Note: This ARF does not mandate that a Relying Party must carry out all of these verifications. Therefore, the intermediary and any Relying Party using its services must agree on what verifications the intermediary will carry out.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="RPI_10" markdown>
+<div class="eudi-hlr__id">RPI_10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+The intermediary SHALL delete any PIDs or attestations it obtained from the Wallet Unit, including any User attributes, completely and immediately after it has sent the User attributes to the intermediated Relying Party. If the intermediary does not send any User attributes to the intermediated Relying Party, for example because one of the verifications in RPI_09 failed, the intermediary SHALL delete the PIDs or attestations completely and immediately as soon as it has completed all necessary verifications.
+
+</div>
+</div>
+
 
 #### A.2.3.31 Topic 53 - Zero-Knowledge Proofs
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ZKP_01 | A ZKP scheme SHALL provide support for the following generic functions, while hiding all attributes of PIDs or attestations: (i) generation of a proof that an (some) attribute(s) having a specific value is (are) included in a PID or attestation, (ii) generation of a proof that a PID or attestation is within its validity period, (iii) generation of a proof that a PID or attestation has not been revoked, and (iv) generation of a proof that a PID or device-bound attestation is bound to a key stored in the WSCA/WSCD or in a keystore of the Wallet Unit. Additionally, a ZKP scheme SHOULD provide support for the following function, which SHOULD be used only when hiding the PID Provider or Attestation Provider is necessary: (v) generation of a proof that a PID or attestation has been issued by a trusted PID Provider or Attestation Provider, without revealing the PID Provider or Attestation Provider. *Note: See section 4.1.1 of the Discussion Paper for Topic G.* |
-| ZKP_02 | A ZKP scheme SHALL support proving possession of attestation of a given type. *Note: See section 4.1.2 and 4.1.3 of the Discussion Paper for Topic G.* |
-| ZKP_03 | A ZKP scheme SHOULD support the privacy-preserving binding of an attestation to a PID. In addition to the generic functions defined in ZKP_01, for this use case, a ZKP scheme SHALL provide support for the following functions: (i) generation of a proof that the Wallet Unit stores an attestation and a PID and that the attestation includes a specific attribute, having a specific value, which is also present in the PID. *Note: See section 4.1.4 of the Discussion Paper for Topic G.* |
-| ZKP_04 | A ZKP scheme SHOULD support the derivation of a verifiable User pseudonym, by combining an attribute value that is unique for the User with Relying Party-specific context (e.g., the Relying Party identifier) In addition to the generic functions defined in ZKP_01, for this use case, a ZKP scheme SHALL provide support for the following functions: (i) generation of a request for the issuance of an attestation that includes a secret attribute unique to the User, without revealing this attribute to the Attestation Provider, (ii) generation of an attestation presentation that includes a verifiable pseudonym derived from the secret attribute, a Relying Party identifier, and context-related information. *Note: See section 4.1.5 of the Discussion Paper for Topic G.* |
-| ZKP_05 | A ZKP scheme SHALL be usable in both remote and proximity presentation flows. While the inclusion of ZKP will introduce computational and verification delays, these delays SHALL NOT critically undermine or defeat the purpose of the Relying Party service (e.g. because of a critical impact on the User experience of the Wallet Unit). |
-| ZKP_06 | A ZKP scheme SHOULD be able to generate proofs for already issued PIDs and attestations in the formats specified in [ISO/IEC 18013-5] or [SD-JWT VC]. |
-| ZKP_07 | A ZKP scheme SHALL NOT introduce any additional communication or information that could be used to track or link User activity during, before, or after proof generation. |
-| ZKP_08 | A ZKP scheme SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0]. |
-| ZKP_09 | Use of a ZKP scheme SHALL NOT prevent the Wallet Unit's ability to provide User authentication with Level of Assurance High. |
+<div class="eudi-hlr" id="ZKP_01" markdown>
+<div class="eudi-hlr__id">ZKP_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A ZKP scheme SHALL provide support for the following generic functions, while hiding all attributes of PIDs or attestations: (i) generation of a proof that an (some) attribute(s) having a specific value is (are) included in a PID or attestation, (ii) generation of a proof that a PID or attestation is within its validity period, (iii) generation of a proof that a PID or attestation has not been revoked, and (iv) generation of a proof that a PID or device-bound attestation is bound to a key stored in the WSCA/WSCD or in a keystore of the Wallet Unit. Additionally, a ZKP scheme SHOULD provide support for the following function, which SHOULD be used only when hiding the PID Provider or Attestation Provider is necessary: (v) generation of a proof that a PID or attestation has been issued by a trusted PID Provider or Attestation Provider, without revealing the PID Provider or Attestation Provider.
+
+*Note: See section 4.1.1 of the Discussion Paper for Topic G.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ZKP_02" markdown>
+<div class="eudi-hlr__id">ZKP_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A ZKP scheme SHALL support proving possession of attestation of a given type.
+
+*Note: See section 4.1.2 and 4.1.3 of the Discussion Paper for Topic G.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ZKP_03" markdown>
+<div class="eudi-hlr__id">ZKP_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A ZKP scheme SHOULD support the privacy-preserving binding of an attestation to a PID. In addition to the generic functions defined in ZKP_01, for this use case, a ZKP scheme SHALL provide support for the following functions: (i) generation of a proof that the Wallet Unit stores an attestation and a PID and that the attestation includes a specific attribute, having a specific value, which is also present in the PID.
+
+*Note: See section 4.1.4 of the Discussion Paper for Topic G.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ZKP_04" markdown>
+<div class="eudi-hlr__id">ZKP_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A ZKP scheme SHOULD support the derivation of a verifiable User pseudonym, by combining an attribute value that is unique for the User with Relying Party-specific context (e.g., the Relying Party identifier) In addition to the generic functions defined in ZKP_01, for this use case, a ZKP scheme SHALL provide support for the following functions: (i) generation of a request for the issuance of an attestation that includes a secret attribute unique to the User, without revealing this attribute to the Attestation Provider, (ii) generation of an attestation presentation that includes a verifiable pseudonym derived from the secret attribute, a Relying Party identifier, and context-related information.
+
+*Note: See section 4.1.5 of the Discussion Paper for Topic G.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ZKP_05" markdown>
+<div class="eudi-hlr__id">ZKP_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A ZKP scheme SHALL be usable in both remote and proximity presentation flows. While the inclusion of ZKP will introduce computational and verification delays, these delays SHALL NOT critically undermine or defeat the purpose of the Relying Party service (e.g. because of a critical impact on the User experience of the Wallet Unit).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ZKP_06" markdown>
+<div class="eudi-hlr__id">ZKP_06<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A ZKP scheme SHOULD be able to generate proofs for already issued PIDs and attestations in the formats specified in [ISO/IEC 18013-5] or [SD-JWT VC].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ZKP_07" markdown>
+<div class="eudi-hlr__id">ZKP_07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A ZKP scheme SHALL NOT introduce any additional communication or information that could be used to track or link User activity during, before, or after proof generation.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ZKP_08" markdown>
+<div class="eudi-hlr__id">ZKP_08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A ZKP scheme SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ZKP_09" markdown>
+<div class="eudi-hlr__id">ZKP_09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Use of a ZKP scheme SHALL NOT prevent the Wallet Unit's ability to provide User authentication with Level of Assurance High.
+
+</div>
+</div>
+
 
 #### A.2.3.32 Topic 54 - Accessibility
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| ACC_01 | Wallet Providers SHALL ensure that their Wallet Units comply with applicable requirements and standards in [Directive 2016/2012 on the accessibility of websites and mobile applications of public sector bodies](http://data.europa.eu/eli/dir/2016/2102/oj). *Note: Compliance with the European Standard [ETSI EN 301 549 V1.1.2](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf) (2015-04) provides a presumption of conformity to the Accessibility Directive.* |
-| ACC_02 | Wallet Providers SHALL ensure that their Wallet Units comply with accessibility requirements for products and services established under [Directive (EU) 2019/882](http://data.europa.eu/eli/dir/2019/882/oj). *Note: Compliance with the European Standard [ETSI EN 301 549 V1.1.2](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf) (2015-04) potentially provides a presumption of conformity to this Directive.* |
+<div class="eudi-hlr" id="ACC_01" markdown>
+<div class="eudi-hlr__id">ACC_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that their Wallet Units comply with applicable requirements and standards in [Directive 2016/2012 on the accessibility of websites and mobile applications of public sector bodies](http://data.europa.eu/eli/dir/2016/2102/oj).
+
+*Note: Compliance with the European Standard [ETSI EN 301 549 V1.1.2](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf) (2015-04) provides a presumption of conformity to the Accessibility Directive.*
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="ACC_02" markdown>
+<div class="eudi-hlr__id">ACC_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL ensure that their Wallet Units comply with accessibility requirements for products and services established under [Directive (EU) 2019/882](http://data.europa.eu/eli/dir/2019/882/oj).
+
+*Note: Compliance with the European Standard [ETSI EN 301 549 V1.1.2](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf) (2015-04) potentially provides a presumption of conformity to this Directive.*
+
+</div>
+</div>
+
 
 #### A.2.3.33 Topic 55 - Certificate Transparency
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| CT_01 | An Access CA issuing access certificates SHALL register these in a CT log according to RFC 9162, if such a log is available for access certificates. |
-| CT_02 | An Access CA issuing access certificates SHALL describe in its CPS how it logs all access certificates. |
-| CT_03 | In case a CT log provider for access certificates is available, all Access CAs SHALL act as monitors in the CT ecosystem. Access CAs SHOULD still monitor the CT logs in situations of temporary unavailability. |
-| CT_04 | An Access CA SHALL include at least one Signed Certificate Timestamp (SCT) in each access certificate. |
-| CT_05 | When verifying an access certificate during PID or attestation issuance or presentation, a Wallet Unit SHALL also verify that the access certificate includes at least one valid Signed Certificate Timestamp (SCT). |
-| CT_06 | If an access certificate does not include a valid SCT, a Wallet Unit SHALL handle this as a failure or Relying Party authentication, in compliance with all requirements in [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] and in particular requirement RPA_06a. |
+<div class="eudi-hlr" id="CT_01" markdown>
+<div class="eudi-hlr__id">CT_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Access CA issuing access certificates SHALL register these in a CT log according to RFC 9162, if such a log is available for access certificates.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="CT_02" markdown>
+<div class="eudi-hlr__id">CT_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Access CA issuing access certificates SHALL describe in its CPS how it logs all access certificates.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="CT_03" markdown>
+<div class="eudi-hlr__id">CT_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+In case a CT log provider for access certificates is available, all Access CAs SHALL act as monitors in the CT ecosystem. Access CAs SHOULD still monitor the CT logs in situations of temporary unavailability.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="CT_04" markdown>
+<div class="eudi-hlr__id">CT_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+An Access CA SHALL include at least one Signed Certificate Timestamp (SCT) in each access certificate.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="CT_05" markdown>
+<div class="eudi-hlr__id">CT_05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+When verifying an access certificate during PID or attestation issuance or presentation, a Wallet Unit SHALL also verify that the access certificate includes at least one valid Signed Certificate Timestamp (SCT).
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="CT_06" markdown>
+<div class="eudi-hlr__id">CT_06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+If an access certificate does not include a valid SCT, a Wallet Unit SHALL handle this as a failure or Relying Party authentication, in compliance with all requirements in [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] and in particular requirement RPA_06a.
+
+</div>
+</div>
+
 
 #### A.2.3.34 Topic 56 - Wallet Provider Support and Maintenance
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-| WPSM_01 | A Wallet Provider SHALL monitor their installed base of operational Wallet Instances for maintenance purposes, and determine and document in a transparent manner the data it needs and is allowed to monitor in order to deliver the required support. Data or attributes that SHOULD be monitored include: 1) Runtime errors, for uncaught errors in production code, 2) UX and telemetry information, for UX field analysis, 3) OS version and health information, for detection of OS level vulnerabilities, 4) Wallet Instance SDK and software library version information, for Wallet Instance code vulnerabilities, 5) User locale/localisation data, for catching localisation related errors, 6) Wallet Instance version, for catching errors or vulnerabilities due to outdated versions, 7) Supported WSCA/WSCDs and keystores and their supported capabilities, for detection of cryptography incompatibilities, 8) Unique device identifier such as IDFV or persisted UUID (iOS) or AndroidID (Android), for maintaining an up-to-date list of Wallet Instance-related device installations and for detecting potential malicious use (unrecognised identifier), 9) Device sensor identifiers and patch levels, for checking if sensor hardware in the device is up-to-date. 10) hardware-level details about the device, to identify known hardware-based problems or vulnerabilities, 11) BLE and NFC support by device, for analysing the security and feasibility of proximity use cases with a given Wallet Instance. |
-| WPSM_02 | Wallet Providers SHALL, for maintenance purposes, write custom crash logs for sending them for further analysis. |
-| WPSM_03 | A Wallet Provider SHALL monitor the security posture of its operational Wallet Instances for the purpose of detecting critical security risks in the environment the Wallet Instance is run at, and determine and document in a transparent manner the data it needs and is allowed to monitor. Information that SHOULD be monitored for software and hardware level problems/vulnerabilities on device includes 1) detection of device rooting/jailbreaking, 2) emulator detection, 3) device OS version and health data, 4) Wallet Instance SDK and SW library versions, 5) Wallet Instance version, 6) Supported WSCA/WSCD and keystore(s) and 7) Sensor identifiers and patch levels. |
-| WPSM_04 | During the lifetime of the Wallet Unit, the Wallet Provider SHALL update the Wallet Unit as necessary to ensure its continued security and functionality. |
+<div class="eudi-hlr" id="WPSM_01" markdown>
+<div class="eudi-hlr__id">WPSM_01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL monitor their installed base of operational Wallet Instances for maintenance purposes, and determine and document in a transparent manner the data it needs and is allowed to monitor in order to deliver the required support. Data or attributes that SHOULD be monitored include: 1) Runtime errors, for uncaught errors in production code, 2) UX and telemetry information, for UX field analysis, 3) OS version and health information, for detection of OS level vulnerabilities, 4) Wallet Instance SDK and software library version information, for Wallet Instance code vulnerabilities, 5) User locale/localisation data, for catching localisation related errors, 6) Wallet Instance version, for catching errors or vulnerabilities due to outdated versions, 7) Supported WSCA/WSCDs and keystores and their supported capabilities, for detection of cryptography incompatibilities, 8) Unique device identifier such as IDFV or persisted UUID (iOS) or AndroidID (Android), for maintaining an up-to-date list of Wallet Instance-related device installations and for detecting potential malicious use (unrecognised identifier), 9) Device sensor identifiers and patch levels, for checking if sensor hardware in the device is up-to-date. 10) hardware-level details about the device, to identify known hardware-based problems or vulnerabilities, 11) BLE and NFC support by device, for analysing the security and feasibility of proximity use cases with a given Wallet Instance.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WPSM_02" markdown>
+<div class="eudi-hlr__id">WPSM_02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Wallet Providers SHALL, for maintenance purposes, write custom crash logs for sending them for further analysis.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WPSM_03" markdown>
+<div class="eudi-hlr__id">WPSM_03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+A Wallet Provider SHALL monitor the security posture of its operational Wallet Instances for the purpose of detecting critical security risks in the environment the Wallet Instance is run at, and determine and document in a transparent manner the data it needs and is allowed to monitor. Information that SHOULD be monitored for software and hardware level problems/vulnerabilities on device includes 1) detection of device rooting/jailbreaking, 2) emulator detection, 3) device OS version and health data, 4) Wallet Instance SDK and SW library versions, 5) Wallet Instance version, 6) Supported WSCA/WSCD and keystore(s) and 7) Sensor identifiers and patch levels.
+
+</div>
+</div>
+
+<div class="eudi-hlr" id="WPSM_04" markdown>
+<div class="eudi-hlr__id">WPSM_04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+During the lifetime of the Wallet Unit, the Wallet Provider SHALL update the Wallet Unit as necessary to ensure its continued security and functionality.
+
+</div>
+</div>
 

--- a/docs/annexes/annex-2/annex-2.03-high-level-requirements-by-category.md
+++ b/docs/annexes/annex-2/annex-2.03-high-level-requirements-by-category.md
@@ -23,7 +23,8 @@ In addition, 'must' (non-capitalised) is used to indicate an external
 constraint, i.e., a requirement that is not mandated by this document, but, for
 instance, by an external standard or specification. The word 'can' indicates a
 capability, whereas other words, such as 'will', and 'is' or 'are', are intended
-as statements of fact.
+as statements of fact. Each requirement is anchorable via its identifier, e.g.
+`#WP_01`.
 
 ---
 
@@ -35,299 +36,3971 @@ as statements of fact.
 *the EUDI Wallet solutions. They cover the core functionalities, security, user*
 *interface elements, and lifecycle management of the wallet.*
 
+<div class="eudi-hlr" id="AS-WP-06-001" markdown>
+<div class="eudi-hlr__id">AS-WP-06-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
 
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
-|AS-WP-06-001 | RPA_01 | The Wallet Unit used by a User, as well as the Relying Party Instance used by the Relying Party, SHALL implement a mechanism for Relying Party authentication in PID or attestation presentation transactions. This mechanism SHALL: - enable the Wallet Unit to identify and authenticate the Relying Party, - enable the Wallet Unit to verify that the request from the Relying Party was not copied and replayed, - use an access certificate issued in accordance with [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].| Wallet Units and Relying Parties comply with this requirement if they comply with the requirements in this Topic. |
-|AS-WP-06-002 | RPA_01a | If a Wallet Unit supports the [W3C Digital Credentials API] for remote presentation flows, it SHALL retain full authority over the process meant in RPA_01. In particular, this process SHALL NOT be handled by a third party, including the browser and the operating system.|  |
-|AS-WP-06-003 | RPA_02 | For performing Relying Party authentication, Wallet Units and Relying Party Instances SHALL support access certificates as specified in [ETSI TS 119 475] and [ETSI TS 119 411-8].| In [ISO/IEC 18013-5], the Relying Party authentication mechanism is called mdoc reader authentication and uses an X.509 certificate. For [OpenID4VP], [HAIP] specifies that Client Identifier Prefix ``x509_hash`` must be used to authenticate the Relying Party; this also uses an X.509 certificate. |
-|AS-WP-06-004 | RPA_03 | A Wallet Unit and a Relying Party Instance SHALL perform Relying Party authentication in all PID or attestation presentation transactions to Relying Parties, whether proximity or remote, using an access certificate.| The actions both entities perform differ. For example, while the Relying Party creates a signature over some data in the request, the Wallet Unit validates that signature. |
-|AS-WP-06-005 | RPA_04 | For the verification of access certificates, a Wallet Unit SHALL accept only the trust anchors in the LoTE(s) of all Access Certificate Authorities notified by Member States.| For more information about Access Certificate Authorities, please see [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)]. |
-|AS-WP-06-006 | RPA_05 | If Relying Party authentication fails for any reason, the Wallet Instance SHALL inform the User that the identity of the Relying Party could not be verified and that therefore the request is not trustworthy.|  |
-|AS-WP-06-007 | RPA_06 | If Relying Party authentication succeeds, the Wallet Instance SHALL display to the User the trade names of the Relying Party and its Service, as included in the access certificate received from the Relying Party Instance, together with the attributes requested by the Relying Party. The Wallet Instance SHALL do so when asking the User for approval according to RPA_07.| a) A Relying Party Instance may be used for multiple Relying Party services, provided it has received a separate access certificate for each, see Reg_10b. b) If the Relying Party is an intermediary acting on behalf of an intermediated Relying Party, the Wallet Instance displays the trade names of both the intermediary and the intermediated Relying Party to the User, see RPI_07. |
-|AS-WP-06-008 | RPA_06a | If Relying Party authentication fails for any reason, the Wallet Unit SHALL notify the User. In addition, the Wallet Unit SHALL either not present the requested attributes to the Relying Party, or give the User the choice to present the requested attributes or not.| It is up to the Wallet Provider to make a choice for one of these two options. |
-|AS-WP-06-009 | RPA_07 | A Wallet Unit SHALL ensure the User approved the presentation of any attribute(s) in the Wallet Unit to a Relying Party or Verifier Wallet Unit, prior to presenting these attributes. A Wallet Unit SHALL always allow the User to refuse presenting an attribute requested by the Relying Party or Verifier Wallet Unit.|  |
-|AS-WP-06-010 | RPA_07a | If a Wallet Unit supports the [W3C Digital Credentials API] for remote presentation flows, it SHALL retain full authority over the process meant in RPA_07. In particular, this process SHALL NOT be handled by a third party, including the browser and the operating system.|  |
-|AS-WP-06-011 | RPA_08 | A Wallet Unit SHALL authenticate the User before allowing the User to give or refuse approval for releasing any attributes, in accordance with WIAM_14 or WIAM_15, as applicable.|  |
-|AS-WP-06-012 | RPA_09 | Empty|  |
-|AS-WP-06-013 | RPA_10 | When asking for User approval, the Wallet Unit SHALL show to the User the User-friendly description of the Relying Party's intended use and, if available, the link to the applicable privacy policy.| The User-friendly description of the Relying Party's intended use is included in the presentation request and also in the registration certificate, if available. The link to the privacy policy is included in the registration certificate, or in the absence of a registration certificate, the Wallet Unit obtained the link from the Registrar's online service, if the User requested this. See RPRC_19a and other requirements in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties) for details. |
-|AS-WP-06-014 | RPA_10a | The Wallet Unit SHOULD ensure that the User gives approval either to present all attributes requested in a presentation request, or none of them.| This means that a User should be asked either to approve the presentation of all requested attributes or to deny all of them. The Wallet Unit should not allow partial approval, since this would mean that the Relying Party cannot deliver the service, but nevertheless receives some User attributes. This would be a violation of the User's privacy. Note that a Relying Party is not allowed to request more data than is justified for the intended use. So if the User feels that the Relying Party is actually requesting more data than needed, that implies that the Relying Party is not trustworthy and should not receive any data. |
-|AS-WP-06-015 | RPA_11 | When the presentation of an attestation or a PID is denied by the User, the Wallet Unit SHALL behave towards the Relying Party as if the attestation or PID did not exist.|  |
-|AS-WP-06-016 | RPA_12 | When asking for User approval, the Wallet Unit MAY indicate to the User whether the attestation requested by a Relying Party is device-bound or not.| The intent of this indication is to warn the User that a non-device-bound attestation may be copied by the Relying Party and presented to a third party. |
-|AS-WP-09-001 | WUA_01 | A Key Attestation SHALL contain information about the certification of the WSCA/WSCD or a keystore available to the Wallet Unit, and SHALL comply with the relevant requirements in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).| A PID Provider or Attestation Provider can use this information to take a well-grounded decision on whether to issue a PID or attestation to the Wallet Unit. |
-|AS-WP-09-002 | WUA_02 | A Key Attestation SHALL enable PID Providers and Attestation Providers to verify the authenticity of a WSCD or keystore and to check whether the WSCD or keystore has been revoked.| A KA carries a revocation reference that is valid for the WSCD or keystore of the Wallet Unit. How this revocation reference is managed (individually or per type of WSCD/keystore) depends on the approach chosen by the Wallet Provider (see WUA_28), but this is not relevant for the PID Provider or Attestation Provider that receives the KA. |
-|AS-WP-09-003 | WUA_03 | A Wallet Provider SHALL ensure that a non-revoked Wallet Unit at all times can present a temporally valid and non-revoked KA to a PID Provider or Attestation Provider during the issuance process of a PID or device-bound attestation.| a) Revocation refers to the attested WSCD/keystore, not to the KA itself. b) For example, the Wallet Provider could pro-actively issue new KAs to the Wallet Unit, so that the Wallet Unit is always in possession of a valid KA. Alternatively, the Wallet Provider could ensure that whenever the User opens the Wallet Unit, it checks whether it is possession of a valid KA, and requests the Wallet Provider to issue a new KA if needed. A third possibility is that the Wallet Unit does this check only when it starts the process of requesting the (re-)issuance of a PID or attestation. Other alternatives to comply with this requirement may be used as well. |
-|AS-WP-09-004 | WUA_04 | When issuing, presenting, or verifying a WIA or KA, Wallet Providers, Wallet Units, PID Providers, and Attestation Providers SHALL only use cryptographic algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].|  |
-|AS-WP-09-005 | WUA_05 | During issuance of a PID, the Wallet Unit SHALL provide the PID Provider with a valid KA describing the WSCA/WSCD that generated the new PID private key.| A PID private key is always generated and managed by the WSCA/WSCD, which by definition complies with requirements for Level of Assurance High. |
-|AS-WP-09-006 | WUA_05a | During issuance of a device-bound attestation, a Wallet Unit SHALL retrieve the requirements of the Attestation Provider regarding key storage from the Credential Issuer metadata (see ISSU_27d). The Wallet Unit SHALL determine which of its WSCA/WSCD or keystore(s), if any, comply with these requirements. If a compliant WSCA/WSCD or keystore is available to the Wallet Unit, the Wallet Unit SHALL provide the Attestation Provider with a valid KA describing the selected WSCA/WSCD or keystore.| A KA describes the certification properties of the WSCA/WSCD or a keystore (see WUA_01) and contains one or more public key(s) corresponding to private key(s) generated by and stored in that WSCA/WSCD or keystore (see WUA_09). |
-|AS-WP-09-007 | WUA_06 | If a Wallet Unit contains a WSCA/WSCD and one or more keystores, it SHALL, internally and securely, keep track of which PID(s) and attestation(s) are bound to which WSCA/WSCD or keystore.|  |
-|AS-WP-09-008 | WUA_07 | A Wallet Unit SHALL present a KA only to a PID Provider or Attestation Provider, as part of the issuance process of a PID or a key-bound attestation, and not to a Relying Party or any other entity.|  |
-|AS-WP-09-009 | WUA_08 | A WIA SHALL enable PID Providers to request a Wallet Provider to revoke a Wallet Unit, in accordance with requirement WURevocation_11, by including an identifier for the Wallet Instance in the WIA. The Wallet Provider SHALL ensure that this Wallet Instance identifier does not enable tracking of the User.| a) This is a legal requirement from [CIR 2024/2977].  b) Under [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) V1.5, this Wallet Instance identifier is the URI and index to the Attestation Status List for WIAs. |
-|AS-WP-09-010 | WUA_09 | A KA SHALL contain one or more public keys, and the corresponding private keys SHALL be generated by and stored in the WSCA/WSCD or the keystore described in the KA.| a) By signing the KA, the Wallet Provider attests to the fact that the private key(s) corresponding to the public key(s) in the KA are generated by and stored in this WSCA/WSCD or keystore. This implies that the Wallet Provider has verified that this is actually the case. However, neither the ARF nor [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) specify at which moment the WSCA/WSCD or keystore generated the private keys, or how the Wallet Provider verified that it did so. b) After receiving a KA during the issuance process for a (batch of) PID(s) or device-bound attestation(s), a PID Provider or Attestation Provider will include each of these public keys in a PID or attestation, thereby ensuring that this PID or attestation is bound to the WSCA/WSCD or keystore described in the KA. |
-|AS-WP-09-011 | WUA_10 | Wallet Providers SHALL ensure that the certificates they use for signing WIAs and KAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 5.|  |
-|AS-WP-09-012 | WUA_10a | An Attestation Provider issuing non-device-bound attestations SHALL indicate in its Credential Issuer metadata that it does not need a KA, as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). A Wallet Unit SHALL NOT send a KA to an Attestation Provider when requesting a non-device-bound attestation.| A Wallet Unit sends a WIA to the Attestation Provider regardless of whether the attestations it issues are device-bound or not. |
-|AS-WP-09-013 | WUA_10b | A Wallet Provider SHALL ensure that the presentation of a KA is cryptographically bound to the specific context it is intended to be used in.| As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), this is achieved by letting the signed KA itself contain a nonce provided by the PID Provider or Attestation Provider during the issuance process. Alternatively, the Wallet Unit presents the KA along with a Proof-of-Possession consisting of a signature over that nonce, created by the private key corresponding to one of the public keys attested in the KA. |
-|AS-WP-09-014 | WUA_11 | When asking for User approval to store an attestation (see ISSU_11), the Wallet Unit MAY indicate to the User whether the attestation requested by a Relying Party is device-bound or not.| The intent of this indication is to warn the User that a non-device-bound attestation may be copied by an attacker breaching the Wallet Unit's security. See also RPA_12. |
-|AS-WP-09-015 | WUA_11a | During issuance of a PID or a device-bound attestation, the PID Provider or Attestation Provider SHALL verify the KA in accordance with the requirements in [OpenID4VCI] Appendix F.4. In addition, the PID Provider or Attestation Provider SHALL validate that the KA is not revoked.| If the verification of the KA is successful, the PID Provider or Attestation Provider can trust that all public keys in the KA are bound to the WSCD or keystore described in the KA (see WUA_09). |
-|AS-WP-09-016 | WUA_11b | Empty|  |
-|AS-WP-09-017 | WUA_12 | During issuance of a PID or a device-bound attestation, the PID Provider or Attestation Provider SHALL receive a proof that the Wallet Unit possesses the private keys corresponding to all public keys in the KA.| As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), this proof consists of the signature of the Wallet Provider over the KA in combination with the proof mentioned in WUA_10b. |
-|AS-WP-09-018 | WUA_13 | Empty|  |
-|AS-WP-09-019 | WUA_14 | Empty|  |
-|AS-WP-09-020 | WUA_15 | Empty|  |
-|AS-WP-09-021 | WUA_16 | Empty|  |
-|AS-WP-09-022 | WUA_16a | A WSCA SHALL NOT enable export of private keys from a WSCD.| The WSCA is dedicated firmware and/or software implementing specific functions needed within the EUDI Wallet ecosystem. Within that context, there is no need for private key export; therefore, a WSCA must not support it. However, a WSCD or a keystore may enable private key export via native firmware or software, for generic purposes. |
-|AS-WP-09-023 | WUA_17 | A Wallet Provider SHALL consider all relevant factors, including offline usage, interoperability, and the risk of a WIA or KA becoming a vector to track the User, when deciding on the validity period of a WIA or KA.| a) Regarding interoperability, see WUA_30, which limits the validity period of PIDs issued based on the revocation maintenance periods of the WIA and KA received during issuance. b) As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), a PID Provider or Attestation Provider may communicate its preferences regarding the minimum revocation maintenance period of the WIA and KA to the Wallet Unit; the Wallet Unit and Wallet Provider should take this into account (see WUA_32). c) For the WIA specifically, a short technical validity period is required to ensure freshness; see WUA_33. |
-|AS-WP-09-024 | WUA_18 | Empty|  |
-|AS-WP-09-025 | WUA_19 | Empty|  |
-|AS-WP-09-026 | WUA_20 | Empty|  |
-|AS-WP-09-027 | WUA_20a | Empty|  |
-|AS-WP-09-028 | WUA_21 | Empty|  |
-|AS-WP-09-029 | WUA_22 | A Wallet Provider SHALL ensure that a non-revoked Wallet Unit at all times can present a temporally valid and non-revoked WIA to a PID Provider or Attestation Provider during the issuance process of a PID or attestation.| a) This requirement applies to both device-bound and non-device-bound attestations. b) Revocation refers to the attested Wallet Instance, not to the WIA itself. c) For example, the Wallet Provider could pro-actively issue new WIAs to the Wallet Unit, so that the Wallet Unit is always in possession of a valid WIA. Alternatively, the Wallet Provider could ensure that whenever the User opens the Wallet Unit, it checks whether it is possession of a valid WIA, and requests the Wallet Provider to issue a new WIA if needed. A third possibility is that the Wallet Unit does this check only when it starts the process of requesting the (re-)issuance of a PID or attestation. Other alternatives to comply with this requirement may be used as well. |
-|AS-WP-09-030 | WUA_23 | Empty|  |
-|AS-WP-09-031 | WUA_24 | A Wallet Unit SHALL present a WIA only to a PID Provider or Attestation Provider, as part of the issuance process of a PID or an attestation, and not to a Relying Party or any other entity.|  |
-|AS-WP-09-032 | WUA_25 | During issuance of a PID or attestation, the PID Provider or Attestation Provider SHALL verify the WIA in accordance with the requirements in [OpenID4VCI] Appendix E. In addition, the PID Provider or Attestation Provider SHALL validate that the WIA is not revoked.| This requirement applies to both device-bound and non-device-bound attestations. |
-|AS-WP-09-033 | WUA_26 | A WIA SHALL enable PID Providers and Attestation Providers to verify the authenticity of a Wallet Instance and to check whether the Wallet Instance has been revoked.| A WIA carries the revocation reference for a Wallet Instance; the revocation status of the Wallet Instance is maintained in a status list referenced in the WIA. |
-|AS-WP-09-034 | WUA_27 | A WIA SHALL contain information about the Wallet Solution, including its identity, version, and certification, and SHALL comply with the relevant requirements in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).| This information allows PID Providers and Attestation Providers to verify that the Wallet Instance belongs to a trusted and certified Wallet Solution, as registered in the Wallet Provider Trusted List. |
-|AS-WP-09-035 | WUA_28 | A Wallet Provider SHALL select either the type-shared index approach or the per-KA index approach (as specified in Section 2.5.2 of [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md)) for managing the revocation status of the WSCD or keystore referenced in a Key Attestation.| a) Under the type-shared index approach, the revocation reference is shared across all Wallet Units using the same type of WSCD or keystore, so that a single revocation action covers all affected Wallet Units (e.g., when a security vulnerability is identified in a hardware component type). Under the per-KA index approach, each KA carries a revocation reference scoped to the specific Wallet Unit's WSCD or keystore instance, enabling individual revocation that may also be triggered by user request. b) The detailed requirements for each approach are specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). |
-|AS-WP-09-036 | WUA_28a | If the per-KA index approach is used, the Wallet Provider SHALL ensure that the revocation reference in a KA cannot be used to link a Wallet Unit's interactions across different PID Providers or Attestation Providers.|  |
-|AS-WP-09-037 | WUA_29 | Throughout the entire validity period of an issued PID, the PID Provider SHALL verify the revocation status of both the Wallet Instance and WSCD using the information in the WIA and the KA (respectively) received during the issuance of that PID. If either is revoked, the PID Provider SHALL revoke the PID.|  |
-|AS-WP-09-038 | WUA_30 | The technical validity period of a PID SHALL be consistent with the period during which the Wallet Provider has committed to maintaining the revocation status of the Wallet Instance and the WSCD, as conveyed in the WIA and KA presented during issuance.| a) This reflects the revocation chaining requirement: PID Providers must be able to check whether the Wallet Instance has been revoked (via the WIA) and whether the WSCD referenced in the KA has been revoked (WUA_29) for the entire PID validity period. |
-|AS-WP-09-039 | WUA_31 | A Wallet Provider SHALL maintain the revocation status of a Wallet Instance during the entire revocation maintenance period indicated in the WIAs issued to that Wallet Instance.|  |
-|AS-WP-09-040 | WUA_31a | A Wallet Provider SHALL maintain the revocation status of a WSCD or keystore during the entire revocation maintenance period indicated in the KAs issued to the Wallet Instance(s) using that WSCD or keystore.|  |
-|AS-WP-09-041 | WUA_32 | At the time of PID or attestation issuance, a PID Provider or Attestation Provider SHALL communicate to the Wallet Unit its minimum requirements regarding the remaining revocation maintenance period for Wallet Instances (in WIAs) or WSCDs/keystores (in KAs), as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).| This allows PID Providers and Attestation Providers to ensure that they receive WIAs and KAs with a sufficiently long remaining revocation maintenance period, enabling revocation chaining for the intended validity period of the PID or attestation to be issued. |
-|AS-WP-09-042 | WUA_33 | A Wallet Provider SHALL ensure that WIAs have a short technical validity period as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), such that a WIA is fresh at the time of use.| As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), the technical validity period of a WIA SHALL be less than 24 hours. This ensures that the WIA reflects a recent integrity check of the Wallet Instance. The revocation maintenance period (see WUA_26 and WUA_31) is specified separately in the WIA and may be considerably longer than the technical validity period. |
-|AS-WP-09-043 | WUA_34 | During issuance of a PID, a PID Provider SHALL verify that the keys attested in the KA are stored in the WSCA/WSCD described in the KA.| PID private keys must be protected at Level of Assurance High, which requires key storage in a WSCA/WSCD. See also WUA_05, which requires the Wallet Unit to provide a KA describing the WSCA/WSCD that generated the PID private key. |
-|AS-WP-09-044 | WUA_35 | A Wallet Unit SHALL comply with all relevant requirements specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).|  |
-|AS-WP-09-045 | WUA_36 | A PID Provider or Attestation Provider SHALL comply with all relevant requirements specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).|  |
-|AS-WP-09-046 | WUA_37 | A Wallet Provider SHALL maintain, for each Wallet Unit it has activated, the set of WIAs and KAs it has issued to that Wallet Unit, in such a way that this association cannot be confused with that of any other Wallet Unit, including across different Wallet Solutions or different Wallet Solution versions. The Wallet Provider SHALL document the procedures, controls, and corresponding risk analysis implementing this requirement as part of the policy meant in WURevocation_03.| This requirement makes explicit at the HLR level the record-keeping duty already implicit in WURevocation_07, WURevocation_07a, WIAM_05, WIAM_06, and WIAM_10, and required of the Wallet Provider by Section 2.4.2 of [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). |
-|AS-WP-11-001 | PA_01 | A Wallet Unit SHALL enable a User to generate a Pseudonym and register it at a Relying Party.| For an attested pseudonym, pseudonym generation takes place by requesting the issuance of a pseudonym attestation. Pseudonym registration takes place by presenting the attestation. |
-|AS-WP-11-002 | PA_02 | A Wallet Unit SHALL enable a User to authenticate with a Pseudonym towards a Relying Party if the Wallet Unit was used previously to register the Pseudonym for the same Relying Party|  |
-|AS-WP-11-003 | PA_03 | A Wallet Unit SHALL be able to perform the actions specified in the above two requirements independently of whether the interaction with the Relying Party is initiated on the same device hosting the Wallet Instance or on a device different from the one hosting the Wallet Instance.|  |
-|AS-WP-11-004 | PA_04 | A Wallet Unit SHALL enable the User to use multiple different Pseudonyms at a given Relying Party, unless it is explicitly designed as a scope rate-limited attestation.|  |
-|AS-WP-11-005 | PA_05 | A Wallet Unit SHOULD enable a User to freely choose a User alias for each Pseudonym registered at a Relying Party. Setting an alias SHOULD be optional for the User. The User SHOULD be able to change the alias for any Pseudonym.|  |
-|AS-WP-11-006 | PA_06 | A Wallet Unit SHALL enable a User to choose which Pseudonym to authenticate with towards a Relying Party, if multiple Pseudonyms are registered for this Relying Party. The Wallet Unit SHOULD present the User with the aliases of the applicable Pseudonyms, if assigned, when making this choice.|  |
-|AS-WP-11-007 | PA_07 | A Wallet Unit SHALL enable a User to delete a Pseudonym.|  |
-|AS-WP-11-008 | PA_08 | A Wallet Unit SHALL enable the User to manage Pseudonyms within the Wallet Unit in a user-friendly and transparent manner.|  |
-|AS-WP-11-009 | PA_08a | A Wallet Unit SHALL log Pseudonym registration and presentation transactions as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).|  |
-|AS-WP-11-010 | PA_09 | A Wallet Unit SHALL enable the User to see all existing pseudonyms, including the associated Relying Party (if any).|  |
-|AS-WP-11-011 | PA_10 | A Relying Party SHALL be able to verify that a User is registering a Pseudonym using a non-revoked Wallet Unit.|  |
-|AS-WP-11-012 | PA_11 | A Relying Party SHALL be able to verify that a User is authenticating with a Pseudonym using a non-revoked Wallet Unit.|  |
-|AS-WP-11-013 | PA_12 | If Wallet Unit is used to register a Pseudonym at a Relying Party in combination with a PID or attestation being presented to the same Relying Party, then this Relying Party SHALL be able to verify that the same User performed both actions.|  |
-|AS-WP-11-014 | PA_13 | The Relying Party SHALL be able to validate that the pseudonym presented to them belongs to the User presenting it.|  |
-|AS-WP-11-015 | PA_14 | A Wallet Unit SHALL store the information necessary for authenticating with a Pseudonym in either a WSCA/WSCD or in a keystore.|  |
-|AS-WP-11-016 | PA_15 | A Relying Party SHALL NOT be able to derive the User's true identity, or any data identifying the User, from the Pseudonym value received by the Relying Party.|  |
-|AS-WP-11-017 | PA_16 | A Wallet Unit SHALL NOT reveal the same Pseudonym to different Relying Parties, unless the User explicitly chooses otherwise.|  |
-|AS-WP-11-018 | PA_17 | The Wallet Provider SHALL use method(s) and/or protocol(s) to implement pseudonyms which make it impossible to correlate Pseudonyms based on their values or on metadata sent by the Wallet Unit to Relying Parties during registration and authentication.| This implies that colluding Relying Parties will not be able to conclude that different Pseudonyms belong to the same User. |
-|AS-WP-11-019 | PA_18 | The Wallet Unit SHALL ensure that Pseudonyms contain sufficient entropy to make the chance of colliding Pseudonyms (meaning two Users having the same Pseudonym value for the same Relying Party) negligible.|  |
-|AS-WP-11-020 | PA_19 | A Wallet Unit SHALL NOT share the User's optionally assigned Pseudonym aliases with any Relying Party.|  |
-|AS-WP-11-021 | PA_20 | The Wallet Unit SHALL verify the identity of a Relying Party when a User registers a Pseudonym or authenticates with a Pseudonym. If the profile or extension of [W3C WebAuthn] meant in PA_21 does not enable the Wallet Unit to do this, the Wallet Unit SHALL trust the WebAuthn Client (i.e., the browser) to verify the Relying Party identity.| [W3C WebAuthn] currently does not offer a way for an Authenticator (i.e., the Wallet Unit) to authenticate a Relying Party. Instead, the Client (i.e., the browser) will authenticate the Relying Party, using TLS. The notion of trust is that the Wallet Unit receives the Relying Party identity from the browser and uses it without further verifications. |
-|AS-WP-11-022 | PA_21 | The Commission SHALL create or reference a technical specification containing a profile or extension of the [W3C WebAuthn] specification compliant with the HLRs specified in this Topic. This specification SHALL contain all details necessary for Wallet Units and Relying Parties to generate, register, and use Pseudonyms.|  |
-|AS-WP-11-023 | PA_22 | Wallet Providers MAY ensure that their Wallet Solution supports the HLRs defined for this topic by letting their Wallet Units perform the role of a WebAuthn authenticator following the [W3C WebAuthn] specification and the technical specification referenced in referenced in PA_21.|  |
-|AS-WP-11-024 | PA_23 | A protocol enabling scope rate-limited pseudonyms SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].|  |
-|AS-WP-11-025 | PA_24 | A protocol enabling scope rate-limited pseudonyms SHALL enable a Wallet Unit to allow a User to generate a scope rate-limited pseudonym, register this by a Relying Party, and prove that this is within the rate and scope restrictions determined by the Relying Party.|  |
-|AS-WP-11-026 | PA_25 | A protocol enabling scope rate-limited pseudonyms SHALL allow a Relying Party, when a User presents a scope rate-limited pseudonym, to verify that the rate is not exceeded for this User.|  |
-|AS-WP-11-027 | PA_26 | A protocol enabling scope rate-limited pseudonyms SHALL allow a Relying Party to choose the scope and rate when requesting a scope rate-limited pseudonym from a User.|  |
-|AS-WP-11-028 | PA_27 | A protocol enabling scope rate-limited pseudonyms SHALL NOT allow any entity or collusion of entities not including the User, to link scope rate-limited pseudonyms of the same User when used across several different Relying Parties. This SHALL hold even if the scope and rate are identical across the different Relying Parties and both for registration and authentication of the scope rate-limited pseudonym|  |
-|AS-WP-11-029 | PA_28 | A protocol enabling scope rate-limited pseudonyms SHALL ensure that if the rate is larger than 1, a User's different pseudonyms SHALL be unlinkable for the same scope. This SHALL hold against any entity or collusion of entities, not including the User. Further, such protocol SHALL ensure that during registration or authentication with such a pseudonym, it SHALL NOT be possible for the Relying Party to deduce any information about how many pseudonyms the User has already registered (except that it does not exceed the predetermined rate).|  |
-|AS-WP-11-030 | PA_29 | A protocol enabling scope rate-limited pseudonyms SHALL ensure that no entity or collusion of entities, not including a User, is able to authenticate or register with a scope rate-limited pseudonym of this User.|  |
-|AS-WP-11-031 | PA_30 | A Wallet Unit SHALL store cryptographic material necessary for authenticating as a scope rate-limited pseudonyms in either a WSCA/WSCD or in a keystore.|  |
-|AS-WP-11-032 | PA_31 | A User's scope rate limited pseudonyms for a particular scope and rate SHALL be persistent over time even if they start using another Wallet Unit.|  |
-|AS-WP-16-001 | QES_01 | Wallet Providers SHALL ensure that each User has the possibility to receive a qualified certificate for Qualified Electronic Signatures, bound to a QSCD, that is either local, external, or remotely managed in relation to the Wallet Instance.|  |
-|AS-WP-16-002 | QES_02 | Wallet Providers SHALL ensure that each User who is a natural person has, at least for non-professional purposes, free-of-charge access to a Signature Creation Application which allows the creation of free-of-charge Qualified Electronic Signatures using the certificates referred to in QES_01. Wallet Providers SHALL ensure that: - The Signature Creation Application SHALL, as a minimum, be capable of signing or sealing User-provided data and Relying Party-provided data. - The Signature Creation Application SHALL be implemented as part of a Wallet Solution or external to it (by providers of trust services or by Relying Parties). - The Signature Creation Application SHALL be able to generate signatures or seals in formats compliant with at least the mandatory formats referred to in QES_08.| a) Signature Creation Application (SCA): see definition in [ETSI TS 119 432]. 2) If the SCA is external to the Wallet Solution, it may be for example a separate mobile application, or be hosted remotely, for instance by the QTSP or by a Relying Party. |
-|AS-WP-16-003 | QES_03 | For the use of the qualified certificate referred to in QES_01, Wallet Providers SHALL ensure that a Wallet Unit implements secure authentication of the User, as well as signature or seal invocation capabilities, as a part of a local, external or remote QSCD.|  |
-|AS-WP-16-004 | QES_04 | Wallet Providers SHALL enable their Wallet Units to interface with QSCDs using protocols and interfaces necessary for the implementation of secure User authentication and signature or seal functionality.| In a Relying Party-centric flow, the remote QTSP will likely be selected by the Relying Party, which implies the QSCD is managed by the remote QTSP. In a Wallet Unit-driven flow, the User should be able to choose the QSCD. |
-|AS-WP-16-005 | QES_05 | Wallet Providers SHALL enable their Wallet Units to be used for User enrolment to a remote QES Provider (i.e., a QTSP offering remote QES), except where the Wallet Unit interfaces with local or external QSCDs.|  |
-|AS-WP-16-006 | QES_06 | Wallet Providers SHALL ensure that their Wallet Solution supports at least one of the following options for remote QES signature creation: - remote QES creation through secure authentication to a QTSP signature web portal, - remote QES creation channelled by the Wallet Unit, - remote QES creation channelled by a Relying Party.|  |
-|AS-WP-16-007 | QES_07 | Wallet Providers SHALL ensure that, where a Signature Creation Application relies on a remote Qualified Signature Creation Device and where it is integrated into a Wallet Unit, it supports the Cloud Signature Consortium API Specification 2.0 [CSC API].|  |
-|AS-WP-16-008 | QES_08 | Wallet Providers SHALL ensure that their Wallet Units are able to create signatures or seals in accordance with the mandatory PAdES format as specified in [ETSI EN 319 142-1[ V1.1.1 (2016-04). In addition, Wallet Providers SHOULD ensure that their Wallet Units are able to create signatures or seals in accordance with the following formats: - XAdES as specified in [ETSI EN 319 132-1] V1.2.1 (2022-02), - JAdES as specified in [ETSI TS 119 182-1] V1.2.1 (2024-07), - CAdES as specified in [ETSI EN 319 122-1] V1.3.1 (2023-06), and - ASiC as specified in [ETSI EN 319 162-1] V1.1.1 (2016-04) and [ETSI EN 319 162-2] V1.1.1 (2016-04).|  |
-|AS-WP-16-009 | QES_09 | Empty|  |
-|AS-WP-16-010 | QES_10 | Wallet Providers SHALL ensure that, where the Signature Creation Application is implemented as part of the Wallet Unit and is used to generate signatures or seals of the representation of the document or data to be signed or sealed, the Wallet Unit presents the representation of the document or data to be signed or sealed to the User.|  |
-|AS-WP-16-011 | QES_11 | Where the Signature Creation Application is implemented as part of the Wallet Unit, a Wallet Unit SHALL compute the hash or digest of the document or data to be signed through its Signature Create Application component.|  |
-|AS-WP-16-012 | QES_12 | A Wallet Unit SHALL be able to create a signature over a document or data to be signed, either by using a local QSCD or by interfacing with a remote QES Provider.| a local signing application is on-device. It may either be embedded in the Wallet Unit or be an external application. |
-|AS-WP-16-013 | QES_13 | A Wallet Unit SHALL provide a log of transactions related to qualified electronic signatures or seals generated by or through the Wallet Unit, allowing the User to view the history of previously signed data or documents, according to requirement DASH_04 in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).| If the signature is generated by a remote Signature Creation Application, the Wallet is at minimum used to authenticate the User to the remote QTSP and to obtain the User's consent for the usage of the private signing key. The logs then record information about these processes. |
-|AS-WP-16-014 | QES_14 | A Wallet Unit SHALL enable the User to explicitly authorise the creation of a qualified electronic signature or seal through their Wallet Unit.|  |
-|AS-WP-16-015 | QES_15 | In remote signature creation scenarios, a Wallet Unit SHALL verify that the qualified electronic signature or seal creation device is part of a qualified service, which is carried out by a qualified trust service provider.|  |
-|AS-WP-16-016 | QES_16 | A Wallet Unit SHOULD support multiple-signing scenarios, where multiple signatories are required to sign the same document or data.|  |
-|AS-WP-16-017 | QES_17 | A Wallet Unit SHALL provide a signature creation confirmation upon the creation of a qualified electronic signature, informing the User about the outcome of the signature creation process.| See also QES_17a. |
-|AS-WP-16-018 | QES_17a | If the Signature Creation Application is external to the Wallet Unit, after the User authorises the usage of the private signing key, the Signature Creation Application SHALL return the outcome of the signature creation process to the Wallet Unit.|  |
-|AS-WP-16-019 | QES_18 | Wallet Providers SHALL configure at least one default qualified signing service in the Wallet Unit.|  |
-|AS-WP-16-020 | QES_19 | Wallet Providers SHALL ensure that, where the Signature Creation Application is implemented as part of the Wallet Unit, a Wallet Unit supports [ETSI TS 119 101] when using signing keys managed by the QSCD, whether locally, externally, or remotely in relation to the Wallet Instance.|  |
-|AS-WP-16-021 | QES_20 | Empty|  |
-|AS-WP-16-022 | QES_21 | Empty|  |
-|AS-WP-16-023 | QES_22 | Empty|  |
-|AS-WP-16-024 | QES_23 | QTSPs providing the remote QES part of a Wallet Solution SHALL support: 1. [ETSI TS 119 431-1] , 2. [ETSI TS 119 431-2] , 3. [ETSI TS 119 432]. Wallet Providers and QTSPs providing the remote QES part of a Wallet Solution SHALL comply with Sole Control Assurance Level (SCAL) 2 as defined in [CEN EN 419 241-1] .|  |
-|AS-WP-16-025 | QES_24 | QTSPs providing the Signature Creation Application as part of the remote QES part of a Wallet Solution SHALL support [ETSI TS 119 101].|  |
-|AS-WP-16-026 | QES_24a | Relying Parties providing the Signature Creation Application in a Relying Party-centric flow SHALL support [ETSI TS 119 101].|  |
-|AS-WP-16-027 | QES_25 | Empty|  |
-|AS-WP-16-028 | QES_26 | Empty|  |
-|AS-WP-18-001 | ACP_01 | A Cryptographic Binding of Attestations scheme SHALL enable a WSCA/WSCD or keystore to prove that it manages two or more private keys, paired with two or more public keys provided to it by the Wallet Unit.| a)These public keys may be included in WIAs and KAs, PIDs, attestations, or pseudonyms. b) The proof may be transitive, so a proof that two keys are stored/managed in the same WSCA/WSCD or keystore may be done by proving these keys relate to each other via a third key (also stored in the WSCA/WSCD or keystore). |
-|AS-WP-18-002 | ACP_04 | A Cryptographic Binding of Attestations scheme SHALL be compatible with the requirements for attestation issuance in this document, in particular [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), as well as with requirements for both remote and proximity presentation flows in this document, in particular [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit) and [Topic 24](./annex-2.02-high-level-requirements-by-topic.md#a2314-topic-24-user-identification-in-proximity-scenarios).|  |
-|AS-WP-18-003 | ACP_05 | A Cryptographic Binding of Attestations scheme SHALL enable an Attestation Provider, during the issuance of an attestation, to request and obtain proof that the private key for the new attestation is managed by the same WSCA/WSCD or keystore as the private key of a PID or another attestation already existing on the Wallet Unit.| ACP_05 and ACP_06 may require an addition to the common OpenID4VCI protocol referenced in requirement ISSU_01, or an extension or profile thereof. |
-|AS-WP-19-001 | DASH_01 | A Wallet Unit SHALL provide a user-friendly dashboard functionality to its User.|  |
-|AS-WP-19-002 | DASH_02 | The Wallet Unit SHALL log all transactions executed through the Wallet Unit, including any transactions that were not completed successfully. This log SHALL include all types of transaction executed through the Wallet Unit: a) PID or attestation issuance and re-issuance transactions, b) PID or attestation presentation transactions, c) Wallet-to-Wallet transactions (see [Topic 30](./annex-2.02-high-level-requirements-by-topic.md#a2319-topic-30-interaction-between-wallet-units)), d) pseudonym registration or presentation transactions, e) signature or seal creation transactions (see [Topic 16](./annex-2.02-high-level-requirements-by-topic.md#a2310-topic-16-signing-documents-with-a-wallet-unit)), f) data deletion requests sent to a Relying Party (see [Topic 48](./annex-2.02-high-level-requirements-by-topic.md#a2327-topic-48-blueprint-for-requesting-data-deletion-to-relying-parties)), g) reports sent to a Data Protection Authority (see [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data)), h) PID or attestation deletions by the User.| For the data to be logged for a data deletion request to a Relying Party or a report sent to a DPA, see Topic 48 and Topic 50, respectively. For other types of transaction, the data to be logged is specified in the requirements in this Topic. |
-|AS-WP-19-003 | DASH_02a | The Wallet Unit SHALL retain transactions in the log at least for the minimum retention period specified in applicable legislation. If the Wallet Unit must delete transactions from the log, for instance because of size limitations, the Wallet Unit SHALL notify the User via the dashboard before doing so, indicating the potential consequences for the User's data protection rights, and SHALL instruct the User how to export the transactions that are about to be deleted. See DASH_07.|  |
-|AS-WP-19-004 | DASH_02b | The dashboard SHALL include a functionality to display to the User an overview of all transactions in the log.|  |
-|AS-WP-19-005 | DASH_02c | The transaction log meant in DASH_02 SHALL comply with all relevant requirement in [Technical Specification 10](../../technical-specifications/ts10-data-portability-and-download-(export).md), including measures to ensure and/or verify its confidentiality, integrity, and authenticity.|  |
-|AS-WP-19-006 | DASH_03 | For a PID or attestation presentation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the name and unique identifier of the corresponding Relying Party, and the Member State in which that Relying Party is established, c) the name, contact details (if available), and unique identifier of the intermediary, if an intermediary is involved in the transaction, d) the attestation type(s) and the identifier(s) of the attribute(s) that were requested, as well as those that were presented, e) in the case of non-completed transactions, the reason for such non-completion, f) the URL of the online service of the Relying Party's Registrar. g) the web form URL (if available), e-mail address (if available), and telephone number (if available) provided by the Relying Party for sending data deletion requests, see requirement RPRC_11 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), h) the name and country of the Data Protection Authority supervising the Relying Party, as well as the web form URL (if available), e-mail address (if available), and telephone number (if available) provided by this DPA for reporting suspicious attribute presentation requests. i) information on the intended use and the URL to the applicable privacy policy (if available).| The information in points g), h), and i) may be retrieved from the registration certificate or from the Registrar's online service (see [Topic 44](../annex-2/annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)). |
-|AS-WP-19-007 | DASH_03a | For a PID or attestation presentation transaction or a Wallet-to-Wallet transaction executed through the Wallet Unit, the log SHALL NOT contain the value of any attributes presented to the Relying Party or the Verifier Wallet Unit.|  |
-|AS-WP-19-008 | DASH_03b | For a Wallet-to-Wallet transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the role of the Wallet Unit (Holder Wallet Unit or Verifier Wallet Unit), c) the attestation type(s) and the identifier(s) of the attribute(s) that were requested, as well as those that were presented, d) in the case of non-completed transactions, the reason for such non-completion.|  |
-|AS-WP-19-009 | DASH_03c | For a pseudonym registration or presentation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) identifying information about the Relying Party, if known to the Wallet Unit, c) whether it is a pseudonym registration or pseudonym presentation transaction, d) in the case of non-completed transactions, the reason for such non-completion.| Regarding point b), see PA_20 in [Topic 11](./annex-2.02-high-level-requirements-by-topic.md#a238-topic-11-pseudonyms). |
-|AS-WP-19-010 | DASH_03d | If a presentation request contains transactional data, the Wallet Unit SHALL log the value of this transactional data only to the extent explicitly required by the applicable Technical Specification associated with the requested SUA attestation, and in accordance with data minimisation principles. If the applicable Technical Specification does not explicitly specify that transactional data shall be logged, the Wallet Unit SHALL NOT log the value of any transactional data.| a) For the concepts of transactional data and SUA attestations and their related Technical Specifications, see [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments). b) For example, for PSD2 Strong Customer Authentication transactions, the scope of transactional data to be included in the transaction log is defined in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md) and includes the payment transaction identifier and merchant name. |
-|AS-WP-19-011 | DASH_04 | For a signature or seal creation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the document or data signed or sealed (if available to the Wallet Unit), c) in the case of non-completed transactions, the reason for such non-completion.|  |
-|AS-WP-19-012 | DASH_05 | For a PID or attestation issuance or re-issuance transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the name, contact details (if available), and unique identifier of the corresponding PID Provider or Attestation Provider, c) the attestation type requested, as well as the attestation type issued, d) the number of attestations requested and issued (i.e., the size of the batch in case of batch issuance), e) in the case of non-completed transactions, the reason for such non-completion. f) for a re-issuance transaction, whether it was triggered by the User or by the Wallet Unit without involvement of the User, g) the URL of the associated Registrar's online service.| Regarding point g): this URL can be retrieved from the access certificate. |
-|AS-WP-19-013 | DASH_05a | For the deletion of a PID or attestation by the User, the log SHALL contain at least: a) the date and time of the deletion event, b) the attestation type of the deleted PID or attestation. c) The name and unique identifier of the corresponding PID Provider or Attestation Provider.| This requirement is not about deletion of transactions from the log, as per DASH_06a. |
-|AS-WP-19-014 | DASH_06 | The Wallet Provider SHALL ensure the confidentiality, integrity, and authenticity of all transactions included in the log.|  |
-|AS-WP-19-015 | DASH_06a | Via the dashboard, the Wallet Unit SHALL enable the User to delete any transaction in the log. Before deleting any transactions, the Wallet Unit SHALL indicate to the User the potential consequences for the User's data protection rights.| This requirement applies even in case the minimum retention period specified in applicable legislation (see DASH_02a) is not yet over. |
-|AS-WP-19-016 | DASH_06b | The Wallet Unit SHALL ensure that no entity other than the User can delete transactions from the log, except possibly for the reason mentioned in DASH_02a.|  |
-|AS-WP-19-017 | DASH_07 | The dashboard SHALL allow the User to export the details of one or more transactions in the log to a file, using the common format specified according to DASH_02c, while ensuring their confidentiality, authenticity and integrity. The file SHALL be stored in an external storage or remote storage location of the User's choice, from among the storage options supported by the Wallet Unit and SHALL use the common format and security measures specified according to DASH_02c.|  |
-|AS-WP-19-018 | DASH_08 | For a natural-person User, a Wallet Instance SHALL provide a User interface.|  |
-|AS-WP-19-019 | DASH_09 | The User interface referred to in DASH_08 SHALL provide a view with - the EU Digital Identity Wallet Trust Mark, - accompanying general information on the certification of Wallet Solutions, - links to the certification status information as defined in the [Technical Specification 1](../../technical-specifications/ts1-eudi-wallet-trust-mark.md).|  |
-|AS-WP-19-020 | DASH_09a | Positioning of the view meant in DASH_09 in the Wallet UI navigation SHALL follow design guidelines provided by the European Commission.|  |
-|AS-WP-19-021 | DASH_09b | Wallet Providers and Wallet Units SHALL comply with all relevant requirements in [Technical Specification 1](../../technical-specifications/ts1-eudi-wallet-trust-mark.md) for the EUDI Wallet Trust Mark.|  |
-|AS-WP-19-022 | DASH_10 | Empty.| See requirement WIAM_12a in [Topic 40](./annex-2.02-high-level-requirements-by-topic.md#a2323-topic-40-wallet-instance-installation-and-wallet-unit-activation-and-management). |
-|AS-WP-19-023 | DASH_11 | Empty|  |
-|AS-WP-19-024 | DASH_12 | The User interface referred to in DASH_08 SHALL enable the User, for each presentation transaction in the log, to easily request the Relying Party to delete any or all attributes presented to it in that transaction, or to send a report about that particular transaction to a DPA.|  |
-|AS-WP-20-001 | SUA_01 | A Wallet Unit SHALL be able to process the transactional data included in a presentation request for the SUA attestation(s) specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md), according to all requirements in that Technical Specification.| Technical Specification 12 specifies a SUA attestation intended for performing SCA as specified in the PSD2 Regulation. The related Rulebook is called "SCA Attestation Rulebook". |
-|AS-WP-20-002 | SUA_02 | Scheme Providers MAY specify Attestation Rulebooks (see [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)) and associated technical specifications for SUA attestations other that the ones specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md)). The Attestation Rulebook or the technical specification of such of a SUA attestation SHALL specify the syntax and semantics of the transactional data associated with that attestation.|  |
-|AS-WP-20-003 | SUA_02a | The Technical Specification associated with a given SUA attestation SHALL specify all necessary requirements for Wallet Units to process transactional data intended for this SUA attestation, at least regarding a) rendering and displaying the data to the User when obtaining approval for presentation, b) processing (e.g., hashing) the data for inclusion in the device binding signature, and c) the scope of information to be logged about a SUA attestation presentation transaction by a Wallet Unit.|  |
-|AS-WP-20-004 | SUA_03 | The Attestation Provider of a SUA attestation other than the one(s) specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md) SHALL NOT issue such an attestation to a Wallet Unit that does not comply with all relevant requirements in the SUA Attestation Rulebook and the technical specification for that attestation.|  |
-|AS-WP-20-005 | SUA_04 | In the response to a presentation request for a SUA attestation that includes transactional data, a Wallet Unit SHALL include (a representation of) that data, according to requirements included in the associated technical specification or Attestation Rulebook or in information provided to the Wallet Unit in the presentation request. In the latter case, the rules to interpret such information SHALL be included in the associated technical specification or Attestation Rulebook.| This requirement, as well as SUA_05, only applies if the requested SUA attestation is present on the Wallet Unit and if the User consents to signing the transactional data and presenting the requested attributes. |
-|AS-WP-20-006 | SUA_05 | The Wallet Unit SHALL include (a representation of) the transactional data received in a presentation request in the signature creation process used for device binding, using the private key of the requested SUA attestation and the mechanisms specified for key binding in [SD-JWT-VC] or mdoc authentication in [ISO/IEC 18013-5], as applicable. For this process, the Wallet Unit SHALL comply with the applicable requirements in the technical specification and the Attestation Rulebook for the requested SUA attestation, see SUA_01 or SUA_02.| a) The resulting signature value constitutes a proof of transaction. This signature value, possibly in combination with other protocols items, fulfils the requirements for the authentication code required in [PSD2]. b) See also requirement OIA_02 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit). |
-|AS-WP-20-007 | SUA_06 | The Wallet Unit SHALL render or adapt the dialogue message(s) displayed to the User (like font size and colour, background colour, text position, labels in the buttons to 'approve' or 'reject' a transaction), according to requirements in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md).|  |
-|AS-WP-20-008 | SUA_07 | Upon receiving a presentation request with transactional data, the Wallet Unit SHALL validate if the transactional data is intended for the given attestation and that the transactional data conforms to the related technical specification and/or Attestation Rulebook. In case the validation result is positive, the Wallet Unit SHALL process the transactional data in compliance with the related technical specification.|  |
-|AS-WP-30-001 | W2W_01 | A Wallet Unit SHALL be able to act as a Holder Wallet Unit, in accordance with all requirements in this Topic.|  |
-|AS-WP-30-002 | W2W_02 | When acting as a Holder Wallet Unit, if there is a contradiction between a requirement for Holder Wallet Units in this Topic and any requirement for Wallet Units in other Topics in this document, the requirement in this Topic SHALL take precedence. However, when acting as a Holder Wallet Unit, a Wallet Unit SHALL comply with all requirements for Wallet Units in other Topics in this document that do not contradict any requirement in this Topic.|  |
-|AS-WP-30-003 | W2W_03 | A Wallet Unit SHALL be able to act as a Verifier Wallet Unit, in accordance with all requirements in this Topic.|  |
-|AS-WP-30-004 | W2W_04 | When acting as a Verifier Wallet Unit, a Wallet Unit SHALL NOT comply with any requirement for Wallet Units in other Topics in this document.|  |
-|AS-WP-30-005 | W2W_05 | A Wallet Unit SHALL act as a Holder Wallet Unit only if the User selects a 'Holder Wallet Unit mode'. If the User closes the Wallet Unit, or after a period of non-activity, the Wallet Unit SHALL return to 'normal' mode.|  |
-|AS-WP-30-006 | W2W_06 | When entering the Holder Wallet Unit mode, a Wallet Unit SHALL inform its User that this mode should only be used for interactions with natural persons using a Wallet Unit, and that the User should not proceed if they are in fact interacting with a Relying Party.|  |
-|AS-WP-30-007 | W2W_07 | A Wallet Unit SHALL act as a Verifier Wallet Unit only if the User selects a 'Verifier Wallet Unit mode'. If the User closes the Wallet Unit, or after a period of non-activity, the Wallet Unit SHALL return to 'normal' mode.|  |
-|AS-WP-30-008 | W2W_09 | Holder Wallet Units SHALL comply with the requirements for mDLs and for mdocs in ISO/IEC 18013-5, unless specified differently in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).|  |
-|AS-WP-30-009 | W2W_10 | Verifier Wallet Units SHALL comply with the requirements for mDL readers and for mdoc readers in ISO/IEC 18013-5, unless specified differently in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).|  |
-|AS-WP-30-010 | W2W_11 | A Holder Wallet Unit SHOULD provide the Holder, through a user-friendly UI, with the option to inform the Verifier Wallet Unit about the attributes which the Verifier should include in the presentation request, by sending a presentation offer. If the Holder creates a presentation offer, the Holder Wallet Unit SHALL transfer it to the Verifier Wallet Unit as specified in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).| TS9 specifies an extension of the device engagement structure specified in ISO/IEC 18013-5. |
-|AS-WP-30-011 | W2W_12 | A Holder Wallet Unit SHALL recommend the Holder to create a presentation offer, as this will increase the chance of success of the use case.|  |
-|AS-WP-30-012 | W2W_13 | A Verifier Wallet Unit SHALL provide the Verifier, through a user-friendly UI, with the possibility to select the attributes that will be included in the presentation request.|  |
-|AS-WP-30-013 | W2W_14 | For the purposes of W2W_07, if the Verifier Wallet Unit received a presentation offer, it SHALL present this offer to the Verifier, and enable the Verifier to include one or more of the attributes in the offer into the presentation request. However, the Verifier Wallet Unit SHALL NOT allow the Verifier to include any attribute not present in the offer.|  |
-|AS-WP-30-014 | W2W_15 | For the purposes of W2W_07, if the Verifier Wallet Unit did not receive a presentation offer, it SHALL present the Verifier with a list of attributes that can be included in the presentation request. The Verifier Wallet Unit MAY ask the Verifier some questions about the purpose of the use case to narrow down the list.|  |
-|AS-WP-30-015 | W2W_16 | A Verifier Wallet Unit SHALL authenticate the Verifier and SHALL obtain the Verifier's approval prior to sending a presentation request to a Holder Wallet Unit.|  |
-|AS-WP-30-016 | W2W_17 | A Verifier Wallet Unit SHALL implement measures to limit the number of presentation requests it can send per unit of time, to prevent abuse of the Wallet-to-Wallet functionality by Relying Parties. The limitation strategy, for instance exponential backoff time between subsequent presentation requests or hard limits for the number of requests, SHALL be decided by the Wallet Provider, based on applicable requirements in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).|  |
-|AS-WP-30-017 | W2W_18 | Empty|  |
-|AS-WP-30-018 | W2W_19 | When receiving a presentation response, a Verifier Wallet SHALL verify the received attestation according to requirements OIA_12 - OIA_15 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit).|  |
-|AS-WP-30-019 | W2W_20 | A Verifier Wallet Unit SHALL display all verified attributes to the Verifier.|  |
-|AS-WP-30-020 | W2W_21 | A Verifier Wallet Unit SHALL NOT persistently store any attestations or attributes received. A Verifier Wallet Unit SHOULD minimise the time the received presentation is stored in memory. A Verifier Wallet Unit SHALL comply with OIA_16 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit).|  |
-|AS-WP-30-021 | W2W_22 | Wallet Providers SHOULD take measures to prevent a User from taking screenshots while their Wallet Unit is acting as a Verifier Wallet Unit.|  |
-|AS-WP-31-001 | PPNot_02 | The common set of information to be notified about a PID Provider SHALL include at least: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. A business registration number from an official record, b. Identification data from that official record. 2. PID Provider trust anchors, i.e., public keys and name as per point 1) ii) above, supporting the authentication of PIDs issued by the PID Provider, 3. Trust anchors of Access Certificate Authorities for PID Providers, i.e., public keys and CA name, supporting the authentication of the PID Provider by Wallet Units at the service supply point(s) listed per point 4. below. 4. Service supply point(s), i.e., the URL(s) at which a Wallet Unit can start the process of requesting and obtaining a PID.| a) Relating to point 3. above: PID Provider Access Certificate Authority trust anchors are notified separately from the Access Certificate Authority for Relying Parties (see Section G below), since PID Providers are -legally speaking- not Relying Parties. b) For the concept of an Access Certificate Authority, see also [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)] and [Section 6.3.2 of the ARF main document](../../architecture-and-reference-framework-main.md#632-pid-provider-or-attestation-provider-registration-and-notification). |
-|AS-WP-31-002 | WPNot_01 | Empty|  |
-|AS-WP-31-003 | WPNot_02 | The common set of information to be notified about a Wallet Provider SHALL include: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. Business registration number from an official record, and b. Identification data from the official record. 2. Wallet Provider trust anchors, i.e., public keys and name as per point 1. b. above, supporting the authentication of Key Attestations and Wallet Instance Attestations issued by the Wallet Provider. 3. Name and reference number of the certified Wallet Solution(s) provided by the Wallet Provider.| a) See [[Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)] and [[Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation)] for the definition of the KA and WIA. b) A Wallet Provider does not need an access certificate to interact with Wallet Units. |
-|AS-WP-31-004 | WPNot_03 | Wallet Providers SHALL ensure that all WIAs and KAs they issue can be authenticated using the trust anchors notified to the Commission.|  |
-|AS-WP-31-005 | WPNot_04 | PID Providers, Attestation Providers and other relevant actors SHALL accept Wallet Provider trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled Wallet Provider LoTE, which is sealed by the Commission.|  |
-|AS-WP-31-006 | WPNot_05 | The format of a Wallet Provider LoTE SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex E.|  |
-|AS-WP-31-007 | WPNot_06 | If a Wallet Provider is cancelled (see requirement GenNot_05 above), that Wallet Provider SHALL immediately revoke all of its Wallet Instances and all associated WSCDs and keystores, in accordance with the requirements in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation). If a Wallet Provider is suspended, that Wallet Provider and the Member State SHALL agree on the necessary precautionary measures that need to be taken, which MAY include the immediate revocation of the Wallet Instances and WSCDs or keystores for all or some of its valid Wallet Units.|  |
-|AS-WP-31-008 | PuBPNot_02 | The common set of information to be notified by Member States about PuB-EAA Providers SHALL include at least: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. Registration number as in official record, and b. Official record identification data. iv. Identification data of the Union or national law under which a. Either the PuB-EAA Provider is established as the responsible body for the Authentic Source based on which the electronic attestation of attributes is issued, or b. The PuB-EAA Provider is the body designated to act on behalf of the responsible body referred to in point 1. iv. a. v.The conformity assessment report issued by a conformity assessment body, confirming that the requirements set out in paragraphs 1, 2 and 6 of [Article 45f](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e3902-1-1) are met. 2. PuB-EAA Provider trust anchors, i.e., public keys and name as per point 1) ii) above, supporting the authentication of PuB-EAAs issued by the PuB-EAA Provider, 3. Service supply point(s), i.e., the URL(s) at which a Wallet Unit can start the process of requesting and obtaining a PuB-EAA from the PuB-EAA Provider.|  |
-|AS-WP-31-009 | RPACANot_02 | The common set of information to be notified about an Access Certificate Authority or a Provider of registration certificates SHALL include: 1. Identification data: i) Member State or country of establishment, ii) Name as registered in an official record, iii) Where applicable: - A business registration number from an official record, - Identification data from that official record. 2. Trust anchors of the Access Certificate Authority or Provider of registration certificates, i.e., public keys and name as per point 1) ii), supporting the authentication of access certificates and registration certificates by Wallet Units.|  |
-|AS-WP-31-010 | TLPub_01 | The European Commission SHALL establish technical specifications for the system enabling the publication by the Commission of the information notified by the Member States regarding PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities, and Providers of registration certificates.|  |
-|AS-WP-31-011 | TLPub_02 | The European Commission SHALL establish technical specifications for the set of information to be published about PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities and Providers of registration certificates, based on the information notified by the Member States.| The information to be published MAY be different from the information to be notified for each of these entities. |
-|AS-WP-31-012 | TLPub_06 | The Commission SHALL publish in the OJEU the locations of the LoTEs for PID Providers, Wallet Providers, Access Certificate Authorities, and Providers of registration certificates, as well as the location of the Trusted List(s) of PuB-EAA Providers.|  |
-|AS-WP-31-013 | TLPub_08 | As part of the specifications referred to in TLPub_01, the European Commission SHALL establish technical specifications for ensuring the availability and authenticity of the full history regarding the information notified about PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities, and Providers of registration certificates.|  |
-|AS-WP-34-001 | Mig_01 | A Wallet Unit SHALL include and keep up-to-date a Migration Object, containing the following information: - The contents of the log for all transactions executed through the Wallet Unit, as listed in requirement DASH_02. - A list of PIDs and attestations (except Key Attestations and Wallet Instance Attestations) present in the Wallet Unit, according to the requirements in this Topic.|  |
-|AS-WP-34-002 | Mig_02 | The Migration Object SHALL comply with all requirements in [Technical Specification 10](../../technical-specifications/ts10-data-portability-and-download-(export).md).|  |
-|AS-WP-34-003 | Mig_03 | For each PID or device-bound attestation that is issued to it, a Wallet Unit SHALL add to the Migration Object all data necessary to request issuance of that PID or attestation once again. This SHALL include at least the attestation type and the PID Provider or Attestation Provider that issued the PID or attestation, as well as their service supply points. However, the Migration Object SHALL NOT contain attribute identifiers or attribute values, and SHALL NOT contain any private keys of the PID or device-bound attestation.|  |
-|AS-WP-34-004 | Mig_03a | For each non-device-bound attestation that is issued to it, a Wallet Unit SHALL add to the Migration Object one of the following: either all data necessary to request issuance of that attestation once again, as listed in Mig_03, or all data necessary to transfer the attestation to a new device without involvement of the Attestation Provider, including attribute identifiers and attribute values. The Wallet Unit SHALL enable the User to indicate if they want to store attribute identifiers and values in the Migration Object.|  |
-|AS-WP-34-005 | Mig_03b | If the User deletes a PID or attestation from their Wallet Unit, the Wallet Unit SHALL delete the corresponding entry from the Migration Object.|  |
-|AS-WP-34-006 | Mig_04 | The Wallet Unit SHALL store the Migration Object in an external storage or remote storage location of the User's choice, from among the storage options supported by the Wallet Unit, in such a way that the User can still retrieve the object from a new Wallet Unit in case the existing Wallet Unit becomes unavailable.| a) It is up to the Wallet Provider to decide which external storage options or remote storage locations the Wallet Unit supports for storing the Migration Object. b) The new Wallet Unit may be either an instance of the same Wallet Solution as the old one, or an instance of a different Wallet Solution. |
-|AS-WP-34-007 | Mig_05 | The Wallet Unit SHALL store the Migration Object in such a way that its confidentiality, integrity, and authenticity is protected and that it is protected against use by others than the User.| This could be done, for example, by using password-based cryptography to encrypt the object. |
-|AS-WP-34-008 | Mig_06 | Directly after installation of a new Wallet Instance, the Wallet Instance SHALL enable the User to import a Migration Object from an external storage or remote storage location indicated by the User, from among the storage options supported by the Wallet Unit.|  |
-|AS-WP-34-009 | Mig_07 | When importing a Migration Object, for each PID and device-bound attestation listed in the Migration Object, the Wallet Unit SHALL enable the User to select that PID or attestation. When a PID or device-bound attestation is selected, the Wallet Unit SHALL request the respective PID Provider or Attestation Provider to issue a new PID or attestation of the same type  to the new Wallet Unit. If the User selects a PID, the Wallet Unit SHALL request issuance of the PID first, before any of the other selected attestations.| a) Since no refresh tokens (see ISSU_65) will be available on the new Wallet Unit, this is a new issuance process, which will include User authentication by the PID Provider or Attestation Provider. b) The rationale for the last requirement is to ensure that if other Attestation Providers want to use a PID to do User authentication, the PID is actually available. |
-|AS-WP-34-010 | Mig_07a | When importing a Migration Object, for each non-device-bound attestation listed in the Migration Object, the Wallet Unit SHALL enable the User to select that attestation. When an attestation is selected, the Wallet Unit SHALL, depending on whether the Migration Object contains attribute identifiers and attribute values (see Mig_03a), either restore the technical attestation directly from the Object or request the respective Attestation Provider to issue a new attestation of the same type to the new Wallet Unit.|  |
-|AS-WP-34-011 | Mig_07b | When importing a Migration Object, the Wallet Unit SHALL ask the User whether they want to restore the log from the Migration Object. When the User agrees, the Wallet Unit SHALL restore the log, and SHALL append future transactions to this log according to the requirements in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).|  |
-|AS-WP-34-012 | Mig_08 | Empty|  |
-|AS-WP-34-013 | Mig_09 | Empty|  |
-|AS-WP-34-014 | Mig_10 | Empty|  |
-|AS-WP-34-015 | Mig_11 | The processes and interfaces used for issuance of a PID or attestation as part of a migration process SHALL be the same as those used for a 'normal' issuance process, as specified in [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit).|  |
-|AS-WP-34-016 | Mig_12 | Empty|  |
-|AS-WP-34-017 | Mig_13 | Empty|  |
-|AS-WP-34-018 | Mig_14 | Empty|  |
-|AS-WP-34-019 | Mig_15 | Empty|  |
-|AS-WP-34-020 | Mig_16 | Empty|  |
-|AS-WP-38-001 | WURevocation_01 | To enable a PID Provider or an Attestation Provider to verify the authenticity and the revocation status of a Wallet Unit it is interacting with, a Wallet Provider SHALL issue one or more Key Attestations (KA) and Wallet Instance Attestations (WIA) to the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation).| The first of these KAs and WIAs will be issued during the activation phase of a Wallet Unit. During the lifetime of the Wallet Unit, the Wallet Provider will re-issue KAs and WIAs as needed. |
-|AS-WP-38-002 | WURevocation_02 | Empty|  |
-|EW-DM-38-005 | WURevocation_07 | To revoke the Wallet Instance of a Wallet Unit, a Wallet Provider SHALL, in the status list(s) for Wallet Instances, set the `revoked` status at all index positions mentioned in the WIAs issued to that Wallet Instance.|  |
-|EW-DM-38-007 | WURevocation_09 | During the lifetime of a Wallet Unit, the Wallet Provider SHALL regularly verify that the security of the Wallet Unit is not breached or compromised. If the Wallet Provider detects a security breach or compromise, the Wallet Provider SHALL analyse its cause(s) and impact(s). If the breach or compromise affects the trustworthiness or reliability of the Wallet Unit, the Wallet Provider SHALL revoke the Wallet Unit by revoking the Wallet Instance according to WURevocation_07. The Wallet Provider SHALL do so at least in the following circumstances: - If the security of the Wallet Unit, or the security of the mobile device and OS on which the corresponding Wallet Instance is installed,  or the security of the WSCA/WSCD it uses for managing critical cryptographic assets, is breached or compromised in a manner that affects its trustworthiness or reliability. - If the security of the Wallet Solution is breached or compromised in a manner that affects the trustworthiness or reliability of all corresponding Wallet Units. - If the security of the common authentication and data protection mechanisms used by the Wallet Unit is breached or compromised in a manner that affects their trustworthiness or reliability. - If the security of the electronic identification scheme under which the Wallet Unit is provided is breached or compromised in a manner that affects its trustworthiness or reliability.| The first bullet corresponds to a Critical or High Risk level security posture risk status according to the table in [Section 6.5.4.2 of the ARF main document](../../architecture-and-reference-framework-main.md#6542-wallet-unit-revocation), as analysed or detected for a Wallet Instance due to monitoring done according to WPSM_03. |
-|EW-DM-38-008 | WURevocation_09a | If  a breach or compromise detected per WURevocation_09 affects the trustworthiness or reliability of a (type of) WSCA/WSCD or keystore, the Wallet Provider SHALL revoke the corresponding (type of) WSCA/WSCD or keystore according to WURevocation_07a; see also WUA_28 and VCR_07e.| Per WURevocation_09, a compromise of a type of WSCA/WSCD always leads to the revocation of both that type of WSCA/WSCD and of all Wallet Instances using a WSCA/WSCD of that type. |
-|EW-DM-38-009 | WURevocation_09b | Empty|  |
-|EW-DM-38-010 | WURevocation_09c | If a Wallet Provider revokes a keystore of a Wallet Unit, it SHOULD also revoke the entire Wallet Unit by revoking the Wallet Instance. If the Wallet Provider decides to not revoke the Wallet Instance, it SHALL create a risk analysis showing that this does not lead to unacceptable risks to the User, PID Providers and Attestation Providers, Relying Parties, or the Wallet Provider itself.| If the Wallet Provider does not revoke the Wallet Instance, only the attestations bound to the revoked keystore will be impacted. Other functionalities of the Wallet Unit, including the presentation of a PID, will remain available to the User. |
-|EW-DM-38-011 | WURevocation_10 | A Wallet Provider SHALL revoke a Wallet Unit upon the explicit request of the User registered during the Wallet Unit activation process, see [Topic 40](./annex-2.02-high-level-requirements-by-topic.md#a2323-topic-40-wallet-instance-installation-and-wallet-unit-activation-and-management). To do so, the Wallet Provider SHALL revoke the Wallet Instance (see WURevocation_07). The Wallet Provider SHALL authenticate the User before accepting a request to revoke the Wallet Unit.|  |
-|EW-DM-38-012 | WURevocation_11 | A Wallet Provider SHALL revoke a Wallet Unit upon the explicit request of a PID Provider, in case the natural person using the Wallet Unit has died. To do so, the Wallet Provider SHALL revoke the Wallet Instance (see WURevocation_07). To identify the Wallet Unit that is to be revoked, the PID Provider SHALL use a Wallet Instance identifier provided by the Wallet Provider in the WIA during PID issuance.| Under [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), the Wallet Instance identifier used for revocation is conveyed in the WIA (see WUA_08). See also the notes to WUA_08. |
-|EW-DM-38-013 | WURevocation_12 | Before revoking a Wallet Unit per WURevocation_11, the Wallet Provider SHALL verify that the party requesting revocation is indeed a valid PID Provider listed in the LoTE of PID Providers.|  |
-|EW-DM-38-014 | WURevocation_13 | Before requesting a Wallet Provider to revoke a Wallet Unit per WURevocation_11, the PID Provider SHALL ensure that the revocation does not harm the interests of any of the stakeholders. The PID Provider SHALL include a documented policy ensuring that this is the case in the policy meant in WURevocation_03.|  |
-|EW-DM-38-015 | WURevocation_14 | A Wallet Provider SHALL inform a User without delay, and within 24 hours at most, in case the Wallet Provider decided to revoke the User's Wallet Unit. The Wallet Provider SHALL also inform the User about the reason(s) for the revocation. This information SHALL be understandable for the general public. It SHALL include (a reference to) technical details about any security breach if applicable. The Wallet Provider SHALL inform the User about the function(s) of the Wallet Unit that remain available to the User, if any, and functions that will not work any more. The Wallet Provider SHALL also inform the User about measures they can take to ensure they have a fully working Wallet Unit again as soon as possible, such as migrating to a different Wallet Solution.| Functions that remain available to the User may include viewing their own attributes in their Wallet Unit and accessing their account at the Wallet Provider. |
-|EW-DM-38-017 | WURevocation_16 | To inform a User about the revocation of their Wallet Unit, the Wallet Provider SHALL use a communication channel that is independent of the Wallet Unit. In addition, the Wallet Provider MAY use the Wallet Unit itself to inform the User.|  |
-|AS-WP-38-018 | WURevocation_18 | A PID Provider issuing revocable PIDs SHALL, for each of its valid PIDs, regularly verify whether the Wallet Instance on which that PID is residing has been revoked and whether the associated WSCD  has been revoked, using the WIA and KA received during issuance of that PID. If either the Wallet Instance or the WSCD has been revoked, the PID Provider SHALL immediately revoke the respective PID.| a) This requirement aligns with WUA_29, which requires PID Providers to check the revocation status of both the WIA and KA throughout the PID validity period. b) This is a consequence of the legal requirement in [CIR 2024/2977], Article 5, 4.(b). c) See [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) for how the PID Provider can do this verification. |
-|AS-WP-38-019 | WURevocation_19 | An Attestation Provider issuing revocable attestations MAY decide to revoke an attestation if the Wallet Provider revoked the Wallet Unit on which that attestation is residing, in the same manner as described in WURevocation_18. An Attestation Provider SHALL publish its policy in this regard.| Publishing its policy regarding revocation allows a Relying Party to decide if it can put sufficient trust in the attestations issued by that Attestation Provider. |
-|AS-WP-40-001 | WIAM_01 | To ensure that the User can trust the Wallet Solution, a Wallet Provider SHOULD make its certified Wallet Solution available for installation only via the official app store of the relevant operating system (e.g., Android, iOS).| This allows the operating system of the device to perform relevant checks regarding the authenticity of the Wallet Unit. |
-|AS-WP-40-002 | WIAM_02 | If a Wallet Provider makes its certified Wallet Solution available for installation through other means than the official OS app store, it SHALL implement a mechanism allowing the User to verify the authenticity of the Wallet Unit. Moreover, it SHALL provide clear instructions to the User on how to install the Wallet Instance, including at least: - instructions on the verification of the authenticity of the Wallet Instance to be installed, - instructions on bypassing of any operating system limitations on side-loading of apps, if applicable, and ensuring that these limitations are restored after the Wallet Instance has been installed.| This requirement also applies for the installation of a Wallet Instance on a User device that is not a mobile device, and for which no official operating system app store may exist. |
-|AS-WP-40-003 | WIAM_03 | A Wallet Provider SHALL ensure that a Wallet Instance starts a process to activate the new Wallet Unit with the Wallet Provider immediately after installation or when the User first opens the Wallet Instance. The Wallet Provider SHALL ensure that the Wallet Instance starts this process only with a secure backend of the Wallet Provider.|  |
-|AS-WP-40-004 | WIAM_04 | During the activation process of a new Wallet Unit, the Wallet Provider SHALL verify that the new Wallet Instance is a genuine instance of its Wallet Solution.|  |
-|AS-WP-40-005 | WIAM_05 | During the activation process of a new Wallet Unit, the Wallet Provider SHALL process information about the User device and the available WSCA/WSCD and keystore(s), as far as necessary to issue Key Attestations and Wallet Instance Attestations to the Wallet Unit conform all requirements in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation). The Wallet Provider MAY process additional information necessary for managing the Wallet Unit, but it SHALL NOT process more information than it reasonably needs for legitimate purposes. The Wallet Provider SHALL request User consent (through the Wallet Instance) for all information and data it will process, both during activation and throughout the lifetime of the Wallet Unit. The Wallet Provider SHALL inform the User about the purposes of data processing, in accordance with the General Data Protection Regulation.|  |
-|AS-WP-40-006 | WIAM_06 | The Wallet Provider SHALL request the User, through the new Wallet Instance, to set up a User account at the Wallet Provider, or to log in to an existing account. The Wallet Provider SHALL explain to the User that this is necessary to enable the User to request revocation of the Wallet Unit in case of theft or loss. The Wallet Provider SHALL register one or more User authentication methods that the Wallet Provider will use to authenticate the User in the future. These methods SHALL be independent of the Wallet Unit and the User device. The Wallet Provider SHALL allow the User to register using an alias instead of true identity data. The Wallet Provider SHALL NOT use any registered User data for purposes other than User authentication, unless the User gives explicit consent to do so. The Wallet Provider SHALL register the relationship between the Wallet Unit and the corresponding User account.| The User may already have an account at the Wallet Provider, for example because they use a Wallet Unit of this Wallet Provider already on another device, or if they are migrating to a new device. |
-|AS-WP-40-007 | WIAM_07 | A Wallet Provider SHALL activate a new Wallet Unit before a User can use it to have issued an PID or attestation.|  |
-|AS-WP-40-008 | WIAM_08 | A Wallet Provider SHALL only activate a new Wallet Unit if it has verified that the Wallet Unit includes a WSCA/WSCD that is certified to be compliant with applicable requirements for Level of Assurance High.| a) A WSCA/WSCD by definition complies with requirements for Level of Assurance High, see WIAM_14. b) In addition, the Wallet Unit can include one or more keystores. |
-|AS-WP-40-009 | WIAM_08a | If a Wallet Unit contains one or more keystores, the Wallet Provider SHALL assign a security level to every keystore, with the following possible values: `iso_18045_high`, `iso_18045_moderate`, `iso_18045_enhanced-basic`, `iso_18045_basic` or `none`, corresponding to the level of resistance for which the keystore was certified (respectively AVA_VAN.5, AVA_VAN.4, AVA_VAN.3, AVA_VAN.2 and no certification).| For the definition of these security levels, also see [OpenID4VC]I Annex D.2 |
-|AS-WP-40-010 | WIAM_09 | If a WSCA/WSCD or keystore contains cryptographic assets related to multiple Wallet Units, the Wallet Provider SHALL ensure that a Wallet Unit can only access assets that are related to that Wallet Unit.|  |
-|AS-WP-40-011 | WIAM_10 | During the activation process of a new Wallet Unit, a Wallet Provider SHALL create and sign at least one Key Attestation for the WSCA/WSCD, at least one Key Attestation for each keystore, and at least one Wallet Instance Attestation, and issue them to the Wallet Unit. The Wallet Provider SHALL verify that the private key(s) corresponding to the public key(s) in each KA are protected by the respective WSCA/WSCD or keystore, under control of the User. The Wallet Provider SHALL take measures to verify the integrity of the Wallet Instance before issuing a Wallet Instance Attestation.|  |
-|AS-WP-40-012 | WIAM_10a | During the activation process of a new Wallet Unit, the Wallet Provider SHALL offer the User a means to verify the formal certification information of their Wallet Solution.|  |
-|AS-WP-40-013 | WIAM_11 | Empty|  |
-|AS-WP-40-014 | WIAM_12 | All communication between the Wallet Provider and the Wallet Instance SHALL be mutually authenticated and SHOULD be encrypted.|  |
-|AS-WP-40-015 | WIAM_12a | A Wallet Provider SHALL NOT access the contents of a Wallet Instance, in particular to learn a) which attestations are present on the Wallet Unit, b) the status of these attestations, c) the value of attributes in these attestations, and d) the contents of the Wallet Unit log meant in DASH_02.|  |
-|AS-WP-40-016 | WIAM_12b | If the contents of a Wallet Unit specified in WIAM_12a are stored in a Wallet Instance on the User's device, the Wallet Instance SHALL ensure that the Wallet Provider cannot access the contents of the Wallet Unit.|  |
-|AS-WP-40-017 | WIAM_12c | If the contents of a Wallet Unit specified in WIAM_12a are stored in a Wallet Unit Service on the Wallet Provider backend, the Wallet Provider SHALL specify and implement strict controls to limit access by the Wallet Provider to the contents of the Wallet Unit.| In this situation, the Wallet Unit cannot fully prevent the Wallet Provider from accessing the Wallet Unit contents. |
-|AS-WP-40-018 | WIAM_13 | A Wallet Unit SHALL enable the User to 'factory reset' the Wallet Unit, which SHALL cause the deletion of all attestations, the log, and all other personal data, settings, and configurations from the Wallet Unit. If the User resets the Wallet Unit, the Wallet Instance SHALL request the associated WSCA/WSCD and keystore(s) to delete all cryptographic assets related to the Wallet Unit and to all PIDs and device-bound attestations on the Wallet Unit, if the WSCA/WSCD and the keystore(s) are connected to the User device.|  a) The User can use this option, for instance, in preparation to the planned uninstallation of the Wallet Instance. b) Deletion of PID or KA cryptographic assets requires User authentication, as specified in requirement WIAM_14. c) The Wallet Unit does not necessarily inform the Wallet Provider about the factory reset. d) It may happen there is no connection to the WSCA/WSCD or to a keystore at the moment the User resets the Wallet Instance. For instance, in case the WSCA/WSCD is an external smart card and the User does not present that card to the User device. Another example occurs when the WSCA/WSCD is a remote HSM and the User device is offline at that moment. In such cases, the cryptographic assets will remain present on the WSCA/WSCD or on the keystore, even though they will never be used again. If needed, it is up to the Wallet Provider to define how the Wallet Unit should handle such situations. For example, an HSM manager could address such cases by deciding to delete cryptographic keys in the HSM that are too old or haven't been used for too long, while being aware of the risks in doing so. |
-|AS-WP-40-019 | WIAM_13a | If a Wallet Unit supports the [W3C Digital Credentials API] and the User resets the Wallet Unit, the Wallet Unit SHALL disclose the fact that it no longer stores any previously disclosed PID(s) or attestation(s) to the Digital Credentials API framework.|  |
-|AS-WP-40-020 | WIAM_14 | A WSCA/WSCD managing the critical assets of a PID, such as private or secret cryptographic keys, SHALL authenticate the User at Level of Assurance High before performing any cryptographic operation involving any of these assets.| a) [CIR 2024/2981], Annex IV, section 2 (3) states "As a prerequisite to the certification under national certification schemes, the WSCD shall be assessed against the requirements of assurance level high as set out in Implementing Regulation (EU) 2015/1502." Therefore, a WSCA/WSCD by legal definition complies with requirements of LoA High. b) Note to WIAM_14 - WIAM_14b: Many actions of the Wallet Unit, such as processing a Relying Party presentation request and presenting an attestation, require multiple cryptographic operations, for example ephemeral key generation followed by key agreement and presentation signing and encryption. These requirements does not imply that a separate User authentication is necessary before each of these operations. Rather, a successful User authentication will be valid for all cryptographic operations necessary for a Wallet Unit action. It is up to the Wallet Provider to determine what constitutes a 'Wallet Unit action', finding a balance between security (more User authentications) and User convenience (fewer User authentications). During certification of the Wallet Solution, it will be verified that the solution provides an adequate level of security. |
-|AS-WP-40-021 | WIAM_14a | A WSCA/WSCD managing the critical assets of a KA SHALL authenticate the User at Level of Assurance High before performing any cryptographic operation involving any of these assets.| The WSCA/WSCD manages the private key(s) corresponding to the public key(s) attested in the KA. |
-|AS-WP-40-022 | WIAM_14b | A WSCA/WSCD managing the cryptographic assets of an attestation having a level of security High SHALL authenticate the User at level of security High before performing any cryptographic operation involving any of these assets.| a) The term 'Level of Assurance', as used in the European Digital Identity Regulation and in Implementing Regulation (EU) 2015/1502, is only applicable to electronic identity means, which in the context of the EUDI Wallet means only the PID. For that reason, this requirement uses the term 'level of security'. Levels of security are defined in standards or specifications different from CIR 2024/1502, for instance ISO/IEC 18045. b) During issuance of an attestation, the Attestation Provider in its Credential Issuer metadata indicates the level of security it requires for the key storage and user authentication for this type of attestation. See [OpenID4VCI] section 12.2.4 and Appendix D.2. |
-|AS-WP-40-023 | WIAM_14c | A Wallet Unit SHALL use either the WSCA/WSCD or a keystore to manage any cryptographic assets that are not considered to be critical assets.| a) The ARF uses the term 'keystore' to refer to a hardware-backed repository and service in which non-critical cryptographic assets are generated, stored, and used exclusively inside a dedicated hardware security boundary. b) Examples of non-critical cryptographic assets are private and secret keys of attestations having a level of security lower than High. c) As mentioned in WIAM_14 and WIAM_14b, the private and secret keys of PIDs and KAs are critical assets and therefore are stored in a WSCA/WSCD. |
-|AS-WP-40-024 | WIAM_15 | Before performing any operation, including allowing a User to view attestations and attribute values, a Wallet Instance SHALL securely authenticate the User using a multi-factor authentication mechanism provided by the User device.| a) One of the authentication factors is the possession of the User device. |
-|AS-WP-40-025 | WIAM_15a | For the purpose of WIAM_15, the Wallet Instance SHALL enforce the activation of an OS-level User authentication mechanism with adequate security policies.| Adequate' here means adequate for any operation excluding the issuance or presentation of PIDs, KAs, and potentially other attestations at level of security High. This includes but is not limited to generating pseudonyms, accessing the transaction log (dashboard), data export and migration, requesting the erasure of personal data by a Relying Party, and reporting a Relying Party to a DPA. |
-|AS-WP-40-026 | WIAM_15b | The Wallet Unit SHALL enable the User to use a Wallet Unit-specific authentication method for User authentication, in addition to the User authentication mechanism provided by the User device per WIAM_15. The Wallet Provider SHALL either make the use of this additional authentication method mandatory for all Users, or leave it to each User to decide if they want to use it.| a) This authentication method may be implemented by the Wallet Instance, a (local) keystore, the WSCA/WSCD, or any other component of the Wallet Unit. b) As an optimisation to reduce the number of User authentication events, the Wallet Provider can choose to implement this additional authentication method in the WSCA/WSCD, in such a way that it complies with WIAM_14. |
-|AS-WP-40-027 | WIAM_15c | The Wallet Instance SHALL also use the User authentication mechanism provided by the User device (WIAM_15) and possibly the Wallet Unit-specific authentication method (WIAM_15b) to unlock the keystore mentioned in WIAM_14c, where applicable.| Apart from using the same mechanism, the intent of this requirement is also to minimize the number of User authentications needed (after the initial authentication per WIAM_15a) to enable the issuance or presentation of (non-PID) attestations. However, see WIAM_16 and WIAM_16a; the Wallet Provider may request another authentication if this is necessary for security. |
-|AS-WP-40-028 | WIAM_16 | For the User authentication mechanism provided by the User device (WIAM_15), the Wallet Instance SHALL force the User device to enable a time-based control (e.g., a session timeout or re-authentication interval), to ensure that access is automatically revoked after a defined period of inactivity.| It is assumed that re-authentication is required by the User device when the device is locked by the User. |
-|AS-WP-40-029 | WIAM_16a | For the Wallet Unit-specific User authentication method (WIAM_15b), the Wallet Provider SHALL define and implement conditions after which user authentication shall again be required, including at least an idle timeout. The Wallet Unit SHOULD provide the User with the option to set the idle timeout to a duration shorter than the default timeout set by the Wallet Provider. The Wallet Provider SHOULD also consider other factors, including the device being locked by the User and the Wallet Instance losing focus.|  |
-|AS-WP-40-030 | WIAM_17 | The Wallet Provider SHALL ensure that the Wallet Unit requests the User, during  activation of the Wallet Unit, to set up the authentication factors for the User authentication mechanism implemented by the WSCA/WSCD meant in WIAM_14, the  authentication mechanism implemented by the User device meant in WIAM_15 and WIAM_15a,  and, if used,  the  Wallet Unit-specific authentication method meant in WIAM_15b.|  |
-|AS-WP-40-031 | WIAM_18 | Empty|  |
-|AS-WP-40-032 | WIAM_19 | A WSCA/WSCD and a keystore SHALL be able to prove possession of the private key corresponding to a public key on request of a Wallet Instance, for example by signing a challenge with that private key.|  |
-|AS-WP-40-033 | WIAM_20 | A WSCA/WSCD SHALL protect a private key it generated during the entire lifetime of the key. This protection SHALL at least imply that the WSCA/WSCD prevents the private key from being extracted in the clear. If a WSCA/WSCD is able to export a private key in encrypted format, the resulting level of protection SHALL be equivalent to the protection level of the private key when stored in the WSCA/WSCD.|  |
-|AS-WP-40-034 | WIAM_21 | Whenever the WSCA/WSCD successfully authenticated the User, the Wallet Unit SHOULD check if the WSCD contains cryptographic assets for technical PIDs or attestations that cannot be presented any longer to Relying Parties, for example because they have expired or because a once-only attestation (see [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), section D, method A) was presented to a Relying Party already. The Wallet Unit SHOULD then request the WSCA/WSCD to destroy all cryptographic assets related to these technical PIDs or attestations. However, the Wallet Unit SHOULD NOT request the destruction of the private key belonging to the last technical PID or attestation corresponding to a logical PID or attestation.| a) The reason for this recommendation is that probably, Wallet Providers will want to prevent an accumulation of unused private keys in the WSCA/WSCD, given that such devices typically do not have much storage space. However, deletion of private keys (and potentially other cryptographic assets) is a cryptographic key operation and cannot be done without User authentication - see WIAM_14. At the same time, for usability reasons the User must not be involved in such 'cleaning up' processes, see also ISSU_42. The recommended solution is to take advantage of a User authentication event to also carry out any necessary cleaning operations.  b) Method A (once-only attestations, see ISSU_ 37) includes a potential fallback to Method B (limited-time attestations) in case no unused technical PIDs or attestations are left. To ensure that falling back to Method B is always possible when needed, a Wallet Unit should ensure that for every logical PID or attestation it has, it is always in possession of at least one technical PID or attestation. |
-|AS-WP-43-001 | EDP_01 | A Wallet Unit SHALL enable an Attestation Provider to optionally express an embedded disclosure policy for a QEAA, PuB-EAA, or non-qualified EAA.| The [European Digital Identity Regulation] does not contain a requirement for PIDs to be able to contain an embedded disclosure policy. |
-|AS-WP-43-002 | EDP_02 | A Wallet Unit SHALL support embedded disclosure policies implementing the 'Authorised relying parties only policy' described in Annex III of Implementing Regulation (EU) 2024/2979. If present, such an embedded disclosure policy SHALL contain a list of EU-wide unique identifiers of Relying Parties, as specified in Reg_32. The Wallet Unit SHALL retrieve the Relying Party identifier from the access certificate presented by the Relying Party, and compare it to the list of authorised identifiers in the policy, unless the Relying Party is an intermediary. If the Relying Party is an intermediary, the Wallet Unit SHALL retrieve the unique identifier of the intermediated Relying Party from the presentation request or from the registration certificate of the intermediated Relying Party and compare this identifier to the list of authorised identifiers in the policy.| See RPI_07 for how the Wallet Unit can see if the Relying Party is an intermediary. |
-|AS-WP-43-003 | EDP_03 | A Wallet Unit SHALL support embedded disclosure policies implementing the 'Specific root of trust' policy described in Annex III of Implementing Regulation (EU) 2024/2979. If present, such an embedded disclosure policy SHALL contain a list of root or intermediate certificates used for signing Relying Party access certificates. The Wallet Unit SHALL compare the certificate chain that was used to sign the access certificate provided by the Relying Party to the list of authorised root or intermediate certificates in the policy, unless the Relying Party is an intermediary. If the Relying Party is an intermediary, the Wallet Unit SHALL retrieve the root certificate of the Provider of registration certificates of the intermediated Relying Party from the presentation request or from the Registrar's online service (as applicable) and compare this certificate to the list of authorised certificates in the policy.| See RPI_07 for how the Wallet Unit can see if the Relying Party is an intermediary. |
-|AS-WP-43-004 | EDP_05 | An embedded disclosure policy SHOULD contain a link to a website of the Attestation Provider explaining the disclosure policy in layman's terms. If this is the case, the Wallet Unit SHALL display the link to the User and allow them to navigate to that website.|  |
-|AS-WP-43-005 | EDP_06 | The Wallet Unit SHALL evaluate an embedded disclosure policy in conjunction with the information received from the requesting Relying Party, in order to determine if the Relying Party has permission from the Attestation Provider to access the requested attestation.|  |
-|AS-WP-43-006 | EDP_07 | The Wallet Unit SHALL enable the User, based on the outcome of the evaluation of the applicable embedded disclosure policy(s), to deny or allow the presentation of the requested attestation to the Relying Party.|  |
-|AS-WP-43-007 | EDP_08 | The Commission SHALL take measures to ensure a technical specification is created establishing common mechanisms for the specification of embedded disclosure policies by Attestation Providers, and for the evaluation of such policies by Wallet Units.|  |
-|AS-WP-43-008 | EDP_10 | During attestation issuance, a Wallet Unit SHALL retrieve and store the corresponding embedded disclosure policy, if any.| The intent of this requirement is that the Wallet Unit is able to evaluate an EDP during a presentation transaction, without needing to request it again from the Attestation Provider. This is necessary in particular during proximity presentations, which must be able to be done without an internet connection. |
-|AS-WP-48-001 | DATA_DLT_01 | A Wallet Unit SHALL support the possibilities mentioned in DATA_DLT_02, allowing a User to request from a Relying Party the erasure of their attributes that were presented by that Wallet Unit to that Relying Party, in accordance with Article 17 of Regulation (EU) 2016/679.|  |
-|AS-WP-48-002 | DATA_DLT_04 | Empty|  |
-|AS-WP-48-003 | DATA_DLT_05 | A Wallet Unit SHALL include the initiation of a data deletion request in a log, so it can be displayed to the User via the dashboard as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).| Because the request is sent by an external web browser, e-mail client, or phone client (see DATA_DLT_02), the Wallet Unit can only log the initiation of the request. |
-|AS-WP-48-004 | DATA_DLT_08 | Wallet Units, Relying Parties, and Registrars SHALL comply with the relevant requirements in [Technical Specification 7](../../technical-specifications/ts7-common-interface-for-data-deletion-request.md).|  |
-|AS-WP-50-001 | RPT_DPA_01 | A Wallet Unit SHALL enable the User to start the process of reporting a suspicious presentation request to a DPA. When prompted by the User, a Wallet Unit SHALL provide the contact details of the DPA which supervises the Relying Party that made the suspicious request, if available in the log for that request (see DASH_03). If the contact details of the supervising DPA are not available in the log, the Wallet Unit SHALL provide the contact details of the DPA of the region in which the Wallet Provider is residing. In addition, the Wallet Unit MAY also provide the contact details of other DPAs, taken from the European Data Protection Board website (<https://www.edpb.europa.eu/about-edpb/about-edpb/members_en>).| The DPA contact details may be unavailable in the log if there was no registration certificate in the presentation request and the User did not request the Wallet Unit to obtain the information registered about the Relying Party from the Registrar. See RPRC_16 - RPRC_18 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties). |
-|AS-WP-50-002 | RPT_DPA_02 | The Wallet Unit SHALL offer the User the option to report a suspicious request to a DPA via the transaction log presented in the dashboard, see [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).|  |
-|AS-WP-50-003 | RPT_DPA_02a | A Wallet Unit SHALL support at least the following possibilities to report a suspicious presentation request to a DPA, depending on what contact details are available for the DPA: a) Open a URL in an external browser to report the request in a web form provided by the DPA. b) Open an external e-mail client and start a draft e-mail to the DPA, with a suitable template text, c) open an external phone client and start a phone call.|  |
-|AS-WP-50-004 | RPT_DPA_04 | A Wallet Provider SHALL ensure that a Wallet Unit allows its User to substantiate a report sent to a DPA, including by attaching relevant information to identify the Relying Party and the Users' claims in a machine-readable format.| The log kept by the Wallet Unit is standardised in [Technical Standard 10](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts10-data-portability-and-download-(export).md) and is machine-readable in order to enable data portability. An excerpt from this log therefore can be used to substantiate the report. |
-|AS-WP-50-005 | RPT_DPA_05 | A Wallet Unit SHALL log the fact that it initiated the sending of a report to a DPA (see RPT_DPA_02a), as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).|  |
-|AS-WP-50-006 | RPT_DPA_06 | Wallet Units, Data Protection Authorities, and Registrars SHALL comply with the relevant requirements in [Technical Specification 8](../../technical-specifications/ts8-common-interface-for-reporting-of-wrp-to-dpa.md).|  |
-|AS-WP-51-001 | PAD_01 | A Wallet Unit SHALL at any time enable the User to delete any PID or attestation from their Wallet Unit.|  |
-|AS-WP-51-002 | PAD_02 | If the User indicates that a logical PID or attestation must be deleted, and the Wallet Unit contains multiple physical PIDs or attestations corresponding to that logical PID or attestation, a Wallet Unit SHALL delete all of these physical PIDs and attestations simultaneously.| a) This situation may occur if the PID Provider or Attestation Provider issued a batch of physical PIDs or attestations to the Wallet Unit, rather than a single one. b) Physical PIDs or attestations correspond to a logical one if they have not only the same attestation type and Provider, but also the same attribute values. In principle, the same Provider can issue two attestations of the same type to the same Wallet Unit, for example two diplomas from the same university. This corresponds to the notion of a Credential Dataset in OpenID4VCI. |
-|AS-WP-51-003 | PAD_03 | If the Wallet Unit deletes a PID or attestation on the User's request, the Wallet Unit SHALL NOT notify the respective PID Provider or Attestation Provider.| This is a matter of User privacy. |
-|AS-WP-51-004 | PAD_04 | If the Wallet Unit deletes a PID or device-bound attestation on the User's request, the Wallet Unit SHALL ensure that all cryptographic assets in the WSCA/WSCD or keystores related to this PID or attestation are securely destroyed.| Key deletion for a PID key is a cryptographic key operation and requires User authentication, as specified in requirement WIAM_14. |
-|AS-WP-51-005 | PAD_05 | If a Wallet Unit supports the [W3C Digital Credentials API] and it deletes, on the User's request, a PID or attestation previously disclosed to the Digital Credentials API framework, the Wallet Instance SHALL disclose the fact that it no longer stores this PID or attestation to the Digital Credentials API framework.|  |
-|AS-WP-51-006 | PAD_06 | Empty|  |
-|AS-WP-54-001 | ACC_01 | Wallet Providers SHALL ensure that their Wallet Units comply with applicable requirements and standards in [Directive 2016/2012 on the accessibility of websites and mobile applications of public sector bodies](http://data.europa.eu/eli/dir/2016/2102/oj).| Compliance with the European Standard [ETSI EN 301 549 V1.1.2](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf) (2015-04) provides a presumption of conformity to the Accessibility Directive. |
-|AS-WP-54-002 | ACC_02 | Wallet Providers SHALL ensure that their Wallet Units comply with accessibility requirements for products and services established under [Directive (EU) 2019/882](http://data.europa.eu/eli/dir/2019/882/oj).| Compliance with the European Standard [ETSI EN 301 549 V1.1.2](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf) (2015-04) potentially provides a presumption of conformity to this Directive. |
-|AS-WP-56-001 | WPSM_01 | A Wallet Provider SHALL monitor their installed base of operational Wallet Instances for maintenance purposes, and determine and document in a transparent manner the data it needs and is allowed to monitor in order to deliver the required support. Data or attributes that SHOULD be monitored include: 1) Runtime errors, for uncaught errors in production code, 2) UX and telemetry information, for UX field analysis, 3) OS version and health information, for detection of OS level vulnerabilities, 4) Wallet Instance SDK and software library version information, for Wallet Instance code vulnerabilities, 5) User locale/localisation data, for catching localisation related errors, 6) Wallet Instance version, for catching errors or vulnerabilities due to outdated versions, 7) Supported WSCA/WSCDs and keystores and their supported capabilities, for detection of cryptography incompatibilities, 8) Unique device identifier such as IDFV or persisted UUID (iOS) or AndroidID (Android), for maintaining an up-to-date list of Wallet Instance-related device installations and for detecting potential malicious use (unrecognised identifier), 9) Device sensor identifiers and patch levels, for checking if sensor hardware in the device is up-to-date. 10) hardware-level details about the device, to identify known hardware-based problems or vulnerabilities, 11) BLE and NFC support by device, for analysing the security and feasibility of proximity use cases with a given Wallet Instance.|  |
-|AS-WP-56-002 | WPSM_02 | Wallet Providers SHALL, for maintenance purposes, write custom crash logs for sending them for further analysis.|  |
-|AS-WP-56-003 | WPSM_03 | A Wallet Provider SHALL monitor the security posture of its operational Wallet Instances for the purpose of detecting critical security risks in the environment the Wallet Instance is run at, and determine and document in a transparent manner the data it needs and is allowed to monitor. Information that SHOULD be monitored for software and hardware level problems/vulnerabilities on device includes 1) detection of device rooting/jailbreaking, 2) emulator detection, 3) device OS version and health data, 4) Wallet Instance SDK and SW library versions, 5) Wallet Instance version, 6) Supported WSCA/WSCD and keystore(s) and 7) Sensor identifiers and patch levels.|  |
-|AS-WP-56-004 | WPSM_04 | During the lifetime of the Wallet Unit, the Wallet Provider SHALL update the Wallet Unit as necessary to ensure its continued security and functionality.|  |
+Legacy ID: RPA_01
+{: .eudi-hlr__meta }
+
+The Wallet Unit used by a User, as well as the Relying Party Instance used by the Relying Party, SHALL implement a mechanism for Relying Party authentication in PID or attestation presentation transactions. This mechanism SHALL: - enable the Wallet Unit to identify and authenticate the Relying Party, - enable the Wallet Unit to verify that the request from the Relying Party was not copied and replayed, - use an access certificate issued in accordance with [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].
+
+*Note: Wallet Units and Relying Parties comply with this requirement if they comply with the requirements in this Topic.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-002" markdown>
+<div class="eudi-hlr__id">AS-WP-06-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_01a
+{: .eudi-hlr__meta }
+
+If a Wallet Unit supports the [W3C Digital Credentials API] for remote presentation flows, it SHALL retain full authority over the process meant in RPA_01. In particular, this process SHALL NOT be handled by a third party, including the browser and the operating system.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-003" markdown>
+<div class="eudi-hlr__id">AS-WP-06-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_02
+{: .eudi-hlr__meta }
+
+For performing Relying Party authentication, Wallet Units and Relying Party Instances SHALL support access certificates as specified in [ETSI TS 119 475] and [ETSI TS 119 411-8].
+
+*Note: In [ISO/IEC 18013-5], the Relying Party authentication mechanism is called mdoc reader authentication and uses an X.509 certificate. For [OpenID4VP], [HAIP] specifies that Client Identifier Prefix ``x509_hash`` must be used to authenticate the Relying Party; this also uses an X.509 certificate.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-004" markdown>
+<div class="eudi-hlr__id">AS-WP-06-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_03
+{: .eudi-hlr__meta }
+
+A Wallet Unit and a Relying Party Instance SHALL perform Relying Party authentication in all PID or attestation presentation transactions to Relying Parties, whether proximity or remote, using an access certificate.
+
+*Note: The actions both entities perform differ. For example, while the Relying Party creates a signature over some data in the request, the Wallet Unit validates that signature.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-005" markdown>
+<div class="eudi-hlr__id">AS-WP-06-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_04
+{: .eudi-hlr__meta }
+
+For the verification of access certificates, a Wallet Unit SHALL accept only the trust anchors in the LoTE(s) of all Access Certificate Authorities notified by Member States.
+
+*Note: For more information about Access Certificate Authorities, please see [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-006" markdown>
+<div class="eudi-hlr__id">AS-WP-06-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_05
+{: .eudi-hlr__meta }
+
+If Relying Party authentication fails for any reason, the Wallet Instance SHALL inform the User that the identity of the Relying Party could not be verified and that therefore the request is not trustworthy.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-007" markdown>
+<div class="eudi-hlr__id">AS-WP-06-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_06
+{: .eudi-hlr__meta }
+
+If Relying Party authentication succeeds, the Wallet Instance SHALL display to the User the trade names of the Relying Party and its Service, as included in the access certificate received from the Relying Party Instance, together with the attributes requested by the Relying Party. The Wallet Instance SHALL do so when asking the User for approval according to RPA_07.
+
+*Note: a) A Relying Party Instance may be used for multiple Relying Party services, provided it has received a separate access certificate for each, see Reg_10b. b) If the Relying Party is an intermediary acting on behalf of an intermediated Relying Party, the Wallet Instance displays the trade names of both the intermediary and the intermediated Relying Party to the User, see RPI_07.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-008" markdown>
+<div class="eudi-hlr__id">AS-WP-06-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_06a
+{: .eudi-hlr__meta }
+
+If Relying Party authentication fails for any reason, the Wallet Unit SHALL notify the User. In addition, the Wallet Unit SHALL either not present the requested attributes to the Relying Party, or give the User the choice to present the requested attributes or not.
+
+*Note: It is up to the Wallet Provider to make a choice for one of these two options.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-009" markdown>
+<div class="eudi-hlr__id">AS-WP-06-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_07
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL ensure the User approved the presentation of any attribute(s) in the Wallet Unit to a Relying Party or Verifier Wallet Unit, prior to presenting these attributes. A Wallet Unit SHALL always allow the User to refuse presenting an attribute requested by the Relying Party or Verifier Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-010" markdown>
+<div class="eudi-hlr__id">AS-WP-06-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_07a
+{: .eudi-hlr__meta }
+
+If a Wallet Unit supports the [W3C Digital Credentials API] for remote presentation flows, it SHALL retain full authority over the process meant in RPA_07. In particular, this process SHALL NOT be handled by a third party, including the browser and the operating system.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-011" markdown>
+<div class="eudi-hlr__id">AS-WP-06-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_08
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL authenticate the User before allowing the User to give or refuse approval for releasing any attributes, in accordance with WIAM_14 or WIAM_15, as applicable.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-012" markdown>
+<div class="eudi-hlr__id">AS-WP-06-012</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_09
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-013" markdown>
+<div class="eudi-hlr__id">AS-WP-06-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_10
+{: .eudi-hlr__meta }
+
+When asking for User approval, the Wallet Unit SHALL show to the User the User-friendly description of the Relying Party's intended use and, if available, the link to the applicable privacy policy.
+
+*Note: The User-friendly description of the Relying Party's intended use is included in the presentation request and also in the registration certificate, if available. The link to the privacy policy is included in the registration certificate, or in the absence of a registration certificate, the Wallet Unit obtained the link from the Registrar's online service, if the User requested this. See RPRC_19a and other requirements in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties) for details.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-014" markdown>
+<div class="eudi-hlr__id">AS-WP-06-014<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_10a
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHOULD ensure that the User gives approval either to present all attributes requested in a presentation request, or none of them.
+
+*Note: This means that a User should be asked either to approve the presentation of all requested attributes or to deny all of them. The Wallet Unit should not allow partial approval, since this would mean that the Relying Party cannot deliver the service, but nevertheless receives some User attributes. This would be a violation of the User's privacy. Note that a Relying Party is not allowed to request more data than is justified for the intended use. So if the User feels that the Relying Party is actually requesting more data than needed, that implies that the Relying Party is not trustworthy and should not receive any data.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-015" markdown>
+<div class="eudi-hlr__id">AS-WP-06-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_11
+{: .eudi-hlr__meta }
+
+When the presentation of an attestation or a PID is denied by the User, the Wallet Unit SHALL behave towards the Relying Party as if the attestation or PID did not exist.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-06-016" markdown>
+<div class="eudi-hlr__id">AS-WP-06-016<span class="kw-may">MAY</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_12
+{: .eudi-hlr__meta }
+
+When asking for User approval, the Wallet Unit MAY indicate to the User whether the attestation requested by a Relying Party is device-bound or not.
+
+*Note: The intent of this indication is to warn the User that a non-device-bound attestation may be copied by the Relying Party and presented to a third party.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-001" markdown>
+<div class="eudi-hlr__id">AS-WP-09-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_01
+{: .eudi-hlr__meta }
+
+A Key Attestation SHALL contain information about the certification of the WSCA/WSCD or a keystore available to the Wallet Unit, and SHALL comply with the relevant requirements in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+*Note: A PID Provider or Attestation Provider can use this information to take a well-grounded decision on whether to issue a PID or attestation to the Wallet Unit.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-002" markdown>
+<div class="eudi-hlr__id">AS-WP-09-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_02
+{: .eudi-hlr__meta }
+
+A Key Attestation SHALL enable PID Providers and Attestation Providers to verify the authenticity of a WSCD or keystore and to check whether the WSCD or keystore has been revoked.
+
+*Note: A KA carries a revocation reference that is valid for the WSCD or keystore of the Wallet Unit. How this revocation reference is managed (individually or per type of WSCD/keystore) depends on the approach chosen by the Wallet Provider (see WUA_28), but this is not relevant for the PID Provider or Attestation Provider that receives the KA.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-003" markdown>
+<div class="eudi-hlr__id">AS-WP-09-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_03
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL ensure that a non-revoked Wallet Unit at all times can present a temporally valid and non-revoked KA to a PID Provider or Attestation Provider during the issuance process of a PID or device-bound attestation.
+
+*Note: a) Revocation refers to the attested WSCD/keystore, not to the KA itself. b) For example, the Wallet Provider could pro-actively issue new KAs to the Wallet Unit, so that the Wallet Unit is always in possession of a valid KA. Alternatively, the Wallet Provider could ensure that whenever the User opens the Wallet Unit, it checks whether it is possession of a valid KA, and requests the Wallet Provider to issue a new KA if needed. A third possibility is that the Wallet Unit does this check only when it starts the process of requesting the (re-)issuance of a PID or attestation. Other alternatives to comply with this requirement may be used as well.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-004" markdown>
+<div class="eudi-hlr__id">AS-WP-09-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_04
+{: .eudi-hlr__meta }
+
+When issuing, presenting, or verifying a WIA or KA, Wallet Providers, Wallet Units, PID Providers, and Attestation Providers SHALL only use cryptographic algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-005" markdown>
+<div class="eudi-hlr__id">AS-WP-09-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_05
+{: .eudi-hlr__meta }
+
+During issuance of a PID, the Wallet Unit SHALL provide the PID Provider with a valid KA describing the WSCA/WSCD that generated the new PID private key.
+
+*Note: A PID private key is always generated and managed by the WSCA/WSCD, which by definition complies with requirements for Level of Assurance High.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-006" markdown>
+<div class="eudi-hlr__id">AS-WP-09-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_05a
+{: .eudi-hlr__meta }
+
+During issuance of a device-bound attestation, a Wallet Unit SHALL retrieve the requirements of the Attestation Provider regarding key storage from the Credential Issuer metadata (see ISSU_27d). The Wallet Unit SHALL determine which of its WSCA/WSCD or keystore(s), if any, comply with these requirements. If a compliant WSCA/WSCD or keystore is available to the Wallet Unit, the Wallet Unit SHALL provide the Attestation Provider with a valid KA describing the selected WSCA/WSCD or keystore.
+
+*Note: A KA describes the certification properties of the WSCA/WSCD or a keystore (see WUA_01) and contains one or more public key(s) corresponding to private key(s) generated by and stored in that WSCA/WSCD or keystore (see WUA_09).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-007" markdown>
+<div class="eudi-hlr__id">AS-WP-09-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_06
+{: .eudi-hlr__meta }
+
+If a Wallet Unit contains a WSCA/WSCD and one or more keystores, it SHALL, internally and securely, keep track of which PID(s) and attestation(s) are bound to which WSCA/WSCD or keystore.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-008" markdown>
+<div class="eudi-hlr__id">AS-WP-09-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_07
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL present a KA only to a PID Provider or Attestation Provider, as part of the issuance process of a PID or a key-bound attestation, and not to a Relying Party or any other entity.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-009" markdown>
+<div class="eudi-hlr__id">AS-WP-09-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_08
+{: .eudi-hlr__meta }
+
+A WIA SHALL enable PID Providers to request a Wallet Provider to revoke a Wallet Unit, in accordance with requirement WURevocation_11, by including an identifier for the Wallet Instance in the WIA. The Wallet Provider SHALL ensure that this Wallet Instance identifier does not enable tracking of the User.
+
+*Note: a) This is a legal requirement from [CIR 2024/2977].  b) Under [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) V1.5, this Wallet Instance identifier is the URI and index to the Attestation Status List for WIAs.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-010" markdown>
+<div class="eudi-hlr__id">AS-WP-09-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_09
+{: .eudi-hlr__meta }
+
+A KA SHALL contain one or more public keys, and the corresponding private keys SHALL be generated by and stored in the WSCA/WSCD or the keystore described in the KA.
+
+*Note: a) By signing the KA, the Wallet Provider attests to the fact that the private key(s) corresponding to the public key(s) in the KA are generated by and stored in this WSCA/WSCD or keystore. This implies that the Wallet Provider has verified that this is actually the case. However, neither the ARF nor [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) specify at which moment the WSCA/WSCD or keystore generated the private keys, or how the Wallet Provider verified that it did so. b) After receiving a KA during the issuance process for a (batch of) PID(s) or device-bound attestation(s), a PID Provider or Attestation Provider will include each of these public keys in a PID or attestation, thereby ensuring that this PID or attestation is bound to the WSCA/WSCD or keystore described in the KA.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-011" markdown>
+<div class="eudi-hlr__id">AS-WP-09-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_10
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that the certificates they use for signing WIAs and KAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 5.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-012" markdown>
+<div class="eudi-hlr__id">AS-WP-09-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_10a
+{: .eudi-hlr__meta }
+
+An Attestation Provider issuing non-device-bound attestations SHALL indicate in its Credential Issuer metadata that it does not need a KA, as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md). A Wallet Unit SHALL NOT send a KA to an Attestation Provider when requesting a non-device-bound attestation.
+
+*Note: A Wallet Unit sends a WIA to the Attestation Provider regardless of whether the attestations it issues are device-bound or not.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-013" markdown>
+<div class="eudi-hlr__id">AS-WP-09-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_10b
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL ensure that the presentation of a KA is cryptographically bound to the specific context it is intended to be used in.
+
+*Note: As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), this is achieved by letting the signed KA itself contain a nonce provided by the PID Provider or Attestation Provider during the issuance process. Alternatively, the Wallet Unit presents the KA along with a Proof-of-Possession consisting of a signature over that nonce, created by the private key corresponding to one of the public keys attested in the KA.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-014" markdown>
+<div class="eudi-hlr__id">AS-WP-09-014<span class="kw-may">MAY</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_11
+{: .eudi-hlr__meta }
+
+When asking for User approval to store an attestation (see ISSU_11), the Wallet Unit MAY indicate to the User whether the attestation requested by a Relying Party is device-bound or not.
+
+*Note: The intent of this indication is to warn the User that a non-device-bound attestation may be copied by an attacker breaching the Wallet Unit's security. See also RPA_12.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-015" markdown>
+<div class="eudi-hlr__id">AS-WP-09-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_11a
+{: .eudi-hlr__meta }
+
+During issuance of a PID or a device-bound attestation, the PID Provider or Attestation Provider SHALL verify the KA in accordance with the requirements in [OpenID4VCI] Appendix F.4. In addition, the PID Provider or Attestation Provider SHALL validate that the KA is not revoked.
+
+*Note: If the verification of the KA is successful, the PID Provider or Attestation Provider can trust that all public keys in the KA are bound to the WSCD or keystore described in the KA (see WUA_09).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-016" markdown>
+<div class="eudi-hlr__id">AS-WP-09-016</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_11b
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-017" markdown>
+<div class="eudi-hlr__id">AS-WP-09-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_12
+{: .eudi-hlr__meta }
+
+During issuance of a PID or a device-bound attestation, the PID Provider or Attestation Provider SHALL receive a proof that the Wallet Unit possesses the private keys corresponding to all public keys in the KA.
+
+*Note: As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), this proof consists of the signature of the Wallet Provider over the KA in combination with the proof mentioned in WUA_10b.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-018" markdown>
+<div class="eudi-hlr__id">AS-WP-09-018</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_13
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-019" markdown>
+<div class="eudi-hlr__id">AS-WP-09-019</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_14
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-020" markdown>
+<div class="eudi-hlr__id">AS-WP-09-020</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_15
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-021" markdown>
+<div class="eudi-hlr__id">AS-WP-09-021</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_16
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-022" markdown>
+<div class="eudi-hlr__id">AS-WP-09-022<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_16a
+{: .eudi-hlr__meta }
+
+A WSCA SHALL NOT enable export of private keys from a WSCD.
+
+*Note: The WSCA is dedicated firmware and/or software implementing specific functions needed within the EUDI Wallet ecosystem. Within that context, there is no need for private key export; therefore, a WSCA must not support it. However, a WSCD or a keystore may enable private key export via native firmware or software, for generic purposes.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-023" markdown>
+<div class="eudi-hlr__id">AS-WP-09-023<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_17
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL consider all relevant factors, including offline usage, interoperability, and the risk of a WIA or KA becoming a vector to track the User, when deciding on the validity period of a WIA or KA.
+
+*Note: a) Regarding interoperability, see WUA_30, which limits the validity period of PIDs issued based on the revocation maintenance periods of the WIA and KA received during issuance. b) As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), a PID Provider or Attestation Provider may communicate its preferences regarding the minimum revocation maintenance period of the WIA and KA to the Wallet Unit; the Wallet Unit and Wallet Provider should take this into account (see WUA_32). c) For the WIA specifically, a short technical validity period is required to ensure freshness; see WUA_33.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-024" markdown>
+<div class="eudi-hlr__id">AS-WP-09-024</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_18
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-025" markdown>
+<div class="eudi-hlr__id">AS-WP-09-025</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_19
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-026" markdown>
+<div class="eudi-hlr__id">AS-WP-09-026</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_20
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-027" markdown>
+<div class="eudi-hlr__id">AS-WP-09-027</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_20a
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-028" markdown>
+<div class="eudi-hlr__id">AS-WP-09-028</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_21
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-029" markdown>
+<div class="eudi-hlr__id">AS-WP-09-029<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_22
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL ensure that a non-revoked Wallet Unit at all times can present a temporally valid and non-revoked WIA to a PID Provider or Attestation Provider during the issuance process of a PID or attestation.
+
+*Note: a) This requirement applies to both device-bound and non-device-bound attestations. b) Revocation refers to the attested Wallet Instance, not to the WIA itself. c) For example, the Wallet Provider could pro-actively issue new WIAs to the Wallet Unit, so that the Wallet Unit is always in possession of a valid WIA. Alternatively, the Wallet Provider could ensure that whenever the User opens the Wallet Unit, it checks whether it is possession of a valid WIA, and requests the Wallet Provider to issue a new WIA if needed. A third possibility is that the Wallet Unit does this check only when it starts the process of requesting the (re-)issuance of a PID or attestation. Other alternatives to comply with this requirement may be used as well.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-030" markdown>
+<div class="eudi-hlr__id">AS-WP-09-030</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_23
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-031" markdown>
+<div class="eudi-hlr__id">AS-WP-09-031<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_24
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL present a WIA only to a PID Provider or Attestation Provider, as part of the issuance process of a PID or an attestation, and not to a Relying Party or any other entity.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-032" markdown>
+<div class="eudi-hlr__id">AS-WP-09-032<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_25
+{: .eudi-hlr__meta }
+
+During issuance of a PID or attestation, the PID Provider or Attestation Provider SHALL verify the WIA in accordance with the requirements in [OpenID4VCI] Appendix E. In addition, the PID Provider or Attestation Provider SHALL validate that the WIA is not revoked.
+
+*Note: This requirement applies to both device-bound and non-device-bound attestations.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-033" markdown>
+<div class="eudi-hlr__id">AS-WP-09-033<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_26
+{: .eudi-hlr__meta }
+
+A WIA SHALL enable PID Providers and Attestation Providers to verify the authenticity of a Wallet Instance and to check whether the Wallet Instance has been revoked.
+
+*Note: A WIA carries the revocation reference for a Wallet Instance; the revocation status of the Wallet Instance is maintained in a status list referenced in the WIA.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-034" markdown>
+<div class="eudi-hlr__id">AS-WP-09-034<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_27
+{: .eudi-hlr__meta }
+
+A WIA SHALL contain information about the Wallet Solution, including its identity, version, and certification, and SHALL comply with the relevant requirements in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+*Note: This information allows PID Providers and Attestation Providers to verify that the Wallet Instance belongs to a trusted and certified Wallet Solution, as registered in the Wallet Provider Trusted List.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-035" markdown>
+<div class="eudi-hlr__id">AS-WP-09-035<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_28
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL select either the type-shared index approach or the per-KA index approach (as specified in Section 2.5.2 of [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md)) for managing the revocation status of the WSCD or keystore referenced in a Key Attestation.
+
+*Note: a) Under the type-shared index approach, the revocation reference is shared across all Wallet Units using the same type of WSCD or keystore, so that a single revocation action covers all affected Wallet Units (e.g., when a security vulnerability is identified in a hardware component type). Under the per-KA index approach, each KA carries a revocation reference scoped to the specific Wallet Unit's WSCD or keystore instance, enabling individual revocation that may also be triggered by user request. b) The detailed requirements for each approach are specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-036" markdown>
+<div class="eudi-hlr__id">AS-WP-09-036<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_28a
+{: .eudi-hlr__meta }
+
+If the per-KA index approach is used, the Wallet Provider SHALL ensure that the revocation reference in a KA cannot be used to link a Wallet Unit's interactions across different PID Providers or Attestation Providers.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-037" markdown>
+<div class="eudi-hlr__id">AS-WP-09-037<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_29
+{: .eudi-hlr__meta }
+
+Throughout the entire validity period of an issued PID, the PID Provider SHALL verify the revocation status of both the Wallet Instance and WSCD using the information in the WIA and the KA (respectively) received during the issuance of that PID. If either is revoked, the PID Provider SHALL revoke the PID.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-038" markdown>
+<div class="eudi-hlr__id">AS-WP-09-038<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_30
+{: .eudi-hlr__meta }
+
+The technical validity period of a PID SHALL be consistent with the period during which the Wallet Provider has committed to maintaining the revocation status of the Wallet Instance and the WSCD, as conveyed in the WIA and KA presented during issuance.
+
+*Note: a) This reflects the revocation chaining requirement: PID Providers must be able to check whether the Wallet Instance has been revoked (via the WIA) and whether the WSCD referenced in the KA has been revoked (WUA_29) for the entire PID validity period.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-039" markdown>
+<div class="eudi-hlr__id">AS-WP-09-039<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_31
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL maintain the revocation status of a Wallet Instance during the entire revocation maintenance period indicated in the WIAs issued to that Wallet Instance.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-040" markdown>
+<div class="eudi-hlr__id">AS-WP-09-040<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_31a
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL maintain the revocation status of a WSCD or keystore during the entire revocation maintenance period indicated in the KAs issued to the Wallet Instance(s) using that WSCD or keystore.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-041" markdown>
+<div class="eudi-hlr__id">AS-WP-09-041<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_32
+{: .eudi-hlr__meta }
+
+At the time of PID or attestation issuance, a PID Provider or Attestation Provider SHALL communicate to the Wallet Unit its minimum requirements regarding the remaining revocation maintenance period for Wallet Instances (in WIAs) or WSCDs/keystores (in KAs), as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+*Note: This allows PID Providers and Attestation Providers to ensure that they receive WIAs and KAs with a sufficiently long remaining revocation maintenance period, enabling revocation chaining for the intended validity period of the PID or attestation to be issued.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-042" markdown>
+<div class="eudi-hlr__id">AS-WP-09-042<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_33
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL ensure that WIAs have a short technical validity period as specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), such that a WIA is fresh at the time of use.
+
+*Note: As specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), the technical validity period of a WIA SHALL be less than 24 hours. This ensures that the WIA reflects a recent integrity check of the Wallet Instance. The revocation maintenance period (see WUA_26 and WUA_31) is specified separately in the WIA and may be considerably longer than the technical validity period.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-043" markdown>
+<div class="eudi-hlr__id">AS-WP-09-043<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_34
+{: .eudi-hlr__meta }
+
+During issuance of a PID, a PID Provider SHALL verify that the keys attested in the KA are stored in the WSCA/WSCD described in the KA.
+
+*Note: PID private keys must be protected at Level of Assurance High, which requires key storage in a WSCA/WSCD. See also WUA_05, which requires the Wallet Unit to provide a KA describing the WSCA/WSCD that generated the PID private key.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-044" markdown>
+<div class="eudi-hlr__id">AS-WP-09-044<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_35
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL comply with all relevant requirements specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-045" markdown>
+<div class="eudi-hlr__id">AS-WP-09-045<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_36
+{: .eudi-hlr__meta }
+
+A PID Provider or Attestation Provider SHALL comply with all relevant requirements specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-09-046" markdown>
+<div class="eudi-hlr__id">AS-WP-09-046<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WUA_37
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL maintain, for each Wallet Unit it has activated, the set of WIAs and KAs it has issued to that Wallet Unit, in such a way that this association cannot be confused with that of any other Wallet Unit, including across different Wallet Solutions or different Wallet Solution versions. The Wallet Provider SHALL document the procedures, controls, and corresponding risk analysis implementing this requirement as part of the policy meant in WURevocation_03.
+
+*Note: This requirement makes explicit at the HLR level the record-keeping duty already implicit in WURevocation_07, WURevocation_07a, WIAM_05, WIAM_06, and WIAM_10, and required of the Wallet Provider by Section 2.4.2 of [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-001" markdown>
+<div class="eudi-hlr__id">AS-WP-11-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_01
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL enable a User to generate a Pseudonym and register it at a Relying Party.
+
+*Note: For an attested pseudonym, pseudonym generation takes place by requesting the issuance of a pseudonym attestation. Pseudonym registration takes place by presenting the attestation.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-002" markdown>
+<div class="eudi-hlr__id">AS-WP-11-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_02
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL enable a User to authenticate with a Pseudonym towards a Relying Party if the Wallet Unit was used previously to register the Pseudonym for the same Relying Party
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-003" markdown>
+<div class="eudi-hlr__id">AS-WP-11-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_03
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL be able to perform the actions specified in the above two requirements independently of whether the interaction with the Relying Party is initiated on the same device hosting the Wallet Instance or on a device different from the one hosting the Wallet Instance.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-004" markdown>
+<div class="eudi-hlr__id">AS-WP-11-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_04
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL enable the User to use multiple different Pseudonyms at a given Relying Party, unless it is explicitly designed as a scope rate-limited attestation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-005" markdown>
+<div class="eudi-hlr__id">AS-WP-11-005<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_05
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHOULD enable a User to freely choose a User alias for each Pseudonym registered at a Relying Party. Setting an alias SHOULD be optional for the User. The User SHOULD be able to change the alias for any Pseudonym.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-006" markdown>
+<div class="eudi-hlr__id">AS-WP-11-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_06
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL enable a User to choose which Pseudonym to authenticate with towards a Relying Party, if multiple Pseudonyms are registered for this Relying Party. The Wallet Unit SHOULD present the User with the aliases of the applicable Pseudonyms, if assigned, when making this choice.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-007" markdown>
+<div class="eudi-hlr__id">AS-WP-11-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_07
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL enable a User to delete a Pseudonym.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-008" markdown>
+<div class="eudi-hlr__id">AS-WP-11-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_08
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL enable the User to manage Pseudonyms within the Wallet Unit in a user-friendly and transparent manner.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-009" markdown>
+<div class="eudi-hlr__id">AS-WP-11-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_08a
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL log Pseudonym registration and presentation transactions as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-010" markdown>
+<div class="eudi-hlr__id">AS-WP-11-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_09
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL enable the User to see all existing pseudonyms, including the associated Relying Party (if any).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-011" markdown>
+<div class="eudi-hlr__id">AS-WP-11-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_10
+{: .eudi-hlr__meta }
+
+A Relying Party SHALL be able to verify that a User is registering a Pseudonym using a non-revoked Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-012" markdown>
+<div class="eudi-hlr__id">AS-WP-11-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_11
+{: .eudi-hlr__meta }
+
+A Relying Party SHALL be able to verify that a User is authenticating with a Pseudonym using a non-revoked Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-013" markdown>
+<div class="eudi-hlr__id">AS-WP-11-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_12
+{: .eudi-hlr__meta }
+
+If Wallet Unit is used to register a Pseudonym at a Relying Party in combination with a PID or attestation being presented to the same Relying Party, then this Relying Party SHALL be able to verify that the same User performed both actions.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-014" markdown>
+<div class="eudi-hlr__id">AS-WP-11-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_13
+{: .eudi-hlr__meta }
+
+The Relying Party SHALL be able to validate that the pseudonym presented to them belongs to the User presenting it.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-015" markdown>
+<div class="eudi-hlr__id">AS-WP-11-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_14
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL store the information necessary for authenticating with a Pseudonym in either a WSCA/WSCD or in a keystore.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-016" markdown>
+<div class="eudi-hlr__id">AS-WP-11-016<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_15
+{: .eudi-hlr__meta }
+
+A Relying Party SHALL NOT be able to derive the User's true identity, or any data identifying the User, from the Pseudonym value received by the Relying Party.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-017" markdown>
+<div class="eudi-hlr__id">AS-WP-11-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_16
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL NOT reveal the same Pseudonym to different Relying Parties, unless the User explicitly chooses otherwise.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-018" markdown>
+<div class="eudi-hlr__id">AS-WP-11-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_17
+{: .eudi-hlr__meta }
+
+The Wallet Provider SHALL use method(s) and/or protocol(s) to implement pseudonyms which make it impossible to correlate Pseudonyms based on their values or on metadata sent by the Wallet Unit to Relying Parties during registration and authentication.
+
+*Note: This implies that colluding Relying Parties will not be able to conclude that different Pseudonyms belong to the same User.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-019" markdown>
+<div class="eudi-hlr__id">AS-WP-11-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_18
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL ensure that Pseudonyms contain sufficient entropy to make the chance of colliding Pseudonyms (meaning two Users having the same Pseudonym value for the same Relying Party) negligible.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-020" markdown>
+<div class="eudi-hlr__id">AS-WP-11-020<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_19
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL NOT share the User's optionally assigned Pseudonym aliases with any Relying Party.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-021" markdown>
+<div class="eudi-hlr__id">AS-WP-11-021<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_20
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL verify the identity of a Relying Party when a User registers a Pseudonym or authenticates with a Pseudonym. If the profile or extension of [W3C WebAuthn] meant in PA_21 does not enable the Wallet Unit to do this, the Wallet Unit SHALL trust the WebAuthn Client (i.e., the browser) to verify the Relying Party identity.
+
+*Note: [W3C WebAuthn] currently does not offer a way for an Authenticator (i.e., the Wallet Unit) to authenticate a Relying Party. Instead, the Client (i.e., the browser) will authenticate the Relying Party, using TLS. The notion of trust is that the Wallet Unit receives the Relying Party identity from the browser and uses it without further verifications.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-022" markdown>
+<div class="eudi-hlr__id">AS-WP-11-022<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_21
+{: .eudi-hlr__meta }
+
+The Commission SHALL create or reference a technical specification containing a profile or extension of the [W3C WebAuthn] specification compliant with the HLRs specified in this Topic. This specification SHALL contain all details necessary for Wallet Units and Relying Parties to generate, register, and use Pseudonyms.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-023" markdown>
+<div class="eudi-hlr__id">AS-WP-11-023<span class="kw-may">MAY</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_22
+{: .eudi-hlr__meta }
+
+Wallet Providers MAY ensure that their Wallet Solution supports the HLRs defined for this topic by letting their Wallet Units perform the role of a WebAuthn authenticator following the [W3C WebAuthn] specification and the technical specification referenced in referenced in PA_21.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-024" markdown>
+<div class="eudi-hlr__id">AS-WP-11-024<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_23
+{: .eudi-hlr__meta }
+
+A protocol enabling scope rate-limited pseudonyms SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-025" markdown>
+<div class="eudi-hlr__id">AS-WP-11-025<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_24
+{: .eudi-hlr__meta }
+
+A protocol enabling scope rate-limited pseudonyms SHALL enable a Wallet Unit to allow a User to generate a scope rate-limited pseudonym, register this by a Relying Party, and prove that this is within the rate and scope restrictions determined by the Relying Party.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-026" markdown>
+<div class="eudi-hlr__id">AS-WP-11-026<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_25
+{: .eudi-hlr__meta }
+
+A protocol enabling scope rate-limited pseudonyms SHALL allow a Relying Party, when a User presents a scope rate-limited pseudonym, to verify that the rate is not exceeded for this User.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-027" markdown>
+<div class="eudi-hlr__id">AS-WP-11-027<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_26
+{: .eudi-hlr__meta }
+
+A protocol enabling scope rate-limited pseudonyms SHALL allow a Relying Party to choose the scope and rate when requesting a scope rate-limited pseudonym from a User.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-028" markdown>
+<div class="eudi-hlr__id">AS-WP-11-028<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_27
+{: .eudi-hlr__meta }
+
+A protocol enabling scope rate-limited pseudonyms SHALL NOT allow any entity or collusion of entities not including the User, to link scope rate-limited pseudonyms of the same User when used across several different Relying Parties. This SHALL hold even if the scope and rate are identical across the different Relying Parties and both for registration and authentication of the scope rate-limited pseudonym
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-029" markdown>
+<div class="eudi-hlr__id">AS-WP-11-029<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_28
+{: .eudi-hlr__meta }
+
+A protocol enabling scope rate-limited pseudonyms SHALL ensure that if the rate is larger than 1, a User's different pseudonyms SHALL be unlinkable for the same scope. This SHALL hold against any entity or collusion of entities, not including the User. Further, such protocol SHALL ensure that during registration or authentication with such a pseudonym, it SHALL NOT be possible for the Relying Party to deduce any information about how many pseudonyms the User has already registered (except that it does not exceed the predetermined rate).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-030" markdown>
+<div class="eudi-hlr__id">AS-WP-11-030<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_29
+{: .eudi-hlr__meta }
+
+A protocol enabling scope rate-limited pseudonyms SHALL ensure that no entity or collusion of entities, not including a User, is able to authenticate or register with a scope rate-limited pseudonym of this User.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-031" markdown>
+<div class="eudi-hlr__id">AS-WP-11-031<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_30
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL store cryptographic material necessary for authenticating as a scope rate-limited pseudonyms in either a WSCA/WSCD or in a keystore.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-11-032" markdown>
+<div class="eudi-hlr__id">AS-WP-11-032<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PA_31
+{: .eudi-hlr__meta }
+
+A User's scope rate limited pseudonyms for a particular scope and rate SHALL be persistent over time even if they start using another Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-001" markdown>
+<div class="eudi-hlr__id">AS-WP-16-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_01
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that each User has the possibility to receive a qualified certificate for Qualified Electronic Signatures, bound to a QSCD, that is either local, external, or remotely managed in relation to the Wallet Instance.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-002" markdown>
+<div class="eudi-hlr__id">AS-WP-16-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_02
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that each User who is a natural person has, at least for non-professional purposes, free-of-charge access to a Signature Creation Application which allows the creation of free-of-charge Qualified Electronic Signatures using the certificates referred to in QES_01. Wallet Providers SHALL ensure that: - The Signature Creation Application SHALL, as a minimum, be capable of signing or sealing User-provided data and Relying Party-provided data. - The Signature Creation Application SHALL be implemented as part of a Wallet Solution or external to it (by providers of trust services or by Relying Parties). - The Signature Creation Application SHALL be able to generate signatures or seals in formats compliant with at least the mandatory formats referred to in QES_08.
+
+*Note: a) Signature Creation Application (SCA): see definition in [ETSI TS 119 432]. 2) If the SCA is external to the Wallet Solution, it may be for example a separate mobile application, or be hosted remotely, for instance by the QTSP or by a Relying Party.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-003" markdown>
+<div class="eudi-hlr__id">AS-WP-16-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_03
+{: .eudi-hlr__meta }
+
+For the use of the qualified certificate referred to in QES_01, Wallet Providers SHALL ensure that a Wallet Unit implements secure authentication of the User, as well as signature or seal invocation capabilities, as a part of a local, external or remote QSCD.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-004" markdown>
+<div class="eudi-hlr__id">AS-WP-16-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_04
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL enable their Wallet Units to interface with QSCDs using protocols and interfaces necessary for the implementation of secure User authentication and signature or seal functionality.
+
+*Note: In a Relying Party-centric flow, the remote QTSP will likely be selected by the Relying Party, which implies the QSCD is managed by the remote QTSP. In a Wallet Unit-driven flow, the User should be able to choose the QSCD.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-005" markdown>
+<div class="eudi-hlr__id">AS-WP-16-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_05
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL enable their Wallet Units to be used for User enrolment to a remote QES Provider (i.e., a QTSP offering remote QES), except where the Wallet Unit interfaces with local or external QSCDs.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-006" markdown>
+<div class="eudi-hlr__id">AS-WP-16-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_06
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that their Wallet Solution supports at least one of the following options for remote QES signature creation: - remote QES creation through secure authentication to a QTSP signature web portal, - remote QES creation channelled by the Wallet Unit, - remote QES creation channelled by a Relying Party.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-007" markdown>
+<div class="eudi-hlr__id">AS-WP-16-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_07
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that, where a Signature Creation Application relies on a remote Qualified Signature Creation Device and where it is integrated into a Wallet Unit, it supports the Cloud Signature Consortium API Specification 2.0 [CSC API].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-008" markdown>
+<div class="eudi-hlr__id">AS-WP-16-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_08
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that their Wallet Units are able to create signatures or seals in accordance with the mandatory PAdES format as specified in [ETSI EN 319 142-1[ V1.1.1 (2016-04). In addition, Wallet Providers SHOULD ensure that their Wallet Units are able to create signatures or seals in accordance with the following formats: - XAdES as specified in [ETSI EN 319 132-1] V1.2.1 (2022-02), - JAdES as specified in [ETSI TS 119 182-1] V1.2.1 (2024-07), - CAdES as specified in [ETSI EN 319 122-1] V1.3.1 (2023-06), and - ASiC as specified in [ETSI EN 319 162-1] V1.1.1 (2016-04) and [ETSI EN 319 162-2] V1.1.1 (2016-04).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-009" markdown>
+<div class="eudi-hlr__id">AS-WP-16-009</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_09
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-010" markdown>
+<div class="eudi-hlr__id">AS-WP-16-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_10
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that, where the Signature Creation Application is implemented as part of the Wallet Unit and is used to generate signatures or seals of the representation of the document or data to be signed or sealed, the Wallet Unit presents the representation of the document or data to be signed or sealed to the User.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-011" markdown>
+<div class="eudi-hlr__id">AS-WP-16-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_11
+{: .eudi-hlr__meta }
+
+Where the Signature Creation Application is implemented as part of the Wallet Unit, a Wallet Unit SHALL compute the hash or digest of the document or data to be signed through its Signature Create Application component.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-012" markdown>
+<div class="eudi-hlr__id">AS-WP-16-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_12
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL be able to create a signature over a document or data to be signed, either by using a local QSCD or by interfacing with a remote QES Provider.
+
+*Note: a local signing application is on-device. It may either be embedded in the Wallet Unit or be an external application.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-013" markdown>
+<div class="eudi-hlr__id">AS-WP-16-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_13
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL provide a log of transactions related to qualified electronic signatures or seals generated by or through the Wallet Unit, allowing the User to view the history of previously signed data or documents, according to requirement DASH_04 in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+*Note: If the signature is generated by a remote Signature Creation Application, the Wallet is at minimum used to authenticate the User to the remote QTSP and to obtain the User's consent for the usage of the private signing key. The logs then record information about these processes.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-014" markdown>
+<div class="eudi-hlr__id">AS-WP-16-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_14
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL enable the User to explicitly authorise the creation of a qualified electronic signature or seal through their Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-015" markdown>
+<div class="eudi-hlr__id">AS-WP-16-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_15
+{: .eudi-hlr__meta }
+
+In remote signature creation scenarios, a Wallet Unit SHALL verify that the qualified electronic signature or seal creation device is part of a qualified service, which is carried out by a qualified trust service provider.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-016" markdown>
+<div class="eudi-hlr__id">AS-WP-16-016<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_16
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHOULD support multiple-signing scenarios, where multiple signatories are required to sign the same document or data.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-017" markdown>
+<div class="eudi-hlr__id">AS-WP-16-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_17
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL provide a signature creation confirmation upon the creation of a qualified electronic signature, informing the User about the outcome of the signature creation process.
+
+*Note: See also QES_17a.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-018" markdown>
+<div class="eudi-hlr__id">AS-WP-16-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_17a
+{: .eudi-hlr__meta }
+
+If the Signature Creation Application is external to the Wallet Unit, after the User authorises the usage of the private signing key, the Signature Creation Application SHALL return the outcome of the signature creation process to the Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-019" markdown>
+<div class="eudi-hlr__id">AS-WP-16-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_18
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL configure at least one default qualified signing service in the Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-020" markdown>
+<div class="eudi-hlr__id">AS-WP-16-020<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_19
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that, where the Signature Creation Application is implemented as part of the Wallet Unit, a Wallet Unit supports [ETSI TS 119 101] when using signing keys managed by the QSCD, whether locally, externally, or remotely in relation to the Wallet Instance.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-021" markdown>
+<div class="eudi-hlr__id">AS-WP-16-021</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_20
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-022" markdown>
+<div class="eudi-hlr__id">AS-WP-16-022</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_21
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-023" markdown>
+<div class="eudi-hlr__id">AS-WP-16-023</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_22
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-024" markdown>
+<div class="eudi-hlr__id">AS-WP-16-024<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_23
+{: .eudi-hlr__meta }
+
+QTSPs providing the remote QES part of a Wallet Solution SHALL support: 1. [ETSI TS 119 431-1] , 2. [ETSI TS 119 431-2] , 3. [ETSI TS 119 432]. Wallet Providers and QTSPs providing the remote QES part of a Wallet Solution SHALL comply with Sole Control Assurance Level (SCAL) 2 as defined in [CEN EN 419 241-1] .
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-025" markdown>
+<div class="eudi-hlr__id">AS-WP-16-025<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_24
+{: .eudi-hlr__meta }
+
+QTSPs providing the Signature Creation Application as part of the remote QES part of a Wallet Solution SHALL support [ETSI TS 119 101].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-026" markdown>
+<div class="eudi-hlr__id">AS-WP-16-026<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_24a
+{: .eudi-hlr__meta }
+
+Relying Parties providing the Signature Creation Application in a Relying Party-centric flow SHALL support [ETSI TS 119 101].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-027" markdown>
+<div class="eudi-hlr__id">AS-WP-16-027</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_25
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-16-028" markdown>
+<div class="eudi-hlr__id">AS-WP-16-028</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QES_26
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-18-001" markdown>
+<div class="eudi-hlr__id">AS-WP-18-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ACP_01
+{: .eudi-hlr__meta }
+
+A Cryptographic Binding of Attestations scheme SHALL enable a WSCA/WSCD or keystore to prove that it manages two or more private keys, paired with two or more public keys provided to it by the Wallet Unit.
+
+*Note: a)These public keys may be included in WIAs and KAs, PIDs, attestations, or pseudonyms. b) The proof may be transitive, so a proof that two keys are stored/managed in the same WSCA/WSCD or keystore may be done by proving these keys relate to each other via a third key (also stored in the WSCA/WSCD or keystore).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-18-002" markdown>
+<div class="eudi-hlr__id">AS-WP-18-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ACP_04
+{: .eudi-hlr__meta }
+
+A Cryptographic Binding of Attestations scheme SHALL be compatible with the requirements for attestation issuance in this document, in particular [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), as well as with requirements for both remote and proximity presentation flows in this document, in particular [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit) and [Topic 24](./annex-2.02-high-level-requirements-by-topic.md#a2314-topic-24-user-identification-in-proximity-scenarios).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-18-003" markdown>
+<div class="eudi-hlr__id">AS-WP-18-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ACP_05
+{: .eudi-hlr__meta }
+
+A Cryptographic Binding of Attestations scheme SHALL enable an Attestation Provider, during the issuance of an attestation, to request and obtain proof that the private key for the new attestation is managed by the same WSCA/WSCD or keystore as the private key of a PID or another attestation already existing on the Wallet Unit.
+
+*Note: ACP_05 and ACP_06 may require an addition to the common OpenID4VCI protocol referenced in requirement ISSU_01, or an extension or profile thereof.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-001" markdown>
+<div class="eudi-hlr__id">AS-WP-19-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_01
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL provide a user-friendly dashboard functionality to its User.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-002" markdown>
+<div class="eudi-hlr__id">AS-WP-19-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_02
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL log all transactions executed through the Wallet Unit, including any transactions that were not completed successfully. This log SHALL include all types of transaction executed through the Wallet Unit: a) PID or attestation issuance and re-issuance transactions, b) PID or attestation presentation transactions, c) Wallet-to-Wallet transactions (see [Topic 30](./annex-2.02-high-level-requirements-by-topic.md#a2319-topic-30-interaction-between-wallet-units)), d) pseudonym registration or presentation transactions, e) signature or seal creation transactions (see [Topic 16](./annex-2.02-high-level-requirements-by-topic.md#a2310-topic-16-signing-documents-with-a-wallet-unit)), f) data deletion requests sent to a Relying Party (see [Topic 48](./annex-2.02-high-level-requirements-by-topic.md#a2327-topic-48-blueprint-for-requesting-data-deletion-to-relying-parties)), g) reports sent to a Data Protection Authority (see [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data)), h) PID or attestation deletions by the User.
+
+*Note: For the data to be logged for a data deletion request to a Relying Party or a report sent to a DPA, see Topic 48 and Topic 50, respectively. For other types of transaction, the data to be logged is specified in the requirements in this Topic.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-003" markdown>
+<div class="eudi-hlr__id">AS-WP-19-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_02a
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL retain transactions in the log at least for the minimum retention period specified in applicable legislation. If the Wallet Unit must delete transactions from the log, for instance because of size limitations, the Wallet Unit SHALL notify the User via the dashboard before doing so, indicating the potential consequences for the User's data protection rights, and SHALL instruct the User how to export the transactions that are about to be deleted. See DASH_07.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-004" markdown>
+<div class="eudi-hlr__id">AS-WP-19-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_02b
+{: .eudi-hlr__meta }
+
+The dashboard SHALL include a functionality to display to the User an overview of all transactions in the log.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-005" markdown>
+<div class="eudi-hlr__id">AS-WP-19-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_02c
+{: .eudi-hlr__meta }
+
+The transaction log meant in DASH_02 SHALL comply with all relevant requirement in [Technical Specification 10](../../technical-specifications/ts10-data-portability-and-download-(export).md), including measures to ensure and/or verify its confidentiality, integrity, and authenticity.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-006" markdown>
+<div class="eudi-hlr__id">AS-WP-19-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_03
+{: .eudi-hlr__meta }
+
+For a PID or attestation presentation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the name and unique identifier of the corresponding Relying Party, and the Member State in which that Relying Party is established, c) the name, contact details (if available), and unique identifier of the intermediary, if an intermediary is involved in the transaction, d) the attestation type(s) and the identifier(s) of the attribute(s) that were requested, as well as those that were presented, e) in the case of non-completed transactions, the reason for such non-completion, f) the URL of the online service of the Relying Party's Registrar. g) the web form URL (if available), e-mail address (if available), and telephone number (if available) provided by the Relying Party for sending data deletion requests, see requirement RPRC_11 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), h) the name and country of the Data Protection Authority supervising the Relying Party, as well as the web form URL (if available), e-mail address (if available), and telephone number (if available) provided by this DPA for reporting suspicious attribute presentation requests. i) information on the intended use and the URL to the applicable privacy policy (if available).
+
+*Note: The information in points g), h), and i) may be retrieved from the registration certificate or from the Registrar's online service (see [Topic 44](../annex-2/annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-007" markdown>
+<div class="eudi-hlr__id">AS-WP-19-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_03a
+{: .eudi-hlr__meta }
+
+For a PID or attestation presentation transaction or a Wallet-to-Wallet transaction executed through the Wallet Unit, the log SHALL NOT contain the value of any attributes presented to the Relying Party or the Verifier Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-008" markdown>
+<div class="eudi-hlr__id">AS-WP-19-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_03b
+{: .eudi-hlr__meta }
+
+For a Wallet-to-Wallet transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the role of the Wallet Unit (Holder Wallet Unit or Verifier Wallet Unit), c) the attestation type(s) and the identifier(s) of the attribute(s) that were requested, as well as those that were presented, d) in the case of non-completed transactions, the reason for such non-completion.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-009" markdown>
+<div class="eudi-hlr__id">AS-WP-19-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_03c
+{: .eudi-hlr__meta }
+
+For a pseudonym registration or presentation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) identifying information about the Relying Party, if known to the Wallet Unit, c) whether it is a pseudonym registration or pseudonym presentation transaction, d) in the case of non-completed transactions, the reason for such non-completion.
+
+*Note: Regarding point b), see PA_20 in [Topic 11](./annex-2.02-high-level-requirements-by-topic.md#a238-topic-11-pseudonyms).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-010" markdown>
+<div class="eudi-hlr__id">AS-WP-19-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_03d
+{: .eudi-hlr__meta }
+
+If a presentation request contains transactional data, the Wallet Unit SHALL log the value of this transactional data only to the extent explicitly required by the applicable Technical Specification associated with the requested SUA attestation, and in accordance with data minimisation principles. If the applicable Technical Specification does not explicitly specify that transactional data shall be logged, the Wallet Unit SHALL NOT log the value of any transactional data.
+
+*Note: a) For the concepts of transactional data and SUA attestations and their related Technical Specifications, see [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments). b) For example, for PSD2 Strong Customer Authentication transactions, the scope of transactional data to be included in the transaction log is defined in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md) and includes the payment transaction identifier and merchant name.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-011" markdown>
+<div class="eudi-hlr__id">AS-WP-19-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_04
+{: .eudi-hlr__meta }
+
+For a signature or seal creation transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the document or data signed or sealed (if available to the Wallet Unit), c) in the case of non-completed transactions, the reason for such non-completion.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-012" markdown>
+<div class="eudi-hlr__id">AS-WP-19-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_05
+{: .eudi-hlr__meta }
+
+For a PID or attestation issuance or re-issuance transaction executed through the Wallet Unit, the log SHALL contain at least: a) the date and time of the transaction, b) the name, contact details (if available), and unique identifier of the corresponding PID Provider or Attestation Provider, c) the attestation type requested, as well as the attestation type issued, d) the number of attestations requested and issued (i.e., the size of the batch in case of batch issuance), e) in the case of non-completed transactions, the reason for such non-completion. f) for a re-issuance transaction, whether it was triggered by the User or by the Wallet Unit without involvement of the User, g) the URL of the associated Registrar's online service.
+
+*Note: Regarding point g): this URL can be retrieved from the access certificate.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-013" markdown>
+<div class="eudi-hlr__id">AS-WP-19-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_05a
+{: .eudi-hlr__meta }
+
+For the deletion of a PID or attestation by the User, the log SHALL contain at least: a) the date and time of the deletion event, b) the attestation type of the deleted PID or attestation. c) The name and unique identifier of the corresponding PID Provider or Attestation Provider.
+
+*Note: This requirement is not about deletion of transactions from the log, as per DASH_06a.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-014" markdown>
+<div class="eudi-hlr__id">AS-WP-19-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_06
+{: .eudi-hlr__meta }
+
+The Wallet Provider SHALL ensure the confidentiality, integrity, and authenticity of all transactions included in the log.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-015" markdown>
+<div class="eudi-hlr__id">AS-WP-19-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_06a
+{: .eudi-hlr__meta }
+
+Via the dashboard, the Wallet Unit SHALL enable the User to delete any transaction in the log. Before deleting any transactions, the Wallet Unit SHALL indicate to the User the potential consequences for the User's data protection rights.
+
+*Note: This requirement applies even in case the minimum retention period specified in applicable legislation (see DASH_02a) is not yet over.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-016" markdown>
+<div class="eudi-hlr__id">AS-WP-19-016<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_06b
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL ensure that no entity other than the User can delete transactions from the log, except possibly for the reason mentioned in DASH_02a.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-017" markdown>
+<div class="eudi-hlr__id">AS-WP-19-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_07
+{: .eudi-hlr__meta }
+
+The dashboard SHALL allow the User to export the details of one or more transactions in the log to a file, using the common format specified according to DASH_02c, while ensuring their confidentiality, authenticity and integrity. The file SHALL be stored in an external storage or remote storage location of the User's choice, from among the storage options supported by the Wallet Unit and SHALL use the common format and security measures specified according to DASH_02c.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-018" markdown>
+<div class="eudi-hlr__id">AS-WP-19-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_08
+{: .eudi-hlr__meta }
+
+For a natural-person User, a Wallet Instance SHALL provide a User interface.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-019" markdown>
+<div class="eudi-hlr__id">AS-WP-19-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_09
+{: .eudi-hlr__meta }
+
+The User interface referred to in DASH_08 SHALL provide a view with - the EU Digital Identity Wallet Trust Mark, - accompanying general information on the certification of Wallet Solutions, - links to the certification status information as defined in the [Technical Specification 1](../../technical-specifications/ts1-eudi-wallet-trust-mark.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-020" markdown>
+<div class="eudi-hlr__id">AS-WP-19-020<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_09a
+{: .eudi-hlr__meta }
+
+Positioning of the view meant in DASH_09 in the Wallet UI navigation SHALL follow design guidelines provided by the European Commission.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-021" markdown>
+<div class="eudi-hlr__id">AS-WP-19-021<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_09b
+{: .eudi-hlr__meta }
+
+Wallet Providers and Wallet Units SHALL comply with all relevant requirements in [Technical Specification 1](../../technical-specifications/ts1-eudi-wallet-trust-mark.md) for the EUDI Wallet Trust Mark.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-022" markdown>
+<div class="eudi-hlr__id">AS-WP-19-022</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_10
+{: .eudi-hlr__meta }
+
+Empty.
+
+*Note: See requirement WIAM_12a in [Topic 40](./annex-2.02-high-level-requirements-by-topic.md#a2323-topic-40-wallet-instance-installation-and-wallet-unit-activation-and-management).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-023" markdown>
+<div class="eudi-hlr__id">AS-WP-19-023</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_11
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-19-024" markdown>
+<div class="eudi-hlr__id">AS-WP-19-024<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DASH_12
+{: .eudi-hlr__meta }
+
+The User interface referred to in DASH_08 SHALL enable the User, for each presentation transaction in the log, to easily request the Relying Party to delete any or all attributes presented to it in that transaction, or to send a report about that particular transaction to a DPA.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-20-001" markdown>
+<div class="eudi-hlr__id">AS-WP-20-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: SUA_01
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL be able to process the transactional data included in a presentation request for the SUA attestation(s) specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md), according to all requirements in that Technical Specification.
+
+*Note: Technical Specification 12 specifies a SUA attestation intended for performing SCA as specified in the PSD2 Regulation. The related Rulebook is called "SCA Attestation Rulebook".*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-20-002" markdown>
+<div class="eudi-hlr__id">AS-WP-20-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: SUA_02
+{: .eudi-hlr__meta }
+
+Scheme Providers MAY specify Attestation Rulebooks (see [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)) and associated technical specifications for SUA attestations other that the ones specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md)). The Attestation Rulebook or the technical specification of such of a SUA attestation SHALL specify the syntax and semantics of the transactional data associated with that attestation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-20-003" markdown>
+<div class="eudi-hlr__id">AS-WP-20-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: SUA_02a
+{: .eudi-hlr__meta }
+
+The Technical Specification associated with a given SUA attestation SHALL specify all necessary requirements for Wallet Units to process transactional data intended for this SUA attestation, at least regarding a) rendering and displaying the data to the User when obtaining approval for presentation, b) processing (e.g., hashing) the data for inclusion in the device binding signature, and c) the scope of information to be logged about a SUA attestation presentation transaction by a Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-20-004" markdown>
+<div class="eudi-hlr__id">AS-WP-20-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: SUA_03
+{: .eudi-hlr__meta }
+
+The Attestation Provider of a SUA attestation other than the one(s) specified in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md) SHALL NOT issue such an attestation to a Wallet Unit that does not comply with all relevant requirements in the SUA Attestation Rulebook and the technical specification for that attestation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-20-005" markdown>
+<div class="eudi-hlr__id">AS-WP-20-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: SUA_04
+{: .eudi-hlr__meta }
+
+In the response to a presentation request for a SUA attestation that includes transactional data, a Wallet Unit SHALL include (a representation of) that data, according to requirements included in the associated technical specification or Attestation Rulebook or in information provided to the Wallet Unit in the presentation request. In the latter case, the rules to interpret such information SHALL be included in the associated technical specification or Attestation Rulebook.
+
+*Note: This requirement, as well as SUA_05, only applies if the requested SUA attestation is present on the Wallet Unit and if the User consents to signing the transactional data and presenting the requested attributes.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-20-006" markdown>
+<div class="eudi-hlr__id">AS-WP-20-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: SUA_05
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL include (a representation of) the transactional data received in a presentation request in the signature creation process used for device binding, using the private key of the requested SUA attestation and the mechanisms specified for key binding in [SD-JWT-VC] or mdoc authentication in [ISO/IEC 18013-5], as applicable. For this process, the Wallet Unit SHALL comply with the applicable requirements in the technical specification and the Attestation Rulebook for the requested SUA attestation, see SUA_01 or SUA_02.
+
+*Note: a) The resulting signature value constitutes a proof of transaction. This signature value, possibly in combination with other protocols items, fulfils the requirements for the authentication code required in [PSD2]. b) See also requirement OIA_02 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-20-007" markdown>
+<div class="eudi-hlr__id">AS-WP-20-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: SUA_06
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL render or adapt the dialogue message(s) displayed to the User (like font size and colour, background colour, text position, labels in the buttons to 'approve' or 'reject' a transaction), according to requirements in [Technical Specification 12](../../technical-specifications/ts12-specification-of-strong-customer-authentication-(sca)-Implementation-with-the-Wallet.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-20-008" markdown>
+<div class="eudi-hlr__id">AS-WP-20-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: SUA_07
+{: .eudi-hlr__meta }
+
+Upon receiving a presentation request with transactional data, the Wallet Unit SHALL validate if the transactional data is intended for the given attestation and that the transactional data conforms to the related technical specification and/or Attestation Rulebook. In case the validation result is positive, the Wallet Unit SHALL process the transactional data in compliance with the related technical specification.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-001" markdown>
+<div class="eudi-hlr__id">AS-WP-30-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_01
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL be able to act as a Holder Wallet Unit, in accordance with all requirements in this Topic.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-002" markdown>
+<div class="eudi-hlr__id">AS-WP-30-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_02
+{: .eudi-hlr__meta }
+
+When acting as a Holder Wallet Unit, if there is a contradiction between a requirement for Holder Wallet Units in this Topic and any requirement for Wallet Units in other Topics in this document, the requirement in this Topic SHALL take precedence. However, when acting as a Holder Wallet Unit, a Wallet Unit SHALL comply with all requirements for Wallet Units in other Topics in this document that do not contradict any requirement in this Topic.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-003" markdown>
+<div class="eudi-hlr__id">AS-WP-30-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_03
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL be able to act as a Verifier Wallet Unit, in accordance with all requirements in this Topic.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-004" markdown>
+<div class="eudi-hlr__id">AS-WP-30-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_04
+{: .eudi-hlr__meta }
+
+When acting as a Verifier Wallet Unit, a Wallet Unit SHALL NOT comply with any requirement for Wallet Units in other Topics in this document.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-005" markdown>
+<div class="eudi-hlr__id">AS-WP-30-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_05
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL act as a Holder Wallet Unit only if the User selects a 'Holder Wallet Unit mode'. If the User closes the Wallet Unit, or after a period of non-activity, the Wallet Unit SHALL return to 'normal' mode.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-006" markdown>
+<div class="eudi-hlr__id">AS-WP-30-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_06
+{: .eudi-hlr__meta }
+
+When entering the Holder Wallet Unit mode, a Wallet Unit SHALL inform its User that this mode should only be used for interactions with natural persons using a Wallet Unit, and that the User should not proceed if they are in fact interacting with a Relying Party.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-007" markdown>
+<div class="eudi-hlr__id">AS-WP-30-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_07
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL act as a Verifier Wallet Unit only if the User selects a 'Verifier Wallet Unit mode'. If the User closes the Wallet Unit, or after a period of non-activity, the Wallet Unit SHALL return to 'normal' mode.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-008" markdown>
+<div class="eudi-hlr__id">AS-WP-30-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_09
+{: .eudi-hlr__meta }
+
+Holder Wallet Units SHALL comply with the requirements for mDLs and for mdocs in ISO/IEC 18013-5, unless specified differently in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-009" markdown>
+<div class="eudi-hlr__id">AS-WP-30-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_10
+{: .eudi-hlr__meta }
+
+Verifier Wallet Units SHALL comply with the requirements for mDL readers and for mdoc readers in ISO/IEC 18013-5, unless specified differently in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-010" markdown>
+<div class="eudi-hlr__id">AS-WP-30-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_11
+{: .eudi-hlr__meta }
+
+A Holder Wallet Unit SHOULD provide the Holder, through a user-friendly UI, with the option to inform the Verifier Wallet Unit about the attributes which the Verifier should include in the presentation request, by sending a presentation offer. If the Holder creates a presentation offer, the Holder Wallet Unit SHALL transfer it to the Verifier Wallet Unit as specified in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).
+
+*Note: TS9 specifies an extension of the device engagement structure specified in ISO/IEC 18013-5.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-011" markdown>
+<div class="eudi-hlr__id">AS-WP-30-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_12
+{: .eudi-hlr__meta }
+
+A Holder Wallet Unit SHALL recommend the Holder to create a presentation offer, as this will increase the chance of success of the use case.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-012" markdown>
+<div class="eudi-hlr__id">AS-WP-30-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_13
+{: .eudi-hlr__meta }
+
+A Verifier Wallet Unit SHALL provide the Verifier, through a user-friendly UI, with the possibility to select the attributes that will be included in the presentation request.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-013" markdown>
+<div class="eudi-hlr__id">AS-WP-30-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_14
+{: .eudi-hlr__meta }
+
+For the purposes of W2W_07, if the Verifier Wallet Unit received a presentation offer, it SHALL present this offer to the Verifier, and enable the Verifier to include one or more of the attributes in the offer into the presentation request. However, the Verifier Wallet Unit SHALL NOT allow the Verifier to include any attribute not present in the offer.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-014" markdown>
+<div class="eudi-hlr__id">AS-WP-30-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_15
+{: .eudi-hlr__meta }
+
+For the purposes of W2W_07, if the Verifier Wallet Unit did not receive a presentation offer, it SHALL present the Verifier with a list of attributes that can be included in the presentation request. The Verifier Wallet Unit MAY ask the Verifier some questions about the purpose of the use case to narrow down the list.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-015" markdown>
+<div class="eudi-hlr__id">AS-WP-30-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_16
+{: .eudi-hlr__meta }
+
+A Verifier Wallet Unit SHALL authenticate the Verifier and SHALL obtain the Verifier's approval prior to sending a presentation request to a Holder Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-016" markdown>
+<div class="eudi-hlr__id">AS-WP-30-016<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_17
+{: .eudi-hlr__meta }
+
+A Verifier Wallet Unit SHALL implement measures to limit the number of presentation requests it can send per unit of time, to prevent abuse of the Wallet-to-Wallet functionality by Relying Parties. The limitation strategy, for instance exponential backoff time between subsequent presentation requests or hard limits for the number of requests, SHALL be decided by the Wallet Provider, based on applicable requirements in [Technical Specification 9](../../technical-specifications/ts9-wallet-to-wallet-interactions.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-017" markdown>
+<div class="eudi-hlr__id">AS-WP-30-017</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_18
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-018" markdown>
+<div class="eudi-hlr__id">AS-WP-30-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_19
+{: .eudi-hlr__meta }
+
+When receiving a presentation response, a Verifier Wallet SHALL verify the received attestation according to requirements OIA_12 - OIA_15 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-019" markdown>
+<div class="eudi-hlr__id">AS-WP-30-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_20
+{: .eudi-hlr__meta }
+
+A Verifier Wallet Unit SHALL display all verified attributes to the Verifier.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-020" markdown>
+<div class="eudi-hlr__id">AS-WP-30-020<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_21
+{: .eudi-hlr__meta }
+
+A Verifier Wallet Unit SHALL NOT persistently store any attestations or attributes received. A Verifier Wallet Unit SHOULD minimise the time the received presentation is stored in memory. A Verifier Wallet Unit SHALL comply with OIA_16 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-30-021" markdown>
+<div class="eudi-hlr__id">AS-WP-30-021<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_22
+{: .eudi-hlr__meta }
+
+Wallet Providers SHOULD take measures to prevent a User from taking screenshots while their Wallet Unit is acting as a Verifier Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-001" markdown>
+<div class="eudi-hlr__id">AS-WP-31-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PPNot_02
+{: .eudi-hlr__meta }
+
+The common set of information to be notified about a PID Provider SHALL include at least: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. A business registration number from an official record, b. Identification data from that official record. 2. PID Provider trust anchors, i.e., public keys and name as per point 1) ii) above, supporting the authentication of PIDs issued by the PID Provider, 3. Trust anchors of Access Certificate Authorities for PID Providers, i.e., public keys and CA name, supporting the authentication of the PID Provider by Wallet Units at the service supply point(s) listed per point 4. below. 4. Service supply point(s), i.e., the URL(s) at which a Wallet Unit can start the process of requesting and obtaining a PID.
+
+*Note: a) Relating to point 3. above: PID Provider Access Certificate Authority trust anchors are notified separately from the Access Certificate Authority for Relying Parties (see Section G below), since PID Providers are -legally speaking- not Relying Parties. b) For the concept of an Access Certificate Authority, see also [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)] and [Section 6.3.2 of the ARF main document](../../architecture-and-reference-framework-main.md#632-pid-provider-or-attestation-provider-registration-and-notification).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-002" markdown>
+<div class="eudi-hlr__id">AS-WP-31-002</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WPNot_01
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-003" markdown>
+<div class="eudi-hlr__id">AS-WP-31-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WPNot_02
+{: .eudi-hlr__meta }
+
+The common set of information to be notified about a Wallet Provider SHALL include: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. Business registration number from an official record, and b. Identification data from the official record. 2. Wallet Provider trust anchors, i.e., public keys and name as per point 1. b. above, supporting the authentication of Key Attestations and Wallet Instance Attestations issued by the Wallet Provider. 3. Name and reference number of the certified Wallet Solution(s) provided by the Wallet Provider.
+
+*Note: a) See [[Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)] and [[Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation)] for the definition of the KA and WIA. b) A Wallet Provider does not need an access certificate to interact with Wallet Units.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-004" markdown>
+<div class="eudi-hlr__id">AS-WP-31-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WPNot_03
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that all WIAs and KAs they issue can be authenticated using the trust anchors notified to the Commission.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-005" markdown>
+<div class="eudi-hlr__id">AS-WP-31-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WPNot_04
+{: .eudi-hlr__meta }
+
+PID Providers, Attestation Providers and other relevant actors SHALL accept Wallet Provider trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled Wallet Provider LoTE, which is sealed by the Commission.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-006" markdown>
+<div class="eudi-hlr__id">AS-WP-31-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WPNot_05
+{: .eudi-hlr__meta }
+
+The format of a Wallet Provider LoTE SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex E.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-007" markdown>
+<div class="eudi-hlr__id">AS-WP-31-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WPNot_06
+{: .eudi-hlr__meta }
+
+If a Wallet Provider is cancelled (see requirement GenNot_05 above), that Wallet Provider SHALL immediately revoke all of its Wallet Instances and all associated WSCDs and keystores, in accordance with the requirements in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation). If a Wallet Provider is suspended, that Wallet Provider and the Member State SHALL agree on the necessary precautionary measures that need to be taken, which MAY include the immediate revocation of the Wallet Instances and WSCDs or keystores for all or some of its valid Wallet Units.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-008" markdown>
+<div class="eudi-hlr__id">AS-WP-31-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PuBPNot_02
+{: .eudi-hlr__meta }
+
+The common set of information to be notified by Member States about PuB-EAA Providers SHALL include at least: 1. Identification data: i. MS/Country of establishment, ii. Name as registered in an official record, iii. Where applicable: a. Registration number as in official record, and b. Official record identification data. iv. Identification data of the Union or national law under which a. Either the PuB-EAA Provider is established as the responsible body for the Authentic Source based on which the electronic attestation of attributes is issued, or b. The PuB-EAA Provider is the body designated to act on behalf of the responsible body referred to in point 1. iv. a. v.The conformity assessment report issued by a conformity assessment body, confirming that the requirements set out in paragraphs 1, 2 and 6 of [Article 45f](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e3902-1-1) are met. 2. PuB-EAA Provider trust anchors, i.e., public keys and name as per point 1) ii) above, supporting the authentication of PuB-EAAs issued by the PuB-EAA Provider, 3. Service supply point(s), i.e., the URL(s) at which a Wallet Unit can start the process of requesting and obtaining a PuB-EAA from the PuB-EAA Provider.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-009" markdown>
+<div class="eudi-hlr__id">AS-WP-31-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPACANot_02
+{: .eudi-hlr__meta }
+
+The common set of information to be notified about an Access Certificate Authority or a Provider of registration certificates SHALL include: 1. Identification data: i) Member State or country of establishment, ii) Name as registered in an official record, iii) Where applicable: - A business registration number from an official record, - Identification data from that official record. 2. Trust anchors of the Access Certificate Authority or Provider of registration certificates, i.e., public keys and name as per point 1) ii), supporting the authentication of access certificates and registration certificates by Wallet Units.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-010" markdown>
+<div class="eudi-hlr__id">AS-WP-31-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: TLPub_01
+{: .eudi-hlr__meta }
+
+The European Commission SHALL establish technical specifications for the system enabling the publication by the Commission of the information notified by the Member States regarding PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities, and Providers of registration certificates.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-011" markdown>
+<div class="eudi-hlr__id">AS-WP-31-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: TLPub_02
+{: .eudi-hlr__meta }
+
+The European Commission SHALL establish technical specifications for the set of information to be published about PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities and Providers of registration certificates, based on the information notified by the Member States.
+
+*Note: The information to be published MAY be different from the information to be notified for each of these entities.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-012" markdown>
+<div class="eudi-hlr__id">AS-WP-31-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: TLPub_06
+{: .eudi-hlr__meta }
+
+The Commission SHALL publish in the OJEU the locations of the LoTEs for PID Providers, Wallet Providers, Access Certificate Authorities, and Providers of registration certificates, as well as the location of the Trusted List(s) of PuB-EAA Providers.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-31-013" markdown>
+<div class="eudi-hlr__id">AS-WP-31-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: TLPub_08
+{: .eudi-hlr__meta }
+
+As part of the specifications referred to in TLPub_01, the European Commission SHALL establish technical specifications for ensuring the availability and authenticity of the full history regarding the information notified about PID Providers, Wallet Providers, PuB-EAA Providers, Access Certificate Authorities, and Providers of registration certificates.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-001" markdown>
+<div class="eudi-hlr__id">AS-WP-34-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_01
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL include and keep up-to-date a Migration Object, containing the following information: - The contents of the log for all transactions executed through the Wallet Unit, as listed in requirement DASH_02. - A list of PIDs and attestations (except Key Attestations and Wallet Instance Attestations) present in the Wallet Unit, according to the requirements in this Topic.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-002" markdown>
+<div class="eudi-hlr__id">AS-WP-34-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_02
+{: .eudi-hlr__meta }
+
+The Migration Object SHALL comply with all requirements in [Technical Specification 10](../../technical-specifications/ts10-data-portability-and-download-(export).md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-003" markdown>
+<div class="eudi-hlr__id">AS-WP-34-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_03
+{: .eudi-hlr__meta }
+
+For each PID or device-bound attestation that is issued to it, a Wallet Unit SHALL add to the Migration Object all data necessary to request issuance of that PID or attestation once again. This SHALL include at least the attestation type and the PID Provider or Attestation Provider that issued the PID or attestation, as well as their service supply points. However, the Migration Object SHALL NOT contain attribute identifiers or attribute values, and SHALL NOT contain any private keys of the PID or device-bound attestation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-004" markdown>
+<div class="eudi-hlr__id">AS-WP-34-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_03a
+{: .eudi-hlr__meta }
+
+For each non-device-bound attestation that is issued to it, a Wallet Unit SHALL add to the Migration Object one of the following: either all data necessary to request issuance of that attestation once again, as listed in Mig_03, or all data necessary to transfer the attestation to a new device without involvement of the Attestation Provider, including attribute identifiers and attribute values. The Wallet Unit SHALL enable the User to indicate if they want to store attribute identifiers and values in the Migration Object.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-005" markdown>
+<div class="eudi-hlr__id">AS-WP-34-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_03b
+{: .eudi-hlr__meta }
+
+If the User deletes a PID or attestation from their Wallet Unit, the Wallet Unit SHALL delete the corresponding entry from the Migration Object.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-006" markdown>
+<div class="eudi-hlr__id">AS-WP-34-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_04
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL store the Migration Object in an external storage or remote storage location of the User's choice, from among the storage options supported by the Wallet Unit, in such a way that the User can still retrieve the object from a new Wallet Unit in case the existing Wallet Unit becomes unavailable.
+
+*Note: a) It is up to the Wallet Provider to decide which external storage options or remote storage locations the Wallet Unit supports for storing the Migration Object. b) The new Wallet Unit may be either an instance of the same Wallet Solution as the old one, or an instance of a different Wallet Solution.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-007" markdown>
+<div class="eudi-hlr__id">AS-WP-34-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_05
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL store the Migration Object in such a way that its confidentiality, integrity, and authenticity is protected and that it is protected against use by others than the User.
+
+*Note: This could be done, for example, by using password-based cryptography to encrypt the object.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-008" markdown>
+<div class="eudi-hlr__id">AS-WP-34-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_06
+{: .eudi-hlr__meta }
+
+Directly after installation of a new Wallet Instance, the Wallet Instance SHALL enable the User to import a Migration Object from an external storage or remote storage location indicated by the User, from among the storage options supported by the Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-009" markdown>
+<div class="eudi-hlr__id">AS-WP-34-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_07
+{: .eudi-hlr__meta }
+
+When importing a Migration Object, for each PID and device-bound attestation listed in the Migration Object, the Wallet Unit SHALL enable the User to select that PID or attestation. When a PID or device-bound attestation is selected, the Wallet Unit SHALL request the respective PID Provider or Attestation Provider to issue a new PID or attestation of the same type  to the new Wallet Unit. If the User selects a PID, the Wallet Unit SHALL request issuance of the PID first, before any of the other selected attestations.
+
+*Note: a) Since no refresh tokens (see ISSU_65) will be available on the new Wallet Unit, this is a new issuance process, which will include User authentication by the PID Provider or Attestation Provider. b) The rationale for the last requirement is to ensure that if other Attestation Providers want to use a PID to do User authentication, the PID is actually available.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-010" markdown>
+<div class="eudi-hlr__id">AS-WP-34-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_07a
+{: .eudi-hlr__meta }
+
+When importing a Migration Object, for each non-device-bound attestation listed in the Migration Object, the Wallet Unit SHALL enable the User to select that attestation. When an attestation is selected, the Wallet Unit SHALL, depending on whether the Migration Object contains attribute identifiers and attribute values (see Mig_03a), either restore the technical attestation directly from the Object or request the respective Attestation Provider to issue a new attestation of the same type to the new Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-011" markdown>
+<div class="eudi-hlr__id">AS-WP-34-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_07b
+{: .eudi-hlr__meta }
+
+When importing a Migration Object, the Wallet Unit SHALL ask the User whether they want to restore the log from the Migration Object. When the User agrees, the Wallet Unit SHALL restore the log, and SHALL append future transactions to this log according to the requirements in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-012" markdown>
+<div class="eudi-hlr__id">AS-WP-34-012</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_08
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-013" markdown>
+<div class="eudi-hlr__id">AS-WP-34-013</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_09
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-014" markdown>
+<div class="eudi-hlr__id">AS-WP-34-014</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_10
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-015" markdown>
+<div class="eudi-hlr__id">AS-WP-34-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_11
+{: .eudi-hlr__meta }
+
+The processes and interfaces used for issuance of a PID or attestation as part of a migration process SHALL be the same as those used for a 'normal' issuance process, as specified in [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-016" markdown>
+<div class="eudi-hlr__id">AS-WP-34-016</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_12
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-017" markdown>
+<div class="eudi-hlr__id">AS-WP-34-017</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_13
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-018" markdown>
+<div class="eudi-hlr__id">AS-WP-34-018</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_14
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-019" markdown>
+<div class="eudi-hlr__id">AS-WP-34-019</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_15
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-34-020" markdown>
+<div class="eudi-hlr__id">AS-WP-34-020</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Mig_16
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-38-001" markdown>
+<div class="eudi-hlr__id">AS-WP-38-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_01
+{: .eudi-hlr__meta }
+
+To enable a PID Provider or an Attestation Provider to verify the authenticity and the revocation status of a Wallet Unit it is interacting with, a Wallet Provider SHALL issue one or more Key Attestations (KA) and Wallet Instance Attestations (WIA) to the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation).
+
+*Note: The first of these KAs and WIAs will be issued during the activation phase of a Wallet Unit. During the lifetime of the Wallet Unit, the Wallet Provider will re-issue KAs and WIAs as needed.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-38-002" markdown>
+<div class="eudi-hlr__id">AS-WP-38-002</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_02
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-005" markdown>
+<div class="eudi-hlr__id">EW-DM-38-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_07
+{: .eudi-hlr__meta }
+
+To revoke the Wallet Instance of a Wallet Unit, a Wallet Provider SHALL, in the status list(s) for Wallet Instances, set the `revoked` status at all index positions mentioned in the WIAs issued to that Wallet Instance.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-007" markdown>
+<div class="eudi-hlr__id">EW-DM-38-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_09
+{: .eudi-hlr__meta }
+
+During the lifetime of a Wallet Unit, the Wallet Provider SHALL regularly verify that the security of the Wallet Unit is not breached or compromised. If the Wallet Provider detects a security breach or compromise, the Wallet Provider SHALL analyse its cause(s) and impact(s). If the breach or compromise affects the trustworthiness or reliability of the Wallet Unit, the Wallet Provider SHALL revoke the Wallet Unit by revoking the Wallet Instance according to WURevocation_07. The Wallet Provider SHALL do so at least in the following circumstances: - If the security of the Wallet Unit, or the security of the mobile device and OS on which the corresponding Wallet Instance is installed,  or the security of the WSCA/WSCD it uses for managing critical cryptographic assets, is breached or compromised in a manner that affects its trustworthiness or reliability. - If the security of the Wallet Solution is breached or compromised in a manner that affects the trustworthiness or reliability of all corresponding Wallet Units. - If the security of the common authentication and data protection mechanisms used by the Wallet Unit is breached or compromised in a manner that affects their trustworthiness or reliability. - If the security of the electronic identification scheme under which the Wallet Unit is provided is breached or compromised in a manner that affects its trustworthiness or reliability.
+
+*Note: The first bullet corresponds to a Critical or High Risk level security posture risk status according to the table in [Section 6.5.4.2 of the ARF main document](../../architecture-and-reference-framework-main.md#6542-wallet-unit-revocation), as analysed or detected for a Wallet Instance due to monitoring done according to WPSM_03.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-008" markdown>
+<div class="eudi-hlr__id">EW-DM-38-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_09a
+{: .eudi-hlr__meta }
+
+If  a breach or compromise detected per WURevocation_09 affects the trustworthiness or reliability of a (type of) WSCA/WSCD or keystore, the Wallet Provider SHALL revoke the corresponding (type of) WSCA/WSCD or keystore according to WURevocation_07a; see also WUA_28 and VCR_07e.
+
+*Note: Per WURevocation_09, a compromise of a type of WSCA/WSCD always leads to the revocation of both that type of WSCA/WSCD and of all Wallet Instances using a WSCA/WSCD of that type.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-009" markdown>
+<div class="eudi-hlr__id">EW-DM-38-009</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_09b
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-010" markdown>
+<div class="eudi-hlr__id">EW-DM-38-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_09c
+{: .eudi-hlr__meta }
+
+If a Wallet Provider revokes a keystore of a Wallet Unit, it SHOULD also revoke the entire Wallet Unit by revoking the Wallet Instance. If the Wallet Provider decides to not revoke the Wallet Instance, it SHALL create a risk analysis showing that this does not lead to unacceptable risks to the User, PID Providers and Attestation Providers, Relying Parties, or the Wallet Provider itself.
+
+*Note: If the Wallet Provider does not revoke the Wallet Instance, only the attestations bound to the revoked keystore will be impacted. Other functionalities of the Wallet Unit, including the presentation of a PID, will remain available to the User.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-011" markdown>
+<div class="eudi-hlr__id">EW-DM-38-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_10
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL revoke a Wallet Unit upon the explicit request of the User registered during the Wallet Unit activation process, see [Topic 40](./annex-2.02-high-level-requirements-by-topic.md#a2323-topic-40-wallet-instance-installation-and-wallet-unit-activation-and-management). To do so, the Wallet Provider SHALL revoke the Wallet Instance (see WURevocation_07). The Wallet Provider SHALL authenticate the User before accepting a request to revoke the Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-012" markdown>
+<div class="eudi-hlr__id">EW-DM-38-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_11
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL revoke a Wallet Unit upon the explicit request of a PID Provider, in case the natural person using the Wallet Unit has died. To do so, the Wallet Provider SHALL revoke the Wallet Instance (see WURevocation_07). To identify the Wallet Unit that is to be revoked, the PID Provider SHALL use a Wallet Instance identifier provided by the Wallet Provider in the WIA during PID issuance.
+
+*Note: Under [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md), the Wallet Instance identifier used for revocation is conveyed in the WIA (see WUA_08). See also the notes to WUA_08.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-013" markdown>
+<div class="eudi-hlr__id">EW-DM-38-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_12
+{: .eudi-hlr__meta }
+
+Before revoking a Wallet Unit per WURevocation_11, the Wallet Provider SHALL verify that the party requesting revocation is indeed a valid PID Provider listed in the LoTE of PID Providers.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-014" markdown>
+<div class="eudi-hlr__id">EW-DM-38-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_13
+{: .eudi-hlr__meta }
+
+Before requesting a Wallet Provider to revoke a Wallet Unit per WURevocation_11, the PID Provider SHALL ensure that the revocation does not harm the interests of any of the stakeholders. The PID Provider SHALL include a documented policy ensuring that this is the case in the policy meant in WURevocation_03.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-015" markdown>
+<div class="eudi-hlr__id">EW-DM-38-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_14
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL inform a User without delay, and within 24 hours at most, in case the Wallet Provider decided to revoke the User's Wallet Unit. The Wallet Provider SHALL also inform the User about the reason(s) for the revocation. This information SHALL be understandable for the general public. It SHALL include (a reference to) technical details about any security breach if applicable. The Wallet Provider SHALL inform the User about the function(s) of the Wallet Unit that remain available to the User, if any, and functions that will not work any more. The Wallet Provider SHALL also inform the User about measures they can take to ensure they have a fully working Wallet Unit again as soon as possible, such as migrating to a different Wallet Solution.
+
+*Note: Functions that remain available to the User may include viewing their own attributes in their Wallet Unit and accessing their account at the Wallet Provider.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-017" markdown>
+<div class="eudi-hlr__id">EW-DM-38-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_16
+{: .eudi-hlr__meta }
+
+To inform a User about the revocation of their Wallet Unit, the Wallet Provider SHALL use a communication channel that is independent of the Wallet Unit. In addition, the Wallet Provider MAY use the Wallet Unit itself to inform the User.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-38-018" markdown>
+<div class="eudi-hlr__id">AS-WP-38-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_18
+{: .eudi-hlr__meta }
+
+A PID Provider issuing revocable PIDs SHALL, for each of its valid PIDs, regularly verify whether the Wallet Instance on which that PID is residing has been revoked and whether the associated WSCD  has been revoked, using the WIA and KA received during issuance of that PID. If either the Wallet Instance or the WSCD has been revoked, the PID Provider SHALL immediately revoke the respective PID.
+
+*Note: a) This requirement aligns with WUA_29, which requires PID Providers to check the revocation status of both the WIA and KA throughout the PID validity period. b) This is a consequence of the legal requirement in [CIR 2024/2977], Article 5, 4.(b). c) See [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) for how the PID Provider can do this verification.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-38-019" markdown>
+<div class="eudi-hlr__id">AS-WP-38-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_19
+{: .eudi-hlr__meta }
+
+An Attestation Provider issuing revocable attestations MAY decide to revoke an attestation if the Wallet Provider revoked the Wallet Unit on which that attestation is residing, in the same manner as described in WURevocation_18. An Attestation Provider SHALL publish its policy in this regard.
+
+*Note: Publishing its policy regarding revocation allows a Relying Party to decide if it can put sufficient trust in the attestations issued by that Attestation Provider.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-001" markdown>
+<div class="eudi-hlr__id">AS-WP-40-001<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_01
+{: .eudi-hlr__meta }
+
+To ensure that the User can trust the Wallet Solution, a Wallet Provider SHOULD make its certified Wallet Solution available for installation only via the official app store of the relevant operating system (e.g., Android, iOS).
+
+*Note: This allows the operating system of the device to perform relevant checks regarding the authenticity of the Wallet Unit.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-002" markdown>
+<div class="eudi-hlr__id">AS-WP-40-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_02
+{: .eudi-hlr__meta }
+
+If a Wallet Provider makes its certified Wallet Solution available for installation through other means than the official OS app store, it SHALL implement a mechanism allowing the User to verify the authenticity of the Wallet Unit. Moreover, it SHALL provide clear instructions to the User on how to install the Wallet Instance, including at least: - instructions on the verification of the authenticity of the Wallet Instance to be installed, - instructions on bypassing of any operating system limitations on side-loading of apps, if applicable, and ensuring that these limitations are restored after the Wallet Instance has been installed.
+
+*Note: This requirement also applies for the installation of a Wallet Instance on a User device that is not a mobile device, and for which no official operating system app store may exist.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-003" markdown>
+<div class="eudi-hlr__id">AS-WP-40-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_03
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL ensure that a Wallet Instance starts a process to activate the new Wallet Unit with the Wallet Provider immediately after installation or when the User first opens the Wallet Instance. The Wallet Provider SHALL ensure that the Wallet Instance starts this process only with a secure backend of the Wallet Provider.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-004" markdown>
+<div class="eudi-hlr__id">AS-WP-40-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_04
+{: .eudi-hlr__meta }
+
+During the activation process of a new Wallet Unit, the Wallet Provider SHALL verify that the new Wallet Instance is a genuine instance of its Wallet Solution.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-005" markdown>
+<div class="eudi-hlr__id">AS-WP-40-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_05
+{: .eudi-hlr__meta }
+
+During the activation process of a new Wallet Unit, the Wallet Provider SHALL process information about the User device and the available WSCA/WSCD and keystore(s), as far as necessary to issue Key Attestations and Wallet Instance Attestations to the Wallet Unit conform all requirements in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation). The Wallet Provider MAY process additional information necessary for managing the Wallet Unit, but it SHALL NOT process more information than it reasonably needs for legitimate purposes. The Wallet Provider SHALL request User consent (through the Wallet Instance) for all information and data it will process, both during activation and throughout the lifetime of the Wallet Unit. The Wallet Provider SHALL inform the User about the purposes of data processing, in accordance with the General Data Protection Regulation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-006" markdown>
+<div class="eudi-hlr__id">AS-WP-40-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_06
+{: .eudi-hlr__meta }
+
+The Wallet Provider SHALL request the User, through the new Wallet Instance, to set up a User account at the Wallet Provider, or to log in to an existing account. The Wallet Provider SHALL explain to the User that this is necessary to enable the User to request revocation of the Wallet Unit in case of theft or loss. The Wallet Provider SHALL register one or more User authentication methods that the Wallet Provider will use to authenticate the User in the future. These methods SHALL be independent of the Wallet Unit and the User device. The Wallet Provider SHALL allow the User to register using an alias instead of true identity data. The Wallet Provider SHALL NOT use any registered User data for purposes other than User authentication, unless the User gives explicit consent to do so. The Wallet Provider SHALL register the relationship between the Wallet Unit and the corresponding User account.
+
+*Note: The User may already have an account at the Wallet Provider, for example because they use a Wallet Unit of this Wallet Provider already on another device, or if they are migrating to a new device.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-007" markdown>
+<div class="eudi-hlr__id">AS-WP-40-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_07
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL activate a new Wallet Unit before a User can use it to have issued an PID or attestation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-008" markdown>
+<div class="eudi-hlr__id">AS-WP-40-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_08
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL only activate a new Wallet Unit if it has verified that the Wallet Unit includes a WSCA/WSCD that is certified to be compliant with applicable requirements for Level of Assurance High.
+
+*Note: a) A WSCA/WSCD by definition complies with requirements for Level of Assurance High, see WIAM_14. b) In addition, the Wallet Unit can include one or more keystores.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-009" markdown>
+<div class="eudi-hlr__id">AS-WP-40-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_08a
+{: .eudi-hlr__meta }
+
+If a Wallet Unit contains one or more keystores, the Wallet Provider SHALL assign a security level to every keystore, with the following possible values: `iso_18045_high`, `iso_18045_moderate`, `iso_18045_enhanced-basic`, `iso_18045_basic` or `none`, corresponding to the level of resistance for which the keystore was certified (respectively AVA_VAN.5, AVA_VAN.4, AVA_VAN.3, AVA_VAN.2 and no certification).
+
+*Note: For the definition of these security levels, also see [OpenID4VC]I Annex D.2*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-010" markdown>
+<div class="eudi-hlr__id">AS-WP-40-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_09
+{: .eudi-hlr__meta }
+
+If a WSCA/WSCD or keystore contains cryptographic assets related to multiple Wallet Units, the Wallet Provider SHALL ensure that a Wallet Unit can only access assets that are related to that Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-011" markdown>
+<div class="eudi-hlr__id">AS-WP-40-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_10
+{: .eudi-hlr__meta }
+
+During the activation process of a new Wallet Unit, a Wallet Provider SHALL create and sign at least one Key Attestation for the WSCA/WSCD, at least one Key Attestation for each keystore, and at least one Wallet Instance Attestation, and issue them to the Wallet Unit. The Wallet Provider SHALL verify that the private key(s) corresponding to the public key(s) in each KA are protected by the respective WSCA/WSCD or keystore, under control of the User. The Wallet Provider SHALL take measures to verify the integrity of the Wallet Instance before issuing a Wallet Instance Attestation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-012" markdown>
+<div class="eudi-hlr__id">AS-WP-40-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_10a
+{: .eudi-hlr__meta }
+
+During the activation process of a new Wallet Unit, the Wallet Provider SHALL offer the User a means to verify the formal certification information of their Wallet Solution.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-013" markdown>
+<div class="eudi-hlr__id">AS-WP-40-013</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_11
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-014" markdown>
+<div class="eudi-hlr__id">AS-WP-40-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_12
+{: .eudi-hlr__meta }
+
+All communication between the Wallet Provider and the Wallet Instance SHALL be mutually authenticated and SHOULD be encrypted.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-015" markdown>
+<div class="eudi-hlr__id">AS-WP-40-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_12a
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL NOT access the contents of a Wallet Instance, in particular to learn a) which attestations are present on the Wallet Unit, b) the status of these attestations, c) the value of attributes in these attestations, and d) the contents of the Wallet Unit log meant in DASH_02.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-016" markdown>
+<div class="eudi-hlr__id">AS-WP-40-016<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_12b
+{: .eudi-hlr__meta }
+
+If the contents of a Wallet Unit specified in WIAM_12a are stored in a Wallet Instance on the User's device, the Wallet Instance SHALL ensure that the Wallet Provider cannot access the contents of the Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-017" markdown>
+<div class="eudi-hlr__id">AS-WP-40-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_12c
+{: .eudi-hlr__meta }
+
+If the contents of a Wallet Unit specified in WIAM_12a are stored in a Wallet Unit Service on the Wallet Provider backend, the Wallet Provider SHALL specify and implement strict controls to limit access by the Wallet Provider to the contents of the Wallet Unit.
+
+*Note: In this situation, the Wallet Unit cannot fully prevent the Wallet Provider from accessing the Wallet Unit contents.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-018" markdown>
+<div class="eudi-hlr__id">AS-WP-40-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_13
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL enable the User to 'factory reset' the Wallet Unit, which SHALL cause the deletion of all attestations, the log, and all other personal data, settings, and configurations from the Wallet Unit. If the User resets the Wallet Unit, the Wallet Instance SHALL request the associated WSCA/WSCD and keystore(s) to delete all cryptographic assets related to the Wallet Unit and to all PIDs and device-bound attestations on the Wallet Unit, if the WSCA/WSCD and the keystore(s) are connected to the User device.
+
+*Note:  a) The User can use this option, for instance, in preparation to the planned uninstallation of the Wallet Instance. b) Deletion of PID or KA cryptographic assets requires User authentication, as specified in requirement WIAM_14. c) The Wallet Unit does not necessarily inform the Wallet Provider about the factory reset. d) It may happen there is no connection to the WSCA/WSCD or to a keystore at the moment the User resets the Wallet Instance. For instance, in case the WSCA/WSCD is an external smart card and the User does not present that card to the User device. Another example occurs when the WSCA/WSCD is a remote HSM and the User device is offline at that moment. In such cases, the cryptographic assets will remain present on the WSCA/WSCD or on the keystore, even though they will never be used again. If needed, it is up to the Wallet Provider to define how the Wallet Unit should handle such situations. For example, an HSM manager could address such cases by deciding to delete cryptographic keys in the HSM that are too old or haven't been used for too long, while being aware of the risks in doing so.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-019" markdown>
+<div class="eudi-hlr__id">AS-WP-40-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_13a
+{: .eudi-hlr__meta }
+
+If a Wallet Unit supports the [W3C Digital Credentials API] and the User resets the Wallet Unit, the Wallet Unit SHALL disclose the fact that it no longer stores any previously disclosed PID(s) or attestation(s) to the Digital Credentials API framework.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-020" markdown>
+<div class="eudi-hlr__id">AS-WP-40-020<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_14
+{: .eudi-hlr__meta }
+
+A WSCA/WSCD managing the critical assets of a PID, such as private or secret cryptographic keys, SHALL authenticate the User at Level of Assurance High before performing any cryptographic operation involving any of these assets.
+
+*Note: a) [CIR 2024/2981], Annex IV, section 2 (3) states "As a prerequisite to the certification under national certification schemes, the WSCD shall be assessed against the requirements of assurance level high as set out in Implementing Regulation (EU) 2015/1502." Therefore, a WSCA/WSCD by legal definition complies with requirements of LoA High. b) Note to WIAM_14 - WIAM_14b: Many actions of the Wallet Unit, such as processing a Relying Party presentation request and presenting an attestation, require multiple cryptographic operations, for example ephemeral key generation followed by key agreement and presentation signing and encryption. These requirements does not imply that a separate User authentication is necessary before each of these operations. Rather, a successful User authentication will be valid for all cryptographic operations necessary for a Wallet Unit action. It is up to the Wallet Provider to determine what constitutes a 'Wallet Unit action', finding a balance between security (more User authentications) and User convenience (fewer User authentications). During certification of the Wallet Solution, it will be verified that the solution provides an adequate level of security.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-021" markdown>
+<div class="eudi-hlr__id">AS-WP-40-021<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_14a
+{: .eudi-hlr__meta }
+
+A WSCA/WSCD managing the critical assets of a KA SHALL authenticate the User at Level of Assurance High before performing any cryptographic operation involving any of these assets.
+
+*Note: The WSCA/WSCD manages the private key(s) corresponding to the public key(s) attested in the KA.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-022" markdown>
+<div class="eudi-hlr__id">AS-WP-40-022<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_14b
+{: .eudi-hlr__meta }
+
+A WSCA/WSCD managing the cryptographic assets of an attestation having a level of security High SHALL authenticate the User at level of security High before performing any cryptographic operation involving any of these assets.
+
+*Note: a) The term 'Level of Assurance', as used in the European Digital Identity Regulation and in Implementing Regulation (EU) 2015/1502, is only applicable to electronic identity means, which in the context of the EUDI Wallet means only the PID. For that reason, this requirement uses the term 'level of security'. Levels of security are defined in standards or specifications different from CIR 2024/1502, for instance ISO/IEC 18045. b) During issuance of an attestation, the Attestation Provider in its Credential Issuer metadata indicates the level of security it requires for the key storage and user authentication for this type of attestation. See [OpenID4VCI] section 12.2.4 and Appendix D.2.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-023" markdown>
+<div class="eudi-hlr__id">AS-WP-40-023<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_14c
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL use either the WSCA/WSCD or a keystore to manage any cryptographic assets that are not considered to be critical assets.
+
+*Note: a) The ARF uses the term 'keystore' to refer to a hardware-backed repository and service in which non-critical cryptographic assets are generated, stored, and used exclusively inside a dedicated hardware security boundary. b) Examples of non-critical cryptographic assets are private and secret keys of attestations having a level of security lower than High. c) As mentioned in WIAM_14 and WIAM_14b, the private and secret keys of PIDs and KAs are critical assets and therefore are stored in a WSCA/WSCD.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-024" markdown>
+<div class="eudi-hlr__id">AS-WP-40-024<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_15
+{: .eudi-hlr__meta }
+
+Before performing any operation, including allowing a User to view attestations and attribute values, a Wallet Instance SHALL securely authenticate the User using a multi-factor authentication mechanism provided by the User device.
+
+*Note: a) One of the authentication factors is the possession of the User device.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-025" markdown>
+<div class="eudi-hlr__id">AS-WP-40-025<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_15a
+{: .eudi-hlr__meta }
+
+For the purpose of WIAM_15, the Wallet Instance SHALL enforce the activation of an OS-level User authentication mechanism with adequate security policies.
+
+*Note: Adequate' here means adequate for any operation excluding the issuance or presentation of PIDs, KAs, and potentially other attestations at level of security High. This includes but is not limited to generating pseudonyms, accessing the transaction log (dashboard), data export and migration, requesting the erasure of personal data by a Relying Party, and reporting a Relying Party to a DPA.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-026" markdown>
+<div class="eudi-hlr__id">AS-WP-40-026<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_15b
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL enable the User to use a Wallet Unit-specific authentication method for User authentication, in addition to the User authentication mechanism provided by the User device per WIAM_15. The Wallet Provider SHALL either make the use of this additional authentication method mandatory for all Users, or leave it to each User to decide if they want to use it.
+
+*Note: a) This authentication method may be implemented by the Wallet Instance, a (local) keystore, the WSCA/WSCD, or any other component of the Wallet Unit. b) As an optimisation to reduce the number of User authentication events, the Wallet Provider can choose to implement this additional authentication method in the WSCA/WSCD, in such a way that it complies with WIAM_14.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-027" markdown>
+<div class="eudi-hlr__id">AS-WP-40-027<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_15c
+{: .eudi-hlr__meta }
+
+The Wallet Instance SHALL also use the User authentication mechanism provided by the User device (WIAM_15) and possibly the Wallet Unit-specific authentication method (WIAM_15b) to unlock the keystore mentioned in WIAM_14c, where applicable.
+
+*Note: Apart from using the same mechanism, the intent of this requirement is also to minimize the number of User authentications needed (after the initial authentication per WIAM_15a) to enable the issuance or presentation of (non-PID) attestations. However, see WIAM_16 and WIAM_16a; the Wallet Provider may request another authentication if this is necessary for security.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-028" markdown>
+<div class="eudi-hlr__id">AS-WP-40-028<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_16
+{: .eudi-hlr__meta }
+
+For the User authentication mechanism provided by the User device (WIAM_15), the Wallet Instance SHALL force the User device to enable a time-based control (e.g., a session timeout or re-authentication interval), to ensure that access is automatically revoked after a defined period of inactivity.
+
+*Note: It is assumed that re-authentication is required by the User device when the device is locked by the User.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-029" markdown>
+<div class="eudi-hlr__id">AS-WP-40-029<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_16a
+{: .eudi-hlr__meta }
+
+For the Wallet Unit-specific User authentication method (WIAM_15b), the Wallet Provider SHALL define and implement conditions after which user authentication shall again be required, including at least an idle timeout. The Wallet Unit SHOULD provide the User with the option to set the idle timeout to a duration shorter than the default timeout set by the Wallet Provider. The Wallet Provider SHOULD also consider other factors, including the device being locked by the User and the Wallet Instance losing focus.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-030" markdown>
+<div class="eudi-hlr__id">AS-WP-40-030<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_17
+{: .eudi-hlr__meta }
+
+The Wallet Provider SHALL ensure that the Wallet Unit requests the User, during  activation of the Wallet Unit, to set up the authentication factors for the User authentication mechanism implemented by the WSCA/WSCD meant in WIAM_14, the  authentication mechanism implemented by the User device meant in WIAM_15 and WIAM_15a,  and, if used,  the  Wallet Unit-specific authentication method meant in WIAM_15b.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-031" markdown>
+<div class="eudi-hlr__id">AS-WP-40-031</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_18
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-032" markdown>
+<div class="eudi-hlr__id">AS-WP-40-032<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_19
+{: .eudi-hlr__meta }
+
+A WSCA/WSCD and a keystore SHALL be able to prove possession of the private key corresponding to a public key on request of a Wallet Instance, for example by signing a challenge with that private key.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-033" markdown>
+<div class="eudi-hlr__id">AS-WP-40-033<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_20
+{: .eudi-hlr__meta }
+
+A WSCA/WSCD SHALL protect a private key it generated during the entire lifetime of the key. This protection SHALL at least imply that the WSCA/WSCD prevents the private key from being extracted in the clear. If a WSCA/WSCD is able to export a private key in encrypted format, the resulting level of protection SHALL be equivalent to the protection level of the private key when stored in the WSCA/WSCD.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-40-034" markdown>
+<div class="eudi-hlr__id">AS-WP-40-034<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WIAM_21
+{: .eudi-hlr__meta }
+
+Whenever the WSCA/WSCD successfully authenticated the User, the Wallet Unit SHOULD check if the WSCD contains cryptographic assets for technical PIDs or attestations that cannot be presented any longer to Relying Parties, for example because they have expired or because a once-only attestation (see [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), section D, method A) was presented to a Relying Party already. The Wallet Unit SHOULD then request the WSCA/WSCD to destroy all cryptographic assets related to these technical PIDs or attestations. However, the Wallet Unit SHOULD NOT request the destruction of the private key belonging to the last technical PID or attestation corresponding to a logical PID or attestation.
+
+*Note: a) The reason for this recommendation is that probably, Wallet Providers will want to prevent an accumulation of unused private keys in the WSCA/WSCD, given that such devices typically do not have much storage space. However, deletion of private keys (and potentially other cryptographic assets) is a cryptographic key operation and cannot be done without User authentication - see WIAM_14. At the same time, for usability reasons the User must not be involved in such 'cleaning up' processes, see also ISSU_42. The recommended solution is to take advantage of a User authentication event to also carry out any necessary cleaning operations.  b) Method A (once-only attestations, see ISSU_ 37) includes a potential fallback to Method B (limited-time attestations) in case no unused technical PIDs or attestations are left. To ensure that falling back to Method B is always possible when needed, a Wallet Unit should ensure that for every logical PID or attestation it has, it is always in possession of at least one technical PID or attestation.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-43-001" markdown>
+<div class="eudi-hlr__id">AS-WP-43-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: EDP_01
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL enable an Attestation Provider to optionally express an embedded disclosure policy for a QEAA, PuB-EAA, or non-qualified EAA.
+
+*Note: The [European Digital Identity Regulation] does not contain a requirement for PIDs to be able to contain an embedded disclosure policy.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-43-002" markdown>
+<div class="eudi-hlr__id">AS-WP-43-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: EDP_02
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL support embedded disclosure policies implementing the 'Authorised relying parties only policy' described in Annex III of Implementing Regulation (EU) 2024/2979. If present, such an embedded disclosure policy SHALL contain a list of EU-wide unique identifiers of Relying Parties, as specified in Reg_32. The Wallet Unit SHALL retrieve the Relying Party identifier from the access certificate presented by the Relying Party, and compare it to the list of authorised identifiers in the policy, unless the Relying Party is an intermediary. If the Relying Party is an intermediary, the Wallet Unit SHALL retrieve the unique identifier of the intermediated Relying Party from the presentation request or from the registration certificate of the intermediated Relying Party and compare this identifier to the list of authorised identifiers in the policy.
+
+*Note: See RPI_07 for how the Wallet Unit can see if the Relying Party is an intermediary.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-43-003" markdown>
+<div class="eudi-hlr__id">AS-WP-43-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: EDP_03
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL support embedded disclosure policies implementing the 'Specific root of trust' policy described in Annex III of Implementing Regulation (EU) 2024/2979. If present, such an embedded disclosure policy SHALL contain a list of root or intermediate certificates used for signing Relying Party access certificates. The Wallet Unit SHALL compare the certificate chain that was used to sign the access certificate provided by the Relying Party to the list of authorised root or intermediate certificates in the policy, unless the Relying Party is an intermediary. If the Relying Party is an intermediary, the Wallet Unit SHALL retrieve the root certificate of the Provider of registration certificates of the intermediated Relying Party from the presentation request or from the Registrar's online service (as applicable) and compare this certificate to the list of authorised certificates in the policy.
+
+*Note: See RPI_07 for how the Wallet Unit can see if the Relying Party is an intermediary.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-43-004" markdown>
+<div class="eudi-hlr__id">AS-WP-43-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: EDP_05
+{: .eudi-hlr__meta }
+
+An embedded disclosure policy SHOULD contain a link to a website of the Attestation Provider explaining the disclosure policy in layman's terms. If this is the case, the Wallet Unit SHALL display the link to the User and allow them to navigate to that website.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-43-005" markdown>
+<div class="eudi-hlr__id">AS-WP-43-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: EDP_06
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL evaluate an embedded disclosure policy in conjunction with the information received from the requesting Relying Party, in order to determine if the Relying Party has permission from the Attestation Provider to access the requested attestation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-43-006" markdown>
+<div class="eudi-hlr__id">AS-WP-43-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: EDP_07
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL enable the User, based on the outcome of the evaluation of the applicable embedded disclosure policy(s), to deny or allow the presentation of the requested attestation to the Relying Party.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-43-007" markdown>
+<div class="eudi-hlr__id">AS-WP-43-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: EDP_08
+{: .eudi-hlr__meta }
+
+The Commission SHALL take measures to ensure a technical specification is created establishing common mechanisms for the specification of embedded disclosure policies by Attestation Providers, and for the evaluation of such policies by Wallet Units.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-43-008" markdown>
+<div class="eudi-hlr__id">AS-WP-43-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: EDP_10
+{: .eudi-hlr__meta }
+
+During attestation issuance, a Wallet Unit SHALL retrieve and store the corresponding embedded disclosure policy, if any.
+
+*Note: The intent of this requirement is that the Wallet Unit is able to evaluate an EDP during a presentation transaction, without needing to request it again from the Attestation Provider. This is necessary in particular during proximity presentations, which must be able to be done without an internet connection.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-48-001" markdown>
+<div class="eudi-hlr__id">AS-WP-48-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DATA_DLT_01
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL support the possibilities mentioned in DATA_DLT_02, allowing a User to request from a Relying Party the erasure of their attributes that were presented by that Wallet Unit to that Relying Party, in accordance with Article 17 of Regulation (EU) 2016/679.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-48-002" markdown>
+<div class="eudi-hlr__id">AS-WP-48-002</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DATA_DLT_04
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-48-003" markdown>
+<div class="eudi-hlr__id">AS-WP-48-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DATA_DLT_05
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL include the initiation of a data deletion request in a log, so it can be displayed to the User via the dashboard as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+*Note: Because the request is sent by an external web browser, e-mail client, or phone client (see DATA_DLT_02), the Wallet Unit can only log the initiation of the request.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-48-004" markdown>
+<div class="eudi-hlr__id">AS-WP-48-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DATA_DLT_08
+{: .eudi-hlr__meta }
+
+Wallet Units, Relying Parties, and Registrars SHALL comply with the relevant requirements in [Technical Specification 7](../../technical-specifications/ts7-common-interface-for-data-deletion-request.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-50-001" markdown>
+<div class="eudi-hlr__id">AS-WP-50-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPT_DPA_01
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL enable the User to start the process of reporting a suspicious presentation request to a DPA. When prompted by the User, a Wallet Unit SHALL provide the contact details of the DPA which supervises the Relying Party that made the suspicious request, if available in the log for that request (see DASH_03). If the contact details of the supervising DPA are not available in the log, the Wallet Unit SHALL provide the contact details of the DPA of the region in which the Wallet Provider is residing. In addition, the Wallet Unit MAY also provide the contact details of other DPAs, taken from the European Data Protection Board website (<https://www.edpb.europa.eu/about-edpb/about-edpb/members_en>).
+
+*Note: The DPA contact details may be unavailable in the log if there was no registration certificate in the presentation request and the User did not request the Wallet Unit to obtain the information registered about the Relying Party from the Registrar. See RPRC_16 - RPRC_18 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-50-002" markdown>
+<div class="eudi-hlr__id">AS-WP-50-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPT_DPA_02
+{: .eudi-hlr__meta }
+
+The Wallet Unit SHALL offer the User the option to report a suspicious request to a DPA via the transaction log presented in the dashboard, see [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-50-003" markdown>
+<div class="eudi-hlr__id">AS-WP-50-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPT_DPA_02a
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL support at least the following possibilities to report a suspicious presentation request to a DPA, depending on what contact details are available for the DPA: a) Open a URL in an external browser to report the request in a web form provided by the DPA. b) Open an external e-mail client and start a draft e-mail to the DPA, with a suitable template text, c) open an external phone client and start a phone call.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-50-004" markdown>
+<div class="eudi-hlr__id">AS-WP-50-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPT_DPA_04
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL ensure that a Wallet Unit allows its User to substantiate a report sent to a DPA, including by attaching relevant information to identify the Relying Party and the Users' claims in a machine-readable format.
+
+*Note: The log kept by the Wallet Unit is standardised in [Technical Standard 10](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts10-data-portability-and-download-(export).md) and is machine-readable in order to enable data portability. An excerpt from this log therefore can be used to substantiate the report.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-50-005" markdown>
+<div class="eudi-hlr__id">AS-WP-50-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPT_DPA_05
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL log the fact that it initiated the sending of a report to a DPA (see RPT_DPA_02a), as specified in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-50-006" markdown>
+<div class="eudi-hlr__id">AS-WP-50-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPT_DPA_06
+{: .eudi-hlr__meta }
+
+Wallet Units, Data Protection Authorities, and Registrars SHALL comply with the relevant requirements in [Technical Specification 8](../../technical-specifications/ts8-common-interface-for-reporting-of-wrp-to-dpa.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-51-001" markdown>
+<div class="eudi-hlr__id">AS-WP-51-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PAD_01
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL at any time enable the User to delete any PID or attestation from their Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-51-002" markdown>
+<div class="eudi-hlr__id">AS-WP-51-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PAD_02
+{: .eudi-hlr__meta }
+
+If the User indicates that a logical PID or attestation must be deleted, and the Wallet Unit contains multiple physical PIDs or attestations corresponding to that logical PID or attestation, a Wallet Unit SHALL delete all of these physical PIDs and attestations simultaneously.
+
+*Note: a) This situation may occur if the PID Provider or Attestation Provider issued a batch of physical PIDs or attestations to the Wallet Unit, rather than a single one. b) Physical PIDs or attestations correspond to a logical one if they have not only the same attestation type and Provider, but also the same attribute values. In principle, the same Provider can issue two attestations of the same type to the same Wallet Unit, for example two diplomas from the same university. This corresponds to the notion of a Credential Dataset in OpenID4VCI.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-51-003" markdown>
+<div class="eudi-hlr__id">AS-WP-51-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PAD_03
+{: .eudi-hlr__meta }
+
+If the Wallet Unit deletes a PID or attestation on the User's request, the Wallet Unit SHALL NOT notify the respective PID Provider or Attestation Provider.
+
+*Note: This is a matter of User privacy.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-51-004" markdown>
+<div class="eudi-hlr__id">AS-WP-51-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PAD_04
+{: .eudi-hlr__meta }
+
+If the Wallet Unit deletes a PID or device-bound attestation on the User's request, the Wallet Unit SHALL ensure that all cryptographic assets in the WSCA/WSCD or keystores related to this PID or attestation are securely destroyed.
+
+*Note: Key deletion for a PID key is a cryptographic key operation and requires User authentication, as specified in requirement WIAM_14.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-51-005" markdown>
+<div class="eudi-hlr__id">AS-WP-51-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PAD_05
+{: .eudi-hlr__meta }
+
+If a Wallet Unit supports the [W3C Digital Credentials API] and it deletes, on the User's request, a PID or attestation previously disclosed to the Digital Credentials API framework, the Wallet Instance SHALL disclose the fact that it no longer stores this PID or attestation to the Digital Credentials API framework.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-51-006" markdown>
+<div class="eudi-hlr__id">AS-WP-51-006</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PAD_06
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-54-001" markdown>
+<div class="eudi-hlr__id">AS-WP-54-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ACC_01
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that their Wallet Units comply with applicable requirements and standards in [Directive 2016/2012 on the accessibility of websites and mobile applications of public sector bodies](http://data.europa.eu/eli/dir/2016/2102/oj).
+
+*Note: Compliance with the European Standard [ETSI EN 301 549 V1.1.2](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf) (2015-04) provides a presumption of conformity to the Accessibility Directive.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-54-002" markdown>
+<div class="eudi-hlr__id">AS-WP-54-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ACC_02
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that their Wallet Units comply with accessibility requirements for products and services established under [Directive (EU) 2019/882](http://data.europa.eu/eli/dir/2019/882/oj).
+
+*Note: Compliance with the European Standard [ETSI EN 301 549 V1.1.2](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf) (2015-04) potentially provides a presumption of conformity to this Directive.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-56-001" markdown>
+<div class="eudi-hlr__id">AS-WP-56-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WPSM_01
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL monitor their installed base of operational Wallet Instances for maintenance purposes, and determine and document in a transparent manner the data it needs and is allowed to monitor in order to deliver the required support. Data or attributes that SHOULD be monitored include: 1) Runtime errors, for uncaught errors in production code, 2) UX and telemetry information, for UX field analysis, 3) OS version and health information, for detection of OS level vulnerabilities, 4) Wallet Instance SDK and software library version information, for Wallet Instance code vulnerabilities, 5) User locale/localisation data, for catching localisation related errors, 6) Wallet Instance version, for catching errors or vulnerabilities due to outdated versions, 7) Supported WSCA/WSCDs and keystores and their supported capabilities, for detection of cryptography incompatibilities, 8) Unique device identifier such as IDFV or persisted UUID (iOS) or AndroidID (Android), for maintaining an up-to-date list of Wallet Instance-related device installations and for detecting potential malicious use (unrecognised identifier), 9) Device sensor identifiers and patch levels, for checking if sensor hardware in the device is up-to-date. 10) hardware-level details about the device, to identify known hardware-based problems or vulnerabilities, 11) BLE and NFC support by device, for analysing the security and feasibility of proximity use cases with a given Wallet Instance.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-56-002" markdown>
+<div class="eudi-hlr__id">AS-WP-56-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WPSM_02
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL, for maintenance purposes, write custom crash logs for sending them for further analysis.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-56-003" markdown>
+<div class="eudi-hlr__id">AS-WP-56-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WPSM_03
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL monitor the security posture of its operational Wallet Instances for the purpose of detecting critical security risks in the environment the Wallet Instance is run at, and determine and document in a transparent manner the data it needs and is allowed to monitor. Information that SHOULD be monitored for software and hardware level problems/vulnerabilities on device includes 1) detection of device rooting/jailbreaking, 2) emulator detection, 3) device OS version and health data, 4) Wallet Instance SDK and SW library versions, 5) Wallet Instance version, 6) Supported WSCA/WSCD and keystore(s) and 7) Sensor identifiers and patch levels.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-WP-56-004" markdown>
+<div class="eudi-hlr__id">AS-WP-56-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WPSM_04
+{: .eudi-hlr__meta }
+
+During the lifetime of the Wallet Unit, the Wallet Provider SHALL update the Wallet Unit as necessary to ensure its continued security and functionality.
+
+</div>
+</div>
+
 
 ---
 
@@ -337,85 +4010,1020 @@ as statements of fact.
 *infrastructure. They focus on establishing registries, notifying the*
 *Commission, and defining national policies.*
 
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
-|AS-MS-18-001 | ACP_02 | A Cryptographic Binding of Attestations scheme SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].|  |
-|AS-MS-25-001 | CAT_01 | Empty|  |
-|AS-MS-25-002 | CAT_01a | Empty|  |
-|AS-MS-25-003 | CAT_01b | Empty|  |
-|AS-MS-25-004 | CAT_02 | Empty|  |
-|AS-MS-25-005 | CAT_03 | Empty|  |
-|AS-MS-25-006 | CAT_03b | Empty|  |
-|AS-MS-25-007 | CAT_04 | A request to include or to modify an attribute in the catalogue of attributes SHALL indicate how a QTSP can use the verification point for that attribute.| This could be, for instance, in the form of (a reference to) an endpoint description text. |
-|AS-MS-27-001 | Reg_01 | Member States SHALL provide processes and mechanisms for PID Providers, QEAA Providers, PuB-EAA Providers, non-qualified EAA Providers, and Relying Parties to register in a registry.| Member States may choose to implement a single registry for all these roles, or a separate registry for each of these roles. |
-|AS-MS-27-002 | Reg_01a | Member States SHALL register a common set of data about a) PID Providers, b) QEAA Providers, c) PuB-EAA Providers, d) non-qualified EAA Providers. and e) Relying Parties, according to the relevant requirements in [Technical Specification 6](../../technical-specifications/ts6-common-set-of-rp-information-to-be-registered.md).| For PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers, the common set of data specified in [Technical Specification 6] include the attestation type(s) that the provider intends to issue to Wallet Units. |
-|AS-MS-27-003 | Reg_01b | Empty|  |
-|AS-MS-27-004 | Reg_02 | Member States SHALL make publicly available all necessary details and documentation about the registration processes for their registry.|  |
-|AS-MS-27-005 | Reg_03 | Member States SHALL publish the registry entries online, in a sealed or signed machine-readable common format suitable for automated processing, according to the relevant requirements in [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md), for the purpose of transparency to Users and other stakeholders.|  |
-|AS-MS-27-006 | Reg_04 | Member States SHALL make the registry entries available online, in a human-readable format. The website used for this purpose SHALL use a secure channel protecting the authenticity and integrity of the information in the registry during transport. Member States SHALL NOT require authentication or prior registration and authorisation of any person wishing to retrieve the information in the registry.|  |
-|AS-MS-27-007 | Reg_05 | Empty|  |
-|AS-MS-27-008 | Reg_06 | Member States SHALL support the common API specified in [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md) for to enable automated retrieval of registry entries from the Member States' registries.| [Technical Specification 5] specifies the use of a secure channel protecting the authenticity and integrity of the information in the registry during transport, and does not require authentication or prior registration and authorisation of any entity wishing to retrieve the information in the registry. |
-|AS-MS-27-009 | Reg_07 | A Member State SHALL enable a registered PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party to update the information registered on it, using a process comparable to the original registration process. For Relying Parties, this SHALL be possible using the API or user interface mentioned in Reg_24.|  |
-|AS-MS-27-010 | Reg_08 | A registered PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party SHALL make any updates necessary to ensure the continued correctness of the registered information without undue delay.|  |
-|AS-MS-27-011 | Reg_09 | Member States SHALL log all changes made on the information registered regarding a PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party, including at least initial registration, updates, deletion of information, and suspension or cancellation.|  |
-|AS-MS-27-012 | Reg_10 | A Member State SHALL ensure that an Access Certificate Authority notified according to [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)] issues an access certificate to all PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers registered in one of the Member State's registries.|  |
-|AS-MS-27-013 | Reg_10a | A Member State SHALL ensure that an Access Certificate Authority notified according to [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)] issues one or more access certificates to all Relying Parties registered in one of the Member State's registries. A Relying Party SHALL receive a separate access certificate for each of its Relying Party Instances.|  |
-|AS-MS-27-014 | Reg_11 | A Member State SHALL ensure that the issuance process of access certificates by their notified Access Certificate Authority(s) complies with [ETSI TS 119 411-8]. In addition, the Access Certificate Authority(s) SHALL comply with at least the normalised certificate policy (‘NCP’) requirements as specified in [ETSI EN 319 411-1].|  |
-|AS-MS-27-015 | Reg_12 | Empty|  |
-|AS-MS-27-016 | Reg_13 | Empty|  |
-|AS-MS-27-017 | Reg_14 | Empty|  |
-|AS-MS-27-018 | Reg_15 | Empty|  |
-|AS-MS-27-019 | Reg_16 | Empty|  |
-|AS-MS-27-020 | Reg_17 | Empty|  |
-|AS-MS-27-021 | Reg_18 | Empty|  |
-|AS-MS-27-022 | Reg_19 | A Member State SHALL approve a PID Provider according to a well-defined policy before including it in its PID Provider Registry. To that end, a Member State SHALL define specific vetting processes and rules of acceptance for inclusion of PID Providers in its Registry.|  |
-|AS-MS-27-023 | Reg_20 | A Member State SHALL identify PID Providers at a level of confidence proportionate to the risk arising from the potential harm a fraudulent PID Provider could cause to Users and other stakeholders in the EUDI Wallet ecosystem.|  |
-|AS-MS-27-024 | Reg_20a | A Registrar SHALL provide a method to suspend or cancel a registered PID Provider.|  |
-|AS-MS-27-025 | Reg_20b | A Registrar SHALL have a policy for the suspension or cancellation of a registered PID Provider, which SHALL specify that a PID Provider is suspended or cancelled at least on request of the PID Provider or of a competent national authority.|  |
-|AS-MS-27-026 | Reg_21 | A Member State SHALL approve an Attestation Provider according to a well-defined policy before including it in its Attestation Provider Registry. To that end, a Member State SHALL define specific vetting processes and rules of acceptance for inclusion of Attestation Providers in its Registry. These processes and rules SHOULD consider any relevant differences between QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers.|  |
-|AS-MS-27-027 | Reg_22 | A Member State SHALL identify Attestation Providers (i.e., QEAA Providers, PuB-EAA Providers and non-qualified EAA Providers) at a level of confidence proportionate to the risk arising from the potential harm a fraudulent Attestation Provider could cause to Users and other stakeholders in the EUDI Wallet ecosystem.|  |
-|AS-MS-27-028 | Reg_22a | A Registrar SHALL provide a method to suspend or cancel a registered Attestation Provider.|  |
-|AS-MS-27-029 | Reg_22b | A Registrar SHALL have a policy for the suspension or cancellation of a registered Attestation Provider, which SHALL specify that an Attestation Provider is suspended or cancelled at least on request of the Attestation Provider or of a competent national authority.|  |
-|AS-MS-27-030 | Reg_23 | Empty|  |
-|AS-MS-27-031 | Reg_24 | A Member State SHALL enable a Relying Party to register remotely, using an API or user interface.|  |
-|AS-MS-27-032 | Reg_25 | A Member State SHALL identify a Relying Party at a level of confidence proportionate to the risk arising from the potential harm a fraudulent Relying Party could cause to Users and other stakeholders in the EUDI Wallet ecosystem.|  |
-|AS-MS-27-033 | Reg_26 | With respect to Reg_25, a Member State SHALL consider whether a registering entity intends to act as an intermediary.| According to the [European Digital Identity Regulation], an intermediary is a Relying Party. |
-|AS-MS-27-034 | Reg_27 | Empty|  |
-|AS-MS-27-035 | Reg_28 | Empty|  |
-|AS-MS-27-036 | Reg_29 | A Member State SHALL have a policy for the cancellation of a registered Relying Party, which SHALL specify that a Relying Party is cancelled at least on request of the Relying Party or of a competent national authority.|  |
-|AS-MS-27-037 | Reg_30 | Empty|  |
-|AS-MS-27-038 | Reg_31 | An access certificate SHALL contain a name for the entity (i.e., the PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party), in a format suitable for presenting to a User. This name SHALL be identical to the name for the entity registered according to [Technical Specification 6] and included in the entity's registration certificate(s) (if present) according to RPRC_06.|  |
-|AS-MS-27-039 | Reg_32 | An access certificate SHALL contain an EU-wide unique identifier for the entity (i.e., the PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party), which SHALL be identical to the identifier for the entity registered according to [Technical Specification 6] and included in the entity's registration certificate(s) (if present) according to RPRC_07.|  |
-|AS-MS-27-040 | Reg_33 | Empty|  |
-|AS-MS-28-001 | LP_01 | Empty|  |
-|AS-MS-29-001 | RP_01 | Attestation Scheme Providers MAY create one or multiple Attestation Rulebooks for representation attestations issued to a natural person representing another natural person. Each Rulebook SHALL specify the unique attestation type of these representation attestations. The Rulebook SHALL also specify attributes used for defining a validity period, the nature of the representation, and the operations the representative is authorised to perform, thereby limiting the scope of its authorisation.|  |
-|AS-MS-31-001 | GenNot_01 | Member States SHALL notify all PID Providers, PuB-EAA Providers, Wallet Providers, Access Certificate Authorities, and Providers of registration certificates to the European Commission, using a common system provided by the Commission, complying with all relevant requirements in[Technical Specification 2](../../technical-specifications/ts2-notification-publication-provider-information.md).|  |
-|AS-MS-31-002 | GenNot_02 | In addition to [Technical Specification 2] referred to in GenNot_01, the European Commission SHALL establish standard operating procedures for the notification of a PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority, or Provider of registration certificates to the Commission.| The outcome of the notification procedure is the publication of the information notified by the Member State according to [Article 5a](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e1347-1-1) (18) in a machine and human readable manner using the common system mentioned in Section H, TLPub_01. |
-|AS-MS-31-003 | GenNot_03 | The common system mentioned in GenNot_01 SHALL enable: - A secure notification channel between Member States and the Commission for all notifications. - A notification, verification, and publication process and associated validation steps (with follow-up and monitoring) at the Commission side. - Collected data to be processed, consolidated, signed or sealed, and published in both a machine-processable Trusted List or LoTE and in a human-readable format, manually and/or automatically using e.g. a web service and/or API.|  |
-|AS-MS-31-004 | GenNot_04 | Empty|  |
-|AS-MS-31-005 | GenNot_05 | In addition to [Technical Specification 2] referred to in GenNot_01, the European Commission SHALL establish standard operating procedures for the suspension or cancellation of a PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority, or Provider of registration certificates. These operating procedures SHALL include unambiguous conditions for suspension or cancellation. As an outcome of the suspension or cancellation procedure, the status of the suspended or cancelled PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority or Provider of registration certificates in the respective LoTE or Trusted List SHALL be changed to Invalid.|  |
-|AS-MS-31-006 | PPNot_01 | Empty|  |
-|AS-MS-31-007 | PPNot_03 | PID Providers SHALL ensure that all PIDs they issue can be authenticated using the PID Provider trust anchors notified to the Commission.|  |
-|AS-MS-31-008 | PPNot_04 | PID Providers SHALL ensure that their access certificates can be authenticated using the applicable Access Certificate Authority trust anchors notified to the Commission.| [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] describes how access certificates will be used. |
-|AS-MS-31-009 | PPNot_05 | Wallet Units, Relying Parties, and other relevant actors SHALL accept PID Provider trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled PID Provider LoTE, which is sealed by the Commission.|  |
-|AS-MS-31-010 | PPNot_06 | Wallet Units and other relevant actors SHALL accept Access Certificate Authority trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled LoTE, which is signed or sealed by the Commission.|  |
-|AS-MS-31-011 | PPNot_07 | The format of a PID Provider LoTE SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex D.|  |
-|AS-MS-31-012 | PuBPNot_01 | Empty|  |
-|AS-MS-31-013 | PuBPNot_03 | The format of the PuB-EAA Provider Trusted List SHALL comply with [ETSI TS 119 612] v2.1.1.|  |
-|AS-MS-31-014 | RPACANot_01 | Empty|  |
-|AS-MS-31-015 | RPACANot_03 | Relying Parties, PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers SHALL ensure that their access certificates can be authenticated using the trust anchors of an Access Certificate Authority notified to the Commission.|  |
-|AS-MS-31-016 | RPACANot_03a | Relying Parties, PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers SHALL ensure that their registration certificates, if issued to them, can be authenticated using the trust anchors of a Provider of registration certificates notified to the Commission.|  |
-|AS-MS-31-017 | RPACANot_04 | The trust anchors of Access Certificate Authorities and Providers of registration certificates SHALL be accepted because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled LoTEs, which are signed or sealed by the Commission.|  |
-|AS-MS-31-018 | RPACANot_05 | The format of a LoTE for Access Certificate Authorities SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex F.|  |
-|AS-MS-31-019 | RPACANot_05a | The format of a LoTE for Providers of registration certificates SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex G.|  |
-|AS-MS-31-020 | RPACANot_07 | If a Provider of registration certificates is suspended or cancelled (see requirement GenNot_05 above), that Provider SHALL immediately revoke all of its valid registration certificates (if any). Moreover, the corresponding Registrar SHALL prohibit all access to the registry entries published online per Reg_03 and Reg_04.|  |
-|AS-MS-31-021 | TLPub_07 | The Commission SHALL publish in the OJEU the trust anchors to be used for verifying the signature or seal mentioned in TLPub_05.|  |
-|AS-MS-55-001 | CT_01 | An Access CA issuing access certificates SHALL register these in a CT log according to RFC 9162, if such a log is available for access certificates.|  |
-|AS-MS-55-002 | CT_02 | An Access CA issuing access certificates SHALL describe in its CPS how it logs all access certificates.|  |
-|AS-MS-55-003 | CT_03 | In case a CT log provider for access certificates is available, all Access CAs SHALL act as monitors in the CT ecosystem. Access CAs SHOULD still monitor the CT logs in situations of temporary unavailability.|  |
-|AS-MS-55-004 | CT_04 | An Access CA SHALL include at least one Signed Certificate Timestamp (SCT) in each access certificate.|  |
-|AS-MS-55-005 | CT_05 | When verifying an access certificate during PID or attestation issuance or presentation, a Wallet Unit SHALL also verify that the access certificate includes at least one valid Signed Certificate Timestamp (SCT).|  |
-|AS-MS-55-006 | CT_06 | If an access certificate does not include a valid SCT, a Wallet Unit SHALL handle this as a failure or Relying Party authentication, in compliance with all requirements in [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] and in particular requirement RPA_06a.|  |
+<div class="eudi-hlr" id="AS-MS-18-001" markdown>
+<div class="eudi-hlr__id">AS-MS-18-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ACP_02
+{: .eudi-hlr__meta }
+
+A Cryptographic Binding of Attestations scheme SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-25-001" markdown>
+<div class="eudi-hlr__id">AS-MS-25-001</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CAT_01
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-25-002" markdown>
+<div class="eudi-hlr__id">AS-MS-25-002</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CAT_01a
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-25-003" markdown>
+<div class="eudi-hlr__id">AS-MS-25-003</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CAT_01b
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-25-004" markdown>
+<div class="eudi-hlr__id">AS-MS-25-004</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CAT_02
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-25-005" markdown>
+<div class="eudi-hlr__id">AS-MS-25-005</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CAT_03
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-25-006" markdown>
+<div class="eudi-hlr__id">AS-MS-25-006</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CAT_03b
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-25-007" markdown>
+<div class="eudi-hlr__id">AS-MS-25-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CAT_04
+{: .eudi-hlr__meta }
+
+A request to include or to modify an attribute in the catalogue of attributes SHALL indicate how a QTSP can use the verification point for that attribute.
+
+*Note: This could be, for instance, in the form of (a reference to) an endpoint description text.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-001" markdown>
+<div class="eudi-hlr__id">AS-MS-27-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_01
+{: .eudi-hlr__meta }
+
+Member States SHALL provide processes and mechanisms for PID Providers, QEAA Providers, PuB-EAA Providers, non-qualified EAA Providers, and Relying Parties to register in a registry.
+
+*Note: Member States may choose to implement a single registry for all these roles, or a separate registry for each of these roles.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-002" markdown>
+<div class="eudi-hlr__id">AS-MS-27-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_01a
+{: .eudi-hlr__meta }
+
+Member States SHALL register a common set of data about a) PID Providers, b) QEAA Providers, c) PuB-EAA Providers, d) non-qualified EAA Providers. and e) Relying Parties, according to the relevant requirements in [Technical Specification 6](../../technical-specifications/ts6-common-set-of-rp-information-to-be-registered.md).
+
+*Note: For PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers, the common set of data specified in [Technical Specification 6] include the attestation type(s) that the provider intends to issue to Wallet Units.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-003" markdown>
+<div class="eudi-hlr__id">AS-MS-27-003</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_01b
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-004" markdown>
+<div class="eudi-hlr__id">AS-MS-27-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_02
+{: .eudi-hlr__meta }
+
+Member States SHALL make publicly available all necessary details and documentation about the registration processes for their registry.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-005" markdown>
+<div class="eudi-hlr__id">AS-MS-27-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_03
+{: .eudi-hlr__meta }
+
+Member States SHALL publish the registry entries online, in a sealed or signed machine-readable common format suitable for automated processing, according to the relevant requirements in [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md), for the purpose of transparency to Users and other stakeholders.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-006" markdown>
+<div class="eudi-hlr__id">AS-MS-27-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_04
+{: .eudi-hlr__meta }
+
+Member States SHALL make the registry entries available online, in a human-readable format. The website used for this purpose SHALL use a secure channel protecting the authenticity and integrity of the information in the registry during transport. Member States SHALL NOT require authentication or prior registration and authorisation of any person wishing to retrieve the information in the registry.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-007" markdown>
+<div class="eudi-hlr__id">AS-MS-27-007</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_05
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-008" markdown>
+<div class="eudi-hlr__id">AS-MS-27-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_06
+{: .eudi-hlr__meta }
+
+Member States SHALL support the common API specified in [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md) for to enable automated retrieval of registry entries from the Member States' registries.
+
+*Note: [Technical Specification 5] specifies the use of a secure channel protecting the authenticity and integrity of the information in the registry during transport, and does not require authentication or prior registration and authorisation of any entity wishing to retrieve the information in the registry.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-009" markdown>
+<div class="eudi-hlr__id">AS-MS-27-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_07
+{: .eudi-hlr__meta }
+
+A Member State SHALL enable a registered PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party to update the information registered on it, using a process comparable to the original registration process. For Relying Parties, this SHALL be possible using the API or user interface mentioned in Reg_24.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-010" markdown>
+<div class="eudi-hlr__id">AS-MS-27-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_08
+{: .eudi-hlr__meta }
+
+A registered PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party SHALL make any updates necessary to ensure the continued correctness of the registered information without undue delay.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-011" markdown>
+<div class="eudi-hlr__id">AS-MS-27-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_09
+{: .eudi-hlr__meta }
+
+Member States SHALL log all changes made on the information registered regarding a PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party, including at least initial registration, updates, deletion of information, and suspension or cancellation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-012" markdown>
+<div class="eudi-hlr__id">AS-MS-27-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_10
+{: .eudi-hlr__meta }
+
+A Member State SHALL ensure that an Access Certificate Authority notified according to [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)] issues an access certificate to all PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers registered in one of the Member State's registries.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-013" markdown>
+<div class="eudi-hlr__id">AS-MS-27-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_10a
+{: .eudi-hlr__meta }
+
+A Member State SHALL ensure that an Access Certificate Authority notified according to [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)] issues one or more access certificates to all Relying Parties registered in one of the Member State's registries. A Relying Party SHALL receive a separate access certificate for each of its Relying Party Instances.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-014" markdown>
+<div class="eudi-hlr__id">AS-MS-27-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_11
+{: .eudi-hlr__meta }
+
+A Member State SHALL ensure that the issuance process of access certificates by their notified Access Certificate Authority(s) complies with [ETSI TS 119 411-8]. In addition, the Access Certificate Authority(s) SHALL comply with at least the normalised certificate policy (‘NCP’) requirements as specified in [ETSI EN 319 411-1].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-015" markdown>
+<div class="eudi-hlr__id">AS-MS-27-015</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_12
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-016" markdown>
+<div class="eudi-hlr__id">AS-MS-27-016</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_13
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-017" markdown>
+<div class="eudi-hlr__id">AS-MS-27-017</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_14
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-018" markdown>
+<div class="eudi-hlr__id">AS-MS-27-018</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_15
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-019" markdown>
+<div class="eudi-hlr__id">AS-MS-27-019</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_16
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-020" markdown>
+<div class="eudi-hlr__id">AS-MS-27-020</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_17
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-021" markdown>
+<div class="eudi-hlr__id">AS-MS-27-021</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_18
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-022" markdown>
+<div class="eudi-hlr__id">AS-MS-27-022<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_19
+{: .eudi-hlr__meta }
+
+A Member State SHALL approve a PID Provider according to a well-defined policy before including it in its PID Provider Registry. To that end, a Member State SHALL define specific vetting processes and rules of acceptance for inclusion of PID Providers in its Registry.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-023" markdown>
+<div class="eudi-hlr__id">AS-MS-27-023<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_20
+{: .eudi-hlr__meta }
+
+A Member State SHALL identify PID Providers at a level of confidence proportionate to the risk arising from the potential harm a fraudulent PID Provider could cause to Users and other stakeholders in the EUDI Wallet ecosystem.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-024" markdown>
+<div class="eudi-hlr__id">AS-MS-27-024<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_20a
+{: .eudi-hlr__meta }
+
+A Registrar SHALL provide a method to suspend or cancel a registered PID Provider.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-025" markdown>
+<div class="eudi-hlr__id">AS-MS-27-025<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_20b
+{: .eudi-hlr__meta }
+
+A Registrar SHALL have a policy for the suspension or cancellation of a registered PID Provider, which SHALL specify that a PID Provider is suspended or cancelled at least on request of the PID Provider or of a competent national authority.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-026" markdown>
+<div class="eudi-hlr__id">AS-MS-27-026<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_21
+{: .eudi-hlr__meta }
+
+A Member State SHALL approve an Attestation Provider according to a well-defined policy before including it in its Attestation Provider Registry. To that end, a Member State SHALL define specific vetting processes and rules of acceptance for inclusion of Attestation Providers in its Registry. These processes and rules SHOULD consider any relevant differences between QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-027" markdown>
+<div class="eudi-hlr__id">AS-MS-27-027<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_22
+{: .eudi-hlr__meta }
+
+A Member State SHALL identify Attestation Providers (i.e., QEAA Providers, PuB-EAA Providers and non-qualified EAA Providers) at a level of confidence proportionate to the risk arising from the potential harm a fraudulent Attestation Provider could cause to Users and other stakeholders in the EUDI Wallet ecosystem.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-028" markdown>
+<div class="eudi-hlr__id">AS-MS-27-028<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_22a
+{: .eudi-hlr__meta }
+
+A Registrar SHALL provide a method to suspend or cancel a registered Attestation Provider.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-029" markdown>
+<div class="eudi-hlr__id">AS-MS-27-029<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_22b
+{: .eudi-hlr__meta }
+
+A Registrar SHALL have a policy for the suspension or cancellation of a registered Attestation Provider, which SHALL specify that an Attestation Provider is suspended or cancelled at least on request of the Attestation Provider or of a competent national authority.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-030" markdown>
+<div class="eudi-hlr__id">AS-MS-27-030</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_23
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-031" markdown>
+<div class="eudi-hlr__id">AS-MS-27-031<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_24
+{: .eudi-hlr__meta }
+
+A Member State SHALL enable a Relying Party to register remotely, using an API or user interface.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-032" markdown>
+<div class="eudi-hlr__id">AS-MS-27-032<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_25
+{: .eudi-hlr__meta }
+
+A Member State SHALL identify a Relying Party at a level of confidence proportionate to the risk arising from the potential harm a fraudulent Relying Party could cause to Users and other stakeholders in the EUDI Wallet ecosystem.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-033" markdown>
+<div class="eudi-hlr__id">AS-MS-27-033<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_26
+{: .eudi-hlr__meta }
+
+With respect to Reg_25, a Member State SHALL consider whether a registering entity intends to act as an intermediary.
+
+*Note: According to the [European Digital Identity Regulation], an intermediary is a Relying Party.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-034" markdown>
+<div class="eudi-hlr__id">AS-MS-27-034</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_27
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-035" markdown>
+<div class="eudi-hlr__id">AS-MS-27-035</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_28
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-036" markdown>
+<div class="eudi-hlr__id">AS-MS-27-036<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_29
+{: .eudi-hlr__meta }
+
+A Member State SHALL have a policy for the cancellation of a registered Relying Party, which SHALL specify that a Relying Party is cancelled at least on request of the Relying Party or of a competent national authority.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-037" markdown>
+<div class="eudi-hlr__id">AS-MS-27-037</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_30
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-038" markdown>
+<div class="eudi-hlr__id">AS-MS-27-038<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_31
+{: .eudi-hlr__meta }
+
+An access certificate SHALL contain a name for the entity (i.e., the PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party), in a format suitable for presenting to a User. This name SHALL be identical to the name for the entity registered according to [Technical Specification 6] and included in the entity's registration certificate(s) (if present) according to RPRC_06.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-039" markdown>
+<div class="eudi-hlr__id">AS-MS-27-039<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_32
+{: .eudi-hlr__meta }
+
+An access certificate SHALL contain an EU-wide unique identifier for the entity (i.e., the PID Provider, QEAA Provider, PuB-EAA Provider, non-qualified EAA Provider, or Relying Party), which SHALL be identical to the identifier for the entity registered according to [Technical Specification 6] and included in the entity's registration certificate(s) (if present) according to RPRC_07.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-27-040" markdown>
+<div class="eudi-hlr__id">AS-MS-27-040</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: Reg_33
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-28-001" markdown>
+<div class="eudi-hlr__id">AS-MS-28-001</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: LP_01
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-29-001" markdown>
+<div class="eudi-hlr__id">AS-MS-29-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RP_01
+{: .eudi-hlr__meta }
+
+Attestation Scheme Providers MAY create one or multiple Attestation Rulebooks for representation attestations issued to a natural person representing another natural person. Each Rulebook SHALL specify the unique attestation type of these representation attestations. The Rulebook SHALL also specify attributes used for defining a validity period, the nature of the representation, and the operations the representative is authorised to perform, thereby limiting the scope of its authorisation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-001" markdown>
+<div class="eudi-hlr__id">AS-MS-31-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: GenNot_01
+{: .eudi-hlr__meta }
+
+Member States SHALL notify all PID Providers, PuB-EAA Providers, Wallet Providers, Access Certificate Authorities, and Providers of registration certificates to the European Commission, using a common system provided by the Commission, complying with all relevant requirements in[Technical Specification 2](../../technical-specifications/ts2-notification-publication-provider-information.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-002" markdown>
+<div class="eudi-hlr__id">AS-MS-31-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: GenNot_02
+{: .eudi-hlr__meta }
+
+In addition to [Technical Specification 2] referred to in GenNot_01, the European Commission SHALL establish standard operating procedures for the notification of a PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority, or Provider of registration certificates to the Commission.
+
+*Note: The outcome of the notification procedure is the publication of the information notified by the Member State according to [Article 5a](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e1347-1-1) (18) in a machine and human readable manner using the common system mentioned in Section H, TLPub_01.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-003" markdown>
+<div class="eudi-hlr__id">AS-MS-31-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: GenNot_03
+{: .eudi-hlr__meta }
+
+The common system mentioned in GenNot_01 SHALL enable: - A secure notification channel between Member States and the Commission for all notifications. - A notification, verification, and publication process and associated validation steps (with follow-up and monitoring) at the Commission side. - Collected data to be processed, consolidated, signed or sealed, and published in both a machine-processable Trusted List or LoTE and in a human-readable format, manually and/or automatically using e.g. a web service and/or API.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-004" markdown>
+<div class="eudi-hlr__id">AS-MS-31-004</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: GenNot_04
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-005" markdown>
+<div class="eudi-hlr__id">AS-MS-31-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: GenNot_05
+{: .eudi-hlr__meta }
+
+In addition to [Technical Specification 2] referred to in GenNot_01, the European Commission SHALL establish standard operating procedures for the suspension or cancellation of a PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority, or Provider of registration certificates. These operating procedures SHALL include unambiguous conditions for suspension or cancellation. As an outcome of the suspension or cancellation procedure, the status of the suspended or cancelled PID Provider, PuB-EAA Provider, Wallet Provider, Access Certificate Authority or Provider of registration certificates in the respective LoTE or Trusted List SHALL be changed to Invalid.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-006" markdown>
+<div class="eudi-hlr__id">AS-MS-31-006</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PPNot_01
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-007" markdown>
+<div class="eudi-hlr__id">AS-MS-31-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PPNot_03
+{: .eudi-hlr__meta }
+
+PID Providers SHALL ensure that all PIDs they issue can be authenticated using the PID Provider trust anchors notified to the Commission.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-008" markdown>
+<div class="eudi-hlr__id">AS-MS-31-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PPNot_04
+{: .eudi-hlr__meta }
+
+PID Providers SHALL ensure that their access certificates can be authenticated using the applicable Access Certificate Authority trust anchors notified to the Commission.
+
+*Note: [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] describes how access certificates will be used.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-009" markdown>
+<div class="eudi-hlr__id">AS-MS-31-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PPNot_05
+{: .eudi-hlr__meta }
+
+Wallet Units, Relying Parties, and other relevant actors SHALL accept PID Provider trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled PID Provider LoTE, which is sealed by the Commission.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-010" markdown>
+<div class="eudi-hlr__id">AS-MS-31-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PPNot_06
+{: .eudi-hlr__meta }
+
+Wallet Units and other relevant actors SHALL accept Access Certificate Authority trust anchors because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled LoTE, which is signed or sealed by the Commission.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-011" markdown>
+<div class="eudi-hlr__id">AS-MS-31-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PPNot_07
+{: .eudi-hlr__meta }
+
+The format of a PID Provider LoTE SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex D.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-012" markdown>
+<div class="eudi-hlr__id">AS-MS-31-012</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PuBPNot_01
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-013" markdown>
+<div class="eudi-hlr__id">AS-MS-31-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PuBPNot_03
+{: .eudi-hlr__meta }
+
+The format of the PuB-EAA Provider Trusted List SHALL comply with [ETSI TS 119 612] v2.1.1.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-014" markdown>
+<div class="eudi-hlr__id">AS-MS-31-014</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPACANot_01
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-015" markdown>
+<div class="eudi-hlr__id">AS-MS-31-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPACANot_03
+{: .eudi-hlr__meta }
+
+Relying Parties, PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers SHALL ensure that their access certificates can be authenticated using the trust anchors of an Access Certificate Authority notified to the Commission.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-016" markdown>
+<div class="eudi-hlr__id">AS-MS-31-016<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPACANot_03a
+{: .eudi-hlr__meta }
+
+Relying Parties, PID Providers, QEAA Providers, PuB-EAA Providers, and non-qualified EAA Providers SHALL ensure that their registration certificates, if issued to them, can be authenticated using the trust anchors of a Provider of registration certificates notified to the Commission.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-017" markdown>
+<div class="eudi-hlr__id">AS-MS-31-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPACANot_04
+{: .eudi-hlr__meta }
+
+The trust anchors of Access Certificate Authorities and Providers of registration certificates SHALL be accepted because of their secure notification by the Member States to the Commission and by their publication in the corresponding Commission-compiled LoTEs, which are signed or sealed by the Commission.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-018" markdown>
+<div class="eudi-hlr__id">AS-MS-31-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPACANot_05
+{: .eudi-hlr__meta }
+
+The format of a LoTE for Access Certificate Authorities SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex F.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-019" markdown>
+<div class="eudi-hlr__id">AS-MS-31-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPACANot_05a
+{: .eudi-hlr__meta }
+
+The format of a LoTE for Providers of registration certificates SHALL comply with [ETSI TS 119 602] v1.1.1, including Annex G.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-020" markdown>
+<div class="eudi-hlr__id">AS-MS-31-020<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPACANot_07
+{: .eudi-hlr__meta }
+
+If a Provider of registration certificates is suspended or cancelled (see requirement GenNot_05 above), that Provider SHALL immediately revoke all of its valid registration certificates (if any). Moreover, the corresponding Registrar SHALL prohibit all access to the registry entries published online per Reg_03 and Reg_04.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-31-021" markdown>
+<div class="eudi-hlr__id">AS-MS-31-021<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: TLPub_07
+{: .eudi-hlr__meta }
+
+The Commission SHALL publish in the OJEU the trust anchors to be used for verifying the signature or seal mentioned in TLPub_05.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-55-001" markdown>
+<div class="eudi-hlr__id">AS-MS-55-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CT_01
+{: .eudi-hlr__meta }
+
+An Access CA issuing access certificates SHALL register these in a CT log according to RFC 9162, if such a log is available for access certificates.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-55-002" markdown>
+<div class="eudi-hlr__id">AS-MS-55-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CT_02
+{: .eudi-hlr__meta }
+
+An Access CA issuing access certificates SHALL describe in its CPS how it logs all access certificates.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-55-003" markdown>
+<div class="eudi-hlr__id">AS-MS-55-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CT_03
+{: .eudi-hlr__meta }
+
+In case a CT log provider for access certificates is available, all Access CAs SHALL act as monitors in the CT ecosystem. Access CAs SHOULD still monitor the CT logs in situations of temporary unavailability.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-55-004" markdown>
+<div class="eudi-hlr__id">AS-MS-55-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CT_04
+{: .eudi-hlr__meta }
+
+An Access CA SHALL include at least one Signed Certificate Timestamp (SCT) in each access certificate.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-55-005" markdown>
+<div class="eudi-hlr__id">AS-MS-55-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CT_05
+{: .eudi-hlr__meta }
+
+When verifying an access certificate during PID or attestation issuance or presentation, a Wallet Unit SHALL also verify that the access certificate includes at least one valid Signed Certificate Timestamp (SCT).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-MS-55-006" markdown>
+<div class="eudi-hlr__id">AS-MS-55-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: CT_06
+{: .eudi-hlr__meta }
+
+If an access certificate does not include a valid SCT, a Wallet Unit SHALL handle this as a failure or Relying Party authentication, in compliance with all requirements in [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] and in particular requirement RPA_06a.
+
+</div>
+</div>
+
 
 ---
 
@@ -425,161 +5033,2130 @@ as statements of fact.
 *the wallet. This includes requirements for identity verification, issuance*
 *protocols, data formats, and revocation policies.*
 
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
-|AS-AP-07-001 | VCR_01 | A PID Provider, QEAA Provider, or PuB-EAA Provider SHALL use one of the following methods for revocation of a PID, QEAA, or PuB-EAA: - Only issue short-lived attestations having a validity period of 24 hours or less, such that revocation will never be necessary, - Use an Attestation Status List mechanism specified per VCR_11, or - Use an Attestation Revocation List mechanism specified per VCR_11.| The 24-hour period originates from [ETSI EN 319 411-1] V1.4.1, requirement REV-6.2.4-03A. This requires that the process of revocation must take at most 24 hours. Consequently, revocation may make no sense if the attestation is valid for less than 24 hours, because it may reach the end of its validity period before it is revoked. |
-|AS-AP-07-002 | VCR_01a | A Wallet Provider SHALL use the method specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) for maintaining the revocation status of the underlying objects referenced in a WIA or key attestation.| The 'underlying object' is the object that is actually revoked by revoking the WIA or key attestation, i.e., the Wallet Instance in case of a WIA and a WSCA/WSCD or keystore in case of a key attestation. |
-|AS-AP-07-003 | VCR_02 | For non-qualified EAAs, the relevant Rulebook SHALL specify whether that type of EAA must be revocable. If a non-qualified EAA type must be revocable, the relevant Rulebook SHALL determine which of the methods mentioned in VCR_01 must be implemented by the relevant EAA Providers for the revocation of such an EAA.|  |
-|AS-AP-07-004 | VCR_03 | If a PID or attestation is revocable, the PID Provider of a given PID, or the Attestation Provider of a given attestation, SHALL be the only party in the EUDI Wallet ecosystem responsible for executing the revocation of that PID or attestation.| A PID Provider or Attestation Provider MAY outsource the operation of the revocation process to a third party. |
-|AS-AP-07-005 | VCR_03a | The Wallet Provider of a given WIA or KA SHALL be the only party in the EUDI Wallet ecosystem responsible for maintaining the revocation status of the underlying object attested in that WIA or KA.| A Wallet Provider MAY outsource the operation of the revocation process to a third party. |
-|AS-AP-07-006 | VCR_04 | A PID Provider, Attestation Provider or Wallet Provider that revoked a PID, attestation, WIA, or KA SHALL NOT reverse the revocation.|  |
-|AS-AP-07-007 | VCR_05 | If a PID, attestation, WIA, or KA is revocable, the PID Provider, Attestation Provider, or Wallet Provider SHALL have a policy specifying under which conditions a PID, attestation, WIA, or KA it issued will be revoked.|  |
-|AS-AP-07-008 | VCR_06 | If a PID or attestation is revocable, the PID Provider or Attestation Provider SHALL revoke a PID or attestation when its security has been compromised.|  |
-|AS-AP-07-009 | VCR_07 | A Wallet Provider SHALL revoke the Wallet Instance upon the explicit request of the User to revoke their Wallet Unit.| See also WURevocation_07 and _10. |
-|AS-AP-07-010 | VCR_07a | If a PID is revocable, the PID Provider SHALL revoke that PID upon the explicit request of the User to whom the PID was issued.|  |
-|AS-AP-07-011 | VCR_07b | If an attestation is revocable, the Attestation Provider SHOULD revoke that attestation upon the explicit request of the User to whom the attestation was issued.|  |
-|AS-AP-07-012 | VCR_07c | If a PID is revocable, the PID Provider SHALL revoke that PID if the Wallet Unit on which it resides is revoked, in compliance with requirement WURevocation_18 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation).|  |
-|AS-AP-07-013 | VCR_07d | If an attestation is revocable, the Attestation Provider MAY revoke that attestation if the Wallet Unit on which it resides is revoked, in compliance with requirement WURevocation_19 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation).|  |
-|AS-AP-07-014 | VCR_07e | If a Wallet Provider uses the per-KA approach for key attestation revocation (see WUA_28), it SHALL revoke a WSCD or keystore upon the explicit request of the User to revoke their WSCD or keystore.| a) The most likely cause of such a request would be that the WSCD or keystore is a local external smart card and the User lost their WSCD or keystore. b) In contrast, under the type-shared index approach (see WUA_28), revoking the WSCD or keystore is not a per-Wallet Unit action that can be triggered by user requests. c) See also WURevocation_07a. |
-|AS-AP-07-015 | VCR_08 | If a PID is revocable, the PID Provider SHALL revoke a PID upon the death of the natural person who is the subject of the PID.| a) In addition, in these circumstances the PID Provider also requests the Wallet Provider to revoke the Wallet Unit, see WURevocation_11. b) The topic of Wallet Units for legal persons, possibly containing a legal-person PID, has has been removed from this ARF in view of the development of a separate business wallet. |
-|AS-AP-07-016 | VCR_09 | If a technical PID or attestation is revocable, the PID Provider or Attestation Provider SHALL revoke that PID or attestation if the value of one or more of the attributes in the corresponding logical PID or attestation was changed (including attributes being added or deleted) and it is still valid for at least 24 hours. Subsequently, if the User's contact details are known, the PID Provider or Attestation Provider SHOULD, via an out-of-band manner, notify the User about the revocation and ask the User to request re-issuance of the PID or attestation using their Wallet Unit.| If the value of the attributes is determined by a party different from the Provider, such as an Authentic Source, the Provider is responsible for ensuring that this third party notifies them about such changes. |
-|AS-AP-07-017 | VCR_10 | Wallet Providers SHALL implement the attestation revocation mechanisms specified per VCR_11 in their Wallet Solutions.|  |
-|AS-AP-07-018 | VCR_11 | The Commission SHALL create or reference technical specifications providing all necessary details for PID Providers, Attestation Providers, and Wallet Providers to implement an Attestation Status List mechanism or an Attestation Revocation List mechanism for the PIDs, attestations, and WIAs and KAs they issue. These technical specifications SHALL also contain all details necessary for Relying Party Instances, Relying Parties, and Wallet Units interacting with other Wallet Units to use these mechanisms to verify the revocation status of PIDs, attestations, and WIAs and KAs.| 'Attestation Status List' and 'Attestation Revocation List' are specific mechanisms, defined in Annex 1. Attestation Revocation Lists are sometimes referred to as 'Identifier Lists'. |
-|AS-AP-07-019 | VCR_12 | If a Relying Party decides it needs to be able to verify the revocation status of PIDs or attestations, it SHALL support both the Attestation Status List mechanism and the Attestation Revocation List mechanism specified per VCR_11.| Per VCR_13, it is recommended but not mandatory for a Relying Party to verify whether a PID or attestation is revoked. |
-|AS-AP-07-020 | VCR_12a | A PID Provider or Attestation Provider SHALL support both the Attestation Status List mechanism and the Attestation Revocation List mechanism specified per VCR_11 for verifying the revocation status of a WIA or KA.|  |
-|AS-AP-07-021 | VCR_13 | A Relying Party Instance SHOULD verify the revocation status of a PID or attestation upon obtaining it from a Wallet Unit, following the steps specified per VCR_11. When a Relying Party considers deviating from this recommendation by not performing revocation checking, it SHALL perform a risk analysis considering all relevant factors for the use case, including risks to the User and risks to the Relying Party itself.|  |
-|AS-AP-07-022 | VCR_14 | A Relying Party SHALL perform a risk analysis considering all relevant factors for the use case, including risks to the User and risks to the Relying Party itself, to determine whether it will accept or refuse a PID or attestation in case no reliable information regarding the revocation status of that PID or attestation is available.| Examples of conditions under which no reliable revocation information is available are 1) The attestation does not contain revocation information (because it is not revocable). 2) The Relying Party Instance is offline and any cached status information is no longer valid. 3) The latest attestation status lists or attestation identifier lists provided by the PID Provider or Attestation Provider (i.e., available online) are no longer valid. 4) The Relying Party Instance is offline, but the use case requires up-to-date revocation information (instead of trusting cached information that is still valid.) |
-|AS-AP-07-023 | VCR_15 | A Relying Party Instance SHOULD NOT request the relevant Attestation Status List or Attestation Revocation List each time an attestation is presented to it by a Wallet Unit. Rather, the Relying Party operating the Relying Party Instance SHOULD download each new version of the list once, at a time and from a location unrelated to the presentation of a PID or attestation by a User. The Relying Party SHOULD then distribute the list to all of its Relying Party Instances, using an Relying Party-internal distribution mechanism. Each Relying Party Instance SHOULD cache the list, so that it can perform revocation checks without making an online request. The Relying Party SHOULD perform a risk analysis to determine the frequency with which it will download the revocation lists and the maximum caching period its Relying Party Instances will use.|  |
-|AS-AP-07-024 | VCR_16 | A PID Provider, Attestation Provider or Wallet Provider SHALL NOT require the Relying Party or Relying Party Instance to authenticate itself before downloading an Attestation Status List or Attestation Revocation List.|  |
-|AS-AP-07-025 | VCR_17 | When using an Attestation Status List for revocation, the PID Provider, Attestation Provider or Wallet Provider SHALL randomly assign the index for each PID or attestation, to prevent this index from becoming a correlator.| Randomly assigning indices within a bitstring or byte array is more complicated than creating random identifiers (e.g. serial numbers) for attestations, as is needed for an Attestation Revocation List. This is because duplicate indices and unnecessarily long bitstrings or byte arrays must be prevented. |
-|AS-AP-07-026 | VCR_18 | When using an Attestation Status List for revocation, the PID Provider, Attestation Provider, or Wallet Provider SHALL represent a sufficiently large number of PIDs, attestations, WIAs, or KAs on each Attestation Status List to ensure herd privacy.| In this context, herd privacy means that if an entity requests a particular status list, the PID Provider, Attestation Provider, or Wallet Provider is not able to deduce which PID, attestation, WIA, or KA (likely) was presented to that entity. Complying with this requirement may be difficult in case the number of PIDs, attestations, WIAs, or KAs to be represented on the list is small. In such a case, decoy entries can be added to the list to obfuscate the real number of referenced PIDs, attestations, WIAs, or KAs. |
-|AS-AP-07-027 | VCR_19 | A Wallet Unit SHOULD regularly check the revocation status of its PIDs and attestations. In addition, the Wallet Unit SHOULD regularly check whether itself or any WSCD or keystore it uses has been revoked. In case of any revocation, the Wallet Unit SHALL notify the User accordingly.| A Wallet Unit can check its own revocation status using its WIAs, and the revocation status of its WSCD and keystores using its key attestations. |
-|AS-AP-10-001 | ISSU_01a | PID Providers and Attestation Providers SHALL support the OpenID4VCI protocol specified in [OpenID4VCI], as profiled in Sections 4 and 6 of [HAIP], and with additions and changes as documented in this Annex (see e.g. this Topic and [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)) and in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).| For clarity: in [HAIP] v1.0, Section 6 implies that PID Providers and Attestation Providers must comply with the applicable requirements in [OpenID4VCI] Annex A.2 when issuing an attestation in ISO/IEC 18013-5-compliant format, and with the applicable requirements in [OpenID4VCI] Annex A.3 when issuing an attestation in SD-JWT VC format. |
-|AS-AP-10-002 | ISSU_02 | Wallet Providers SHALL ensure that their Wallet Solution supports the attestation formats specified in ISO/IEC 18013-5, see [ISO18013-5], and in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC], with additions and changes as documented in this Annex and in future technical specifications created by or on behalf of the Commission.|  |
-|AS-AP-10-003 | ISSU_03 | Wallet Units, PID Providers, and Attestation Providers SHALL support the [W3C Digital Credentials API](https://wicg.github.io/digital-credentials/) for the issuance of PIDs and attestations.| This requirement implies that the following conditions will be satisfied: a) the DC API specification will become a W3C Recommendation, b) this specification will comply with the principles outlined in [Section 4.4.3.1](../../architecture-and-reference-framework-main.md#4431-introduction) of the ARF main document, c) this specification will be broadly supported by relevant browsers and operating systems, and d) the [OpenID4VCI] standard will specify how to use OpenID4VCI with the DC API. |
-|AS-AP-10-004 | ISSU_04 | The OpenID4VCI protocol referenced in requirement ISSU_01, or an EUDI Wallet-specific extension or profile thereof, SHALL enable PID Providers and Attestation Provider to issue to a Wallet Unit a batch of multiple PIDs or attestations that are simultaneously valid and contain the same attributes.|  |
-|AS-AP-10-005 | ISSU_05 | A Wallet Unit SHALL support a process to activate a newly issued PID, in accordance with the requirements for LoA High in [Commission Implementing Regulation (EU) 2015/1502](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32015R1502) Section 2.2.2. The Wallet Unit SHALL NOT allow a User to use a non-activated PID.| a) The goal of the activation process is to verify that the PID was delivered into the Wallet Unit and WSCA/WSCD of the User who is the subject of the PID. b) This requirement is not applicable for QEAAs, PuB-EAAs or non-qualified EAAs, since these are not identity means in the sense of Commission Implementing Regulation (EU) 2015/1502. |
-|AS-AP-10-006 | ISSU_06 | After a Wallet Unit receives a PID or an attestation from a PID Provider or Attestation Provider, it SHALL verify that the PID or attestation it received matches the PID or attestation requested by the Wallet Unit.|  |
-|AS-AP-10-007 | ISSU_07 | After a Wallet Unit receives a PID from a PID Provider, it SHALL validate the signature of the PID using a trust anchor of the PID Provider provided in a LoTE made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].| The Wallet Provider and PID Provider may be the same entity. In such a case, the remote WSCD used by the Wallet Provider may be the same hardware HSM that is also used by the PID Provider to sign PIDs. In such a situation, this requirement may look superfluous, since the same HSM would generate the signature and verify it. However, this is not true, since for security reasons the PID Provider and Wallet Provider must use proper partitioning and logical key segregation within the HSM. Therefore, this requirement also applies in such a situation. |
-|AS-AP-10-008 | ISSU_08 | After a Wallet Unit receives a QEAA from a QEAA Provider, it SHALL validate the qualified signature of the QEAA in accordance with Art. 32 of the [European Digital Identity Regulation]. For the verification, the Wallet Unit SHALL use a trust anchor provided in a QEAA Provider Trusted List made available in accordance with [Art. 22](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ.L_.2014.257.01.0073.01.ENG#d1e2162-73-1) of the [European Digital Identity Regulation].| a) Requirements ISSU_07 to ISSU_10 are equivalent to requirements OIA_12 to OIA_15 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit). b) These requirements imply that a Wallet Instance must be aware whether the attestation it is requesting from an issuer is a PID, a QEAA, a PuB-EAA, or a non-qualified EAA. These requirements also imply that the Wallet Unit must store trust anchors in such a way that, when it receives an issued attestation, it is able to distinguish between trust anchors usable either for PIDs, for QEAAs, for PuB-EAAs, or for non-qualified EAAs. |
-|AS-AP-10-009 | ISSU_09 | After a Wallet Unit receives a PuB-EAA from a PUB-EAA Provider, it SHALL validate the signature of a PuB-EAA using a trust anchor provided in a PUB-EAA Provider Trusted List made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].|  |
-|AS-AP-10-010 | ISSU_10 | After a Wallet Unit receives a non-qualified EAA from an EAA Provider, it SHALL validate the signature of the EAA if it has access to the trust anchors of the EAA Provider.| For a non-qualified EAA, an Attestation Rulebook may be available, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)], explaining how EAA Providers distribute their trust anchors. However, it is not required for Wallet Units to be in possession of the trust anchors of all non-qualified EAA Providers, even when an Attestation Rulebook is available. |
-|AS-AP-10-011 | ISSU_11 | A Wallet Unit SHALL request the User's approval before storing a PID or attestation obtained from a PID Provider or Attestation Provider. When requesting approval, the Wallet Instance SHALL display the contents of the PID or attestation to the User. The Wallet Instance SHALL also inform the User about the identity of the PID Provider or Attestation Provider, using the subject information in the PID Provider's or Attestation Provider's access certificate.|  |
-|AS-AP-10-012 | ISSU_11a | In case a PID or attestation is issued in batches, the Wallet Unit SHALL verify that  all PIDs and attestations in a batch have the same attribute values and the same technical validity period.| PIDs and attestations are issued in batches when Method A, Method B, or Method D is used, see ISSU_37, ISSU_43, ISSU_51. |
-|AS-AP-10-013 | ISSU_11b | In case one or more of the verifications in ISSU_06 - ISSU_11a fail, the Wallet Unit SHALL immediately delete the PID or attestation it received. The Wallet Instance SHALL notify the User about the fact that issuance of the PID or attestation was not successful, including the reason for this failure.|  |
-|AS-AP-10-014 | ISSU_12 | A PID Provider or Attestation Provider SHALL offer its PIDs or attestations in all formats required in the PID Rulebook or the applicable Attestation Rulebook, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)].| Examples include the mdoc format specified in [ISO/IEC 18013-5] and the SD-JWT VC-format specified in [SD-JWT VC]. |
-|AS-AP-10-015 | ISSU_12a | When a User instructs their Wallet Unit to request a PID or attestation from a PID Provider or Attestation Provider, the Wallet Unit SHALL request that PID or attestation in all formats offered by the PID Provider or Attestation Provider.| Examples include the mdoc format specified in [ISO/IEC 18013-5] and the SD-JWT VC-format specified in [SD-JWT VC]. |
-|AS-AP-10-016 | ISSU_12b | The WSCA/WSCD or a keystore SHALL generate a new key pair for a new PID or attestation on request of the Wallet Instance, unless that PID or attestation is issued synchronously in a remote HSM architecture. This generation request MAY be done either prior to the issuance of any PID or attestation, or during the issuance process.| a) See also WUA_05 and WUA_05a. b) In case of synchronous issuing in a remote HSM architecture, re-use of an existing key pair within a limited period of time can be acceptable, based on the PID Provider's or Attestation Provider's issuance security policy. This is similar to a choice between Method A or Method B (see ISSU_37 and ISSU_38) when issuing PIDs or attestations non-synchronously. |
-|AS-AP-10-017 | ISSU_12c | The expiration date of a PID SHALL be no later than the end of the revocation maintenance periods of the WIA and the KA presented as part of the PID issuance process.| This requirement is an implication of WURevocation_18 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation) and WUA_29-WUA_31. If the PID would be valid beyond the period for which the Wallet Provider has committed to maintaining the revocation status of the Wallet Instance and the WSCD or keystore, the PID Provider would not be able to fulfil its obligation to regularly check whether the Wallet Instance and WSCD or keystore have been revoked for the full PID validity period. |
-|AS-AP-10-018 | ISSU_12d | If an Attestation Provider supports revocation chaining for its attestations per WURevocation_19 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation), the expiration date of an attestation SHALL be no later than the end of the revocation maintenance periods of the WIA and the KA (if applicable) presented as part of the attestation issuance process.| See note in ISSU_12c. |
-|AS-AP-10-019 | ISSU_13 | A Wallet Provider SHALL ensure that at least one PID Provider is willing to issue a PID complying with [PID Rulebook] to Users of the Wallet Units it provides.|  |
-|AS-AP-10-020 | ISSU_14 | A PID Provider SHALL ensure that all PIDs it issues to Wallet Units comply with the requirements specified in [PID Rulebook].|  |
-|AS-AP-10-021 | ISSU_15 | A PID Provider SHALL support the OpenID4VCI protocol referenced in ISSU_01 for issuing PIDs.|  |
-|AS-AP-10-022 | ISSU_16 | Empty|  |
-|AS-AP-10-023 | ISSU_17 | A PID Provider SHALL implement device binding for all PIDs it issues, meaning it SHALL ensure that a PID is cryptographically bound to the WSCA/WSCD included in the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation).| Device binding is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT-VC]. |
-|AS-AP-10-024 | ISSU_18 | A PID Provider SHALL verify the identity of the subject of the PID in compliance with Level of Assurance (LoA) High requirements.| These requirements will be determined by the relevant eID scheme. |
-|AS-AP-10-025 | ISSU_18a | A PID Provider SHALL ensure that the attributes attested in the PID issued are valid for the identified PID subject at any point of time of PID validity.|  |
-|AS-AP-10-026 | ISSU_19 | For the verification of a WIA or KA, a PID Provider SHALL accept the trust anchors in the Wallet Provider LoTE(s) it needs.| a) The Wallet Provider LoTE is explained in [Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates). b) It is not mandatory for a PID Provider to accept all Wallet Provider LoTEs, if there are multiple. This is because it is not mandatory for a PID Provider to accept all certified Wallet Solutions in the EUDI Wallet ecosystem. Each PID Provider will choose which LoTEs they need to subscribe to. |
-|AS-AP-10-027 | ISSU_19a | A PID Provider SHALL support all Wallet Solutions recognised under the corresponding notified eID scheme, meaning that it is willing and able to issue a PID to a Wallet Unit on request of the User.|  |
-|AS-AP-10-028 | ISSU_20 | To inform its potential PID subjects about the Wallet Solution(s) they can use for requesting a PID, a PID Provider SHALL publish a list of supported Wallet Solutions in such a way that it can be easily found, for example on the PID Provider's website.| This a policy requirement rather than a technical requirement. |
-|AS-AP-10-029 | ISSU_21 | Before issuing a PID, a PID Provider SHALL verify the Wallet Unit's WIA and KA using a trust anchor registered in the Wallet Provider LoTE. Moreover, it SHALL verify that the Wallet Instance referenced in the WIA has not been revoked, and that the WSCD referenced in the KA has not been revoked.| a) For WIAs and KAs, see [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation) and [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation). b) [CIR 2024/2977], Article 3 (9), also allows another authentication mechanism in accordance with an electronic identity scheme notified at assurance level high. However, the ARF does not further specify such other authentication mechanisms, which means that in general they will not be interoperable. |
-|AS-AP-10-030 | ISSU_22 | A PID Provider SHALL sign its Credential Issuer metadata as specified in section 12.2.3 of [OpenID4VCI]. To do so, the PID Provider SHALL use the private key corresponding to the public key in its access certificate. The PID Provider SHALL include its access certificate, as well as all intermediate certificate(s) leading up to the trust anchor of the corresponding Access Certificate Authority (see ISSU_33) in the LoTE, in the ``x5c`` parameter in the JOSE header of the JSON Web Signature for the metadata.|  |
-|AS-AP-10-031 | ISSU_22a | Empty|  |
-|AS-AP-10-032 | ISSU_22b | Empty|  |
-|AS-AP-10-033 | ISSU_23 | For the verification of a PID Provider's access certificates, a Wallet Unit SHALL accept the trust anchors in the LoTE(s) of Access Certificate Authorities it needs.| a) Access Certificate Authority LoTEs are explained in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)]. |
-|AS-AP-10-034 | ISSU_23a | A Wallet Provider SHALL support at least one PID Provider, meaning that its Wallet Units SHALL be capable of requesting the issuance of a PID from these PID Provider(s), and that the Wallet Provider has agreed with the PID Provider(s) that the PID Provider(s) will process such a request according to the agreed rules and procedures.|  |
-|AS-AP-10-035 | ISSU_23b | Prior to or during installation of a Wallet Instance, the Wallet Provider SHALL notify the User about the PID Provider(s) that are supported by the Wallet Unit.|  |
-|AS-AP-10-036 | ISSU_24 | A Wallet Unit SHALL authenticate and validate the access certificate of the PID Provider before requesting the issuance of a PID. The Wallet Unit SHALL verify that the access certificate is authentic and is valid at the time of validation, and that the issuer of the access certificate is included in an Access Certificate Authority LoTE.|  |
-|AS-AP-10-037 | ISSU_24a | Before requesting the issuance of a PID, the Wallet Unit SHALL verify that the PID Provider is indeed a registered PID Provider. To do so, the Wallet Unit SHALL a) Inspect the ``entitlement`` member in the registration certificate of the PID Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``entitlement``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``entitlement`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the PID Provider is indeed registered as a PID Provider, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of a PID.| The information in the ``entitlement`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the PID Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful. |
-|AS-AP-10-038 | ISSU_24b | Before requesting the issuance of a PID, the Wallet Unit SHALL verify whether the PID Provider properly registered for the issuance of PIDs. To do so, the Wallet Unit SHALL a) Inspect the ``providesAttestations`` member in the registration certificate of the PID Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``providesAttestations``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``providesAttestations`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the PID Provider registered for the issuance of PIDs, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of a PID.| a) The information in the ``providesAttestations``  member included in the Credential Issuer Metadata (3rd option above) is self-declared by the PID Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful. b) It may be argued that this verification is superfluous, since an entity registered as a PID Provider (ISSU_24a) by definition is registered for issuing PIDs. However, this verification was added to ensure that Wallet Unit can use the same verification process for PIDs as for other attestations (see ISSU_34b), as well as to ensure that in the future, it is possible to distinguish between different types of PID if needed, where not all PID Providers are registered to issue all types of PID. |
-|AS-AP-10-039 | ISSU_25 | An Attestation Provider SHALL ensure all attestations issued to Wallet Units comply with the requirements specified in the applicable Rulebook, as described in [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)].|  |
-|AS-AP-10-040 | ISSU_26 | An Attestation Provider SHALL support the OpenID4VCI protocol referenced in ISSU_01 for issuing attestations.|  |
-|AS-AP-10-041 | ISSU_27 | An Attestation Provider SHOULD implement device binding for all attestations it issues. If an issued attestation is device-bound, the Attestation Provider SHALL ensure that the attestation is cryptographically bound to a WSCA/WSCD or a keystore available to the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation).| a) Device binding is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT-VC]. b) Implementing mdoc authentication is mandatory in [ISO/IEC 18013-5] and therefore, it is mandatory for attestations complying with that standard. c) See ISSU_27d. |
-|AS-AP-10-042 | ISSU_27a | If the subject of the attestation is a natural person, an Attestation Provider SHALL verify the identity of the subject of the attestation, in compliance with applicable requirements and in accordance with relevant standards or Implementing Regulations.| Not every attestation has a natural person as its subject. For example, a holiday voucher may be valid for any User that can present it to a Relying Party and therefore has no subject. This is comparable to the concept of a 'bearer token'. |
-|AS-AP-10-043 | ISSU_27b | If applicable, an Attestation Provider SHALL ensure that the attributes attested in the attestation issued are valid for the identified attestation subject.|  |
-|AS-AP-10-044 | ISSU_27c | The Attestation Provider SHALL verify that the User requesting the attestation has the right to receive it.|  |
-|AS-AP-10-045 | ISSU_27d | An Attestation Provider issuing device-bound attestations SHALL indicate the desired level of security for the private key storage and for User authentication in its Credential Issuer metadata, according to [OpenID4VCI] section 12.2.4 and Appendix D.2.| See also WIAM_14b, WIAM_14c, and WUA_05 and WUA_05a. |
-|AS-AP-10-046 | ISSU_28 | For the verification of a WIA or KA, an Attestation Provider SHALL accept the trust anchors in the Wallet Provider LoTE.| The Wallet Provider LoTE is explained in [Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates). |
-|AS-AP-10-047 | ISSU_29 | A QEAA Provider or PuB-EAA Provider SHALL support all Wallet Solutions, except in case the attestation in question is a Strong User Authentication (SUA) attestation as meant in [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments) and the Wallet Provider does not support processing of the transactional data associated with the SUA attestation. Except for such cases, A QEAA Provider or PuB-EAA Provider SHALL NOT discriminate between Wallet Solutions when processing a request for the issuance of an attestation.| This requirement is not applicable for non-qualified EAA Providers. For example, a non-qualified EAA Provider may choose to issue attestations in the format specified in [W3C VCDM], see ARB_01a. In that case, it will support only those Wallet Solutions that have implemented this attestation format. |
-|AS-AP-10-048 | ISSU_30 | Before issuing a device-bound attestation, an Attestation Provider SHALL verify the Wallet Unit's key attestation using a trust anchor registered in the Wallet Provider LoTE. Moreover, it SHALL verify that the WSCD or keystore referenced in the KA has not been revoked.| This requirement applies specifically to the KA received during device-bound attestation issuance. The corresponding requirement for verifying the WIA is ISSU_30a. |
-|AS-AP-10-049 | ISSU_30a | Before issuing an attestation, an Attestation Provider SHALL: - verify that the Wallet Provider mentioned in the Wallet Unit's WIA is present in the Wallet Provider LoTE. - authenticate and validate the WIA using the trust anchor(s) registered for the Wallet Provider in that LoTE.| This requirement applies to both device-bound and non-device-bound attestations |
-|AS-AP-10-050 | ISSU_31 | Empty|  |
-|AS-AP-10-051 | ISSU_32 | An Attestation Provider SHALL sign its Credential Issuer metadata as specified in section 12.2.3 of [OpenID4VCI]. To do so, the Attestation Provider SHALL use the private key corresponding to the public key in its access certificate. The Attestation Provider SHALL include its access certificate, as well as all intermediate certificate(s) leading up to the trust anchor of the corresponding Access Certificate Authority  in the LoTE (see ISSU_33), in the ``x5c`` parameter in the JOSE header of the JSON Web Signature for the metadata.|  |
-|AS-AP-10-052 | ISSU_32a | Empty|  |
-|AS-AP-10-053 | ISSU_33 | For the verification of access certificates, a Wallet Unit SHALL accept only the trust anchors in all LoTE(s) for Access Certificate Authorities.| Access Certificate Authority LoTEs are explained in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)]. |
-|AS-AP-10-054 | ISSU_33a | For the verification of the registration certificates of Attestation Providers, a Wallet Unit SHALL accept only the trust anchors in all LoTE(s) for Providers of registration certificates.|  |
-|AS-AP-10-055 | ISSU_33b | A Wallet Provider SHALL support all Attestation Providers, except possibly if the attestation in question is a Strong User Authentication (SUA) attestation as meant in [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments) and the Wallet Provider chooses to not support processing of the transactional data associated with that attestation. Except for such cases, Wallet Units SHALL be capable of requesting the issuance of a QEAA, PuB-EAA, or non-qualified EAA from all Attestation Providers at the User's request.|  |
-|AS-AP-10-056 | ISSU_34 | A Wallet Unit SHALL authenticate and validate the access certificate of the Attestation Provider before requesting the issuance of an attestation. The Wallet Unit SHALL verify that the access certificate is authentic and is valid at the time of validation, and that the issuer of the access certificate is in the Access Certificate Authority LoTE(s), as documented in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].|  |
-|AS-AP-10-057 | ISSU_34a | Before requesting the issuance of an attestation, the Wallet Unit SHALL verify that the Attestation Provider is a registered QEAA Provider, PuB-EAA Provider, or EAA Provider. To do so, the Wallet Unit SHALL a) Inspect the ``entitlement`` member in the registration certificate of the Attestation Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``entitlement``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``entitlement`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the Attestation Provider is indeed registered as a QEAA Provider, PuB-EAA Provider, or EAA Provider, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of an attestation.| The information in the ``entitlement`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the Attestation Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful. |
-|AS-AP-10-058 | ISSU_34b | Before requesting the issuance of an attestation, the Wallet Unit SHALL verify whether the Provider properly registered for the issuance of the type of attestation that the User wants to obtain. To do so, the Wallet Unit SHALL a) Inspect the ``providesAttestations`` member in the registration certificate of the Attestation Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``providesAttestations``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``providesAttestations`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the Attestation Provider registered for the relevant type of attestation, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of an attestation.| The information in the ``providesAttestation`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the Attestation Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful. |
-|AS-AP-10-059 | ISSU_35 | A PID Provider or Attestation Provider SHALL ensure that all unique elements in a PID or attestation have a negligible chance of having the same value across all PIDs or attestations issued by that Provider. This SHALL include at least a) the salt used for hashing every attribute, b) the hash values of all attributes, c) the attestation identifier or index used for revocation purposes (if applicable), d) the attestation public key used for device binding (if applicable), and e) the value of the Attestation Provider signature.| a) The list of unique elements is based on [ISO/IEC 18013-5] and [SD-JWT VC]. b) This requirement can be achieved, for example, by ensuring that salt values, indexes and attestation identifiers are pseudo-random numbers generated by a cryptographically secure pseudo-random number generator (CSPRNG). |
-|AS-AP-10-060 | ISSU_35a | A Wallet Provider SHALL ensure that all unique elements in a  WIA or KA have a negligible chance of having the same value across all WIAs and KAs issued by that Wallet Provider and intended to be presented to different PID Providers or Attestation Providers. This SHALL include at least a) the attestation identifier or index, unless the per-KA index approach meant in WUA_28 is used,  b) the WIA or KA public key, and c) the value of the Wallet Provider signature over the WIA or KA.|  In other words, the following do not have to be unique: i) WIAs presented to the same PID Provider or Attestation Provider; and ii) the revocation reference in a KA under the type-shared index approach (see WUA_28). However, under the per-KA index approach (see WUA_28), the KA revocation reference is unique per KA or per KA-issuer pair and is subject to this requirement. |
-|AS-AP-10-061 | ISSU_35b | After issuing a PID, attestation, KA, or WIA, a PID Provider, Attestation Provider or Wallet Provider SHALL discard the values of all unique elements, including at least the ones mentioned in requirement ISSU_35 or ISSU_35a (as applicable) above, as well as any timestamps, as soon as they are no longer needed. The Provider SHALL NOT communicate these values to any other party inside or outside the EUDI Wallet ecosystem.|  |
-|AS-AP-10-062 | ISSU_36 | When issuing PIDs, attestations, or WIAs or KAs in a batch to a Wallet Unit, a PID Provider, Attestation Provider, or Wallet Provider SHALL ensure that the timestamps in these PIDs, attestations, or WIAs and KAs do not enable Relying Parties to conclude that they are part of the same batch (and therefore belong to the same User).| a) This can be done, for example, by making timestamps sufficiently imprecise that a high number of batches, each issued to a different Wallet Unit, share the same timestamp values (herd privacy). b) This requirement does not apply to timestamps included in the attestation as selectively disclosable attributes, see ISSU_36a. |
-|AS-AP-10-063 | ISSU_36a | If the exact time of the issuance of an attestation or the beginning or end of its validity period is relevant for the use case, the applicable Rulebook SHALL specify one or more selectively disclosable attribute(s) containing a timestamp with the required precision.| a) An example of this may be a vehicle registration attestation indicating the date and time (down to the second) at which a car changed ownership and therefore legal responsibility. b) This requirement ensures that requirement ISSU_36 can be complied with without running into challenges related to the use case. |
-|AS-AP-10-064 | ISSU_37 | A Wallet Provider SHALL ensure that its Wallet Solution supports the following methods for limiting the number of times a User can present the same technical PID or attestation to Relying Parties: Method A (Once-only attestations, as specified in requirement ISSU_43 - ISSU_47) and Method B (Limited-time attestations, as specified in requirement ISSU_48 - ISSU_50). In addition, a Wallet Provider MAY ensure that its Wallet Solution supports Method C (Rotating-batch attestations, as specified in requirement ISSU_51 - ISSU_54) or Method D (Per-Relying Party attestations, as specified in requirement ISSU_55 - ISSU_57).| Wallet Solutions, PID Providers, Attestation Providers, and Wallet Providers are free to define and use other methods as well. However, such other methods are out of scope of the ARF. |
-|AS-AP-10-065 | ISSU_38 | A PID Provider or Attestation Provider SHALL have a policy describing which method(s) (i.e,  A, B, C, and/or D) it will use to limit the number of times a Wallet Unit may present a single technical PID or attestation. For each supported method, the policy SHALL also specify how the values for respective parameters for that method, such as technical validity period and batch size, will be chosen. The goal of the policy SHALL be to ensure that the risk of linkability is mitigated to an acceptable level, given the (expected) usage of the logical PID or attestation by the User. To determine what an acceptable level of risk is, the PID Provider or Attestation Provider SHALL carry out a risk analysis regarding linkability.| a) If an Attestation Provider issues multiple attestation types, these requirements apply for each type of attestation separately. b) [Technical Specification 3] specifies that WIAs and KAs shall be sent to a PID Provider or Attestation Provider only once. In other words, for WIAs and KAs, the use of Method A is mandatory. |
-|AS-AP-10-066 | ISSU_39 | PID Providers and Attestation Providers SHALL include the ``credential_reuse_policy`` parameter, specified in section 4.2.4.2 of [ETSI TS 119 472-3], in their Credential Issuer Metadata to specify which of the methods A, B, C, or D the Wallet Unit must use for the logical PID or attestation issued. Indicated methods SHALL be ordered by preference.| See also ISSU_40. |
-|AS-AP-10-067 | ISSU_39a | Wallet Units SHALL support the ``credential_reuse_policy`` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3] and SHALL present each technical PID and attestation in accordance with the values set for this parameter by the relevant PID Provider or Attestation Provider.|  |
-|AS-AP-10-068 | ISSU_40 | A PID Provider or Attestation Provider SHALL indicate in their OpenID4VCI Issuer metadata that either method A or method B must be used for a given type of PID or attestation. In addition, a PID Provider or Attestation Provider MAY indicate that it prefers using method C and/or method D over method A or method B, by including the methods in the metadata in the appropriate order. In such a case, a Wallet Unit supporting method C and/or method D SHALL use that method, while a Wallet Unit not supporting these methods SHALL use method A or method B, as applicable.| a) This requirement implies that a PID Provider or Attestation Provider must not include both method A and method B in its metadata.  b) Example: An Attestation Provider indicates methods {D, C, A} in its metadata, in that order. A Wallet Unit that supports methods C and D (as well as A and B) then uses method D for this type of attestation. A Wallet Unit supporting methods A, B and C uses method C. A Wallet Unit supporting only methods A and B uses method A. |
-|AS-AP-10-069 | ISSU_40a | When implementing any of the methods mentioned in ISSU_37, a  Wallet Unit, PID Provider, or Attestation Provider SHALL comply with the applicable requirements in [ETSI TS 119 472-3], section 4.2.4.|  |
-|AS-AP-10-070 | ISSU_41 | To the maximum extent possible, Wallet Providers, PID Providers, and Attestation Providers SHALL ensure that Users do not notice which of the methods A, B, C, or D is used for their PIDs and attestations.|  |
-|AS-AP-10-071 | ISSU_42 | To the maximum extent possible, Wallet Providers, PID Providers, and Attestation Providers SHALL ensure that no User action is needed for the re-issuance of WIAs or KAs, PIDs, or attestations.| For the topic of re-issuance, see also the [Discussion Paper for Topic B](../../discussion-topics/b-re-issuance-and-batch-issuance-of-pids-and-attestations.md). |
-|AS-AP-10-072 | ISSU_43 | If Method A is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue technical PIDs or attestations in batches to the Wallet Unit. All PIDs or attestations in a batch SHALL have the same attribute values and the same technical validity period.|  |
-|AS-AP-10-073 | ISSU_44 | If Method A is used, the Wallet Unit SHALL present each technical PID or attestation only once to a Relying Party that requests the corresponding logical PID or attestation, except when it has fallen back to Method B as specified in ISSU_47.|  |
-|AS-AP-10-074 | ISSU_45 | If Method A is used, the Wallet Unit SHALL have a lower limit for the number of unused technical PIDs or attestations it holds for each logical PID or attestation, and SHALL request the issuance of a new batch when this limit is reached. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the value of the lower limit and the size of the batch to be requested, using the ``credential_reuse_policy`` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3].|  |
-|AS-AP-10-075 | ISSU_46 | If Method A is used and the Wallet Unit must request a new batch of technical PIDs or attestations but is not able to do so (for instance because it is offline), the Wallet Unit SHALL warn the User that they are about to lose the possibility to present the corresponding logical PID or attestation to Relying Parties, and request them to connect their device to the internet.|  |
-|AS-AP-10-076 | ISSU_47 | If Method A is used and the Wallet Unit has run out of unused technical PIDs or attestations, but is not able to request a new batch, it SHALL fall back to method B (see ISSU_48 - ISSU_50). This means that, when requested by a Relying Party or Attestation Provider, the Wallet Unit SHALL again present one of the already used technical PIDs or attestations. The Wallet Unit SHALL return to using method A as soon as it is able to go online and request a new batch of PIDs or attestations.|  |
-|AS-AP-10-077 | ISSU_48 | If Method B is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue a single technical PID or attestation to the Wallet Unit.|  |
-|AS-AP-10-078 | ISSU_49 | If Method B is used, the Wallet Unit SHALL present a technical PID or attestation multiple times to the same Relying Party or to different Relying Parties, when a Relying Party requests the corresponding logical PID or attestation.|  |
-|AS-AP-10-079 | ISSU_50 | If Method B is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to re-issue a technical PID or attestation some time before the one existing in the Wallet Unit expires. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the moment at which the Wallet Unit must request the re-issuance of a technical PID or attestation, relative to the expiration date of the existing one. To do so, the  PID Provider or Attestation Provider SHALL use the `credential_reuse_policy` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3].| It is the responsibility of the Relying Party receiving a PID or attestation to validate whether a presented technical PID or attestation is temporally valid. A Wallet Unit is allowed to present a PID or attestation even if its expiration date is in the past. |
-|AS-AP-10-080 | ISSU_51 | If Method C is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue technical PIDs or attestations in batches to the Wallet Unit. All PIDs or attestations in a batch SHALL have the same attribute values and the same technical validity period.|  |
-|AS-AP-10-081 | ISSU_52 | If Method C is used, the Wallet Unit SHALL present each technical PID or attestation in a batch once to a Relying Party that requests the corresponding logical PID or attestation, in a random order. When all PIDs or attestations in a batch have been presented once, the Wallet Unit SHALL reset the batch, and start presenting each PID or attestation in the batch again, in a random order. The Wallet Unit SHALL continue doing this until it receives a new batch, see ISSU_54.|  |
-|AS-AP-10-082 | ISSU_53 | Empty|  |
-|AS-AP-10-083 | ISSU_54 | If Method C is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to re-issue a batch of technical PIDs or attestations some time before the batch in the Wallet Unit expires. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the size of the batch and about the moment at which the Wallet Unit must request the re-issuance of a batch, relative to the expiration date of the existing batch.  To do so, the  PID Provider or Attestation Provider SHALL use the `credential_reuse_policy` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3].|  |
-|AS-AP-10-084 | ISSU_55 | If Method D is used, the Wallet Unit SHALL present a different technical PID or attestation to each different Relying Party that requests the corresponding logical PID or attestation. This means that it SHALL comply with all requirements for Method A for such Relying Parties.| This means the Wallet Unit presents an unused technical attestation to each new Relying Party that request the logical attestation, and it requests a new batch of technical attestations if the number of remaining unused attestations goes below the lower limit. If for some reason requesting a new batch is not successful and the Wallet Unit runs out of unused technical attestations, it re-uses one of the already used technical attestations. |
-|AS-AP-10-085 | ISSU_56 | If Method D is used and a given Relying Party requests attributes from a given logical  PID or attestation multiple times, the Wallet Unit MAY present the same technical PID or attestation to this Relying Party each time. If it does, it SHALL comply with all requirements for Method B for such a Relying Party.|  |
-|AS-AP-10-086 | ISSU_56a | Empty|  |
-|AS-AP-10-087 | ISSU_57 | If Method D is used, the Wallet Unit SHALL keep track of which technical PID or attestation it has presented to which Relying Party.| To do so, the Wallet Unit can use the unique RP identifier from the extension of the presentation request meant in RPRC_19a. |
-|AS-AP-10-088 | ISSU_57a | Empty|  |
-|AS-AP-10-089 | ISSU_58 | A Wallet Unit SHALL give its User the option to manually initiate a re-issuance process for any of the logical PIDs or attestations in their Wallet Unit. If the User uses this option, the Wallet Unit SHALL attempt to start the re-issuance process immediately, and SHALL notify the User if it did not succeed in requesting re-issuance.| a) This requirement does not apply for KAs or WIAs, since Users must not be involved in their management. b) In the case of a PID or an attestation bound to the WSCA/WSCD, the Wallet Unit will request the User to authenticate to the WSCA/WSCD (see WIAM_14). In case of an attestation bound to a keystore, no additional User authentication is needed, see WIAM_15c. |
-|AS-AP-10-090 | ISSU_59 | After a successful re-issuance, a Wallet Unit SHALL compare the attribute values of the re-issued technical PID or attestation with those of the existing technical PID or attestation, and SHALL notify the User in case of any differences.| a) This requirement does not apply for KAs or WIAs, since Users must not be involved in their management. b) The point of this requirement is to allow the User to detect errors in the attribute values in the new attestation. The follow-up process in case of errors is not defined. Presumably, the User can contact the Attestation Provider to discuss the fact that it apparently holds false attribute values for the User, and as a result, the Attestation Provider may decide to revoke the attestation. |
-|AS-AP-10-091 | ISSU_60 | A Wallet Unit SHALL gracefully handle situations in which re-issuance of a PID, attestation, KA, or WIA fails or is refused by the PID Provider, Attestation Provider, or Wallet Provider, for example by attempting a retry after an appropriate delay.|  |
-|AS-AP-10-092 | ISSU_61 | A Wallet Unit SHALL support PID or attestation first-time batch issuance with a single User authentication, regardless of the size of the batch.|  See also requirement WIAM_14. |
-|AS-AP-10-093 | ISSU_62 | If a technical PID or attestation was successfully re-issued because the value of one or more of its attributes was changed (including attributes being added or deleted), a Wallet Unit SHALL no longer present the (now obsolete) pre-existing technical PID or attestation, and SHOULD delete it.| a) It is up to the Wallet Unit, possibly using metadata provided by the PID Provider or Attestation Provider using the [OpenID4VCI] protocol, to determine the technical PID or attestation to be deleted. b) Additionally, per requirement VCR_09, the PID Provider or Attestation Provider revokes the pre-existing technical PID or attestation. |
-|AS-AP-10-094 | ISSU_63 | PID Providers and Attestation Providers, and Wallet Units SHALL support the features of [OpenID4VCI] enabling the re-issuance of PIDs and attestations.|  |
-|AS-AP-10-095 | ISSU_64 | PID Providers, Attestation Providers, and Wallet Units SHALL support the features of [OpenID4VCI] enabling the batch issuance of technical PIDs or attestations.|  |
-|AS-AP-10-096 | ISSU_65 | A PID Provider or an Attestation Provider of device-bound attestations SHALL verify that a re-issued technical PID or device-bound attestation is issued to the same Wallet Unit as the existing PID or attestation.| A PID Provider or Attestation Provider can do so by issuing a device-bound refresh token to the Wallet Instance during the original issuance of the PID or attestation, and requiring that the Wallet Instance uses it to obtain a fresh access token during re-issuance; see [OpenID4VCI] section 14.5. The PID Provider or Attestation Provider needs to be able to trust that the Wallet Instance handles the refresh tokens in a secure way, so that an attacker cannot use them from another Wallet Instance. This requires trust in the (continued) security and integrity of both the original Wallet Instance and the other Wallet Instance. This trust is provided by providing the PID Provider or Attestation Provider with a valid KA for the new Wallet Unit during re-issuance, and by enabling the PID Provider or Attestation Provider to verify that the original Wallet Unit has not been revoked. |
-|AS-AP-10-097 | ISSU_66 | Empty|  |
-|AS-AP-10-098 | ISSU_67 | A PID Provider SHALL have a policy governing all aspects of PID issuance and management. The policy SHALL comply with at least the extended normalised certificate policy (‘NCP+’) requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of PIDs rather than public key certificates.| A common dedicated policy for issuing PIDs may be developed in the future. If so, this requirement will be changed to refer to it. |
-|AS-AP-10-099 | ISSU_68 | PID Providers SHALL ensure that the certificates they use for signing PIDs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 4.|  |
-|AS-AP-10-100 | ISSU_69 | A QEAA Provider SHALL have a policy governing all aspects of QEAA issuance and management. The policy SHALL comply with at least the policy for qualified certificates issued to a natural person where the private key and the related certificate reside on a QSCD (‘QCP-n-qscd’) or qualified certificates issued to a legal person where the private key and the related certificate reside on a QSCD (‘QCP-l-qscd’) requirements as specified in [ETSI EN 319 411-2], insofar applicable for the issuance of QEAAs rather than public key certificates.| A common dedicated policy for issuing QEAAs may be developed in the future. If so, this requirement will be changed to refer to it. |
-|AS-AP-10-101 | ISSU_70 | QEAA Providers SHALL ensure that the certificates they use for signing QEAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 7.|  |
-|AS-AP-10-102 | ISSU_71 | Providers of non-qualified EAAs SHALL ensure that the certificates they use for signing EAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 6.|  |
-|AS-AP-10-103 | ISSU_72 | A PuB-EAA Provider SHALL have a policy governing all aspects of PuB-EAA issuance and management. The policy SHALL comply with at least the extended normalised certificate policy (‘NCP+’) requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of PuB-EAAs rather than public key certificates.| A common dedicated policy for issuing PuB-EAAs may be developed in the future. If so, this requirement will be changed to refer to it |
-|AS-AP-10-104 | ISSU_73 | PuB-EAAs Providers SHALL ensure that the certificates they use for signing PuB-EAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 8.|  |
-|AS-AP-12-001 | ARB_01 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL specify that one or more of the following two common format(s) must be used for these attestations: - The format specified in ISO/IEC 18013-5, see [ISO18013-5]. - The format specified in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC].|  |
-|AS-AP-18-001 | ACP_03 | A Cryptographic Binding of Attestations scheme SHOULD be implemented using a Zero-Knowledge Proof mechanism that satisfies the requirements specified in [Topic 53](./annex-2.02-high-level-requirements-by-topic.md#a2331-topic-53-zero-knowledge-proofs).|  |
-|AS-AP-18-002 | ACP_06 | Empty|  |
-|AS-AP-18-003 | ACP_07 | Before making a request according to ACP_05, an Attestation Provider SHALL verify that the new attestation indeed belongs to the User of the existing PID or attestation.|  |
-|AS-AP-28-001 | LP_02 | Empty|  |
-|AS-AP-42-001 | QTSPAS_01 | In accordance with [ETSI TS 119 478] and [Technical Specification 11], Member States SHALL define: - discovery mechanisms that enable QTSPs to request information about Authentic Sources or designated intermediaries recognised at the national level. This includes information regarding the attributes of a natural or legal person for which the Authentic Source or designated intermediary is considered a primary source, or for which it is recognised as authentic in accordance with Union law or national law, including administrative practices. - procedures for QTSPs to request the verification of attributes from Authentic Sources.|  |
-|AS-AP-42-002 | QTSPAS_02 | An Authentic Source in the public sector, or its designated intermediary, SHALL implement an interface complying with [ETSI TS 119 478] and [Technical Specification 11] for receiving verification requests and sending responses. For each received request, the Authentic Source SHALL - identify and authenticate the requestor in such a way that it can subsequently determine whether the requestor is a QTSP issuing qualified electronic attestation of attributes, for example by means of a lookup in the QTSP Trusted List. - authenticate the User and obtain their approval, if it is legally obliged to do so, in addition to the User authentication and approval already performed by the QTSP according to QTSPAS_08. - verify whether the attribute values claimed by the QTSP match the values held by the Authentic Source and, finally, - respond with one of the following for each attribute: +'match', if the attribute value held for this User by the Authentic Source is identical to the value claimed by the QTSP, + 'no match', if the attribute value held for this User by the Authentic Source is not identical to the value claimed by the QTSP, including if the Authentic Source is the authentic source for this attribute but does not hold a value for this User, +'unknown', if the Authentic Source is not the authentic source for this attribute.|  |
-|AS-AP-42-003 | QTSPAS_03 | An Authentic Source or designated intermediary SHALL respond to a verification request for attributes by any QTSP issuing qualified electronic attestation of attributes.|  |
-|AS-AP-42-004 | QTSPAS_04 | An Authentic Source or designated intermediary SHALL implement the technical specifications mentioned in QTSPAS_01, so that the QTSP will receive the result of the verification of the requested attributes as described in QTSPAS_02. If the verification is deferred, the response to the QTSP SHALL include the maximum time that it will take to verify the requested attributes, and a unique identifier that the QTSP SHALL use to obtain the result of the verification.|  |
-|AS-AP-42-005 | QTSPAS_05 | A QTSP SHALL send an attribute verification request directly to the Authentic Source or designated intermediary recognised at national level, after discovering it using the mechanisms specified the technical specifications mentioned in QTSPAS_01.|  |
-|AS-AP-42-006 | QTSPAS_06 | Member States SHALL specify the processes and mechanisms to designate the Authentic Sources or intermediaries recognised at national level in accordance with Union or national law, allowing these Authentic Sources or intermediaries to verify the attributes presented to them by QTSPs.|  |
-|AS-AP-42-007 | QTSPAS_07 | Empty|  |
-|AS-AP-42-008 | QTSPAS_07a | Empty|  |
-|AS-AP-42-009 | QTSPAS_08 | A QTSP SHALL obtain approval from the User to verify the authenticity of the attributes, before requesting the verification of those attributes by the relevant Authentic Source or designated intermediary.|  |
-|AS-AP-43-001 | EDP_11 | An Attestation Provider SHALL revoke an attestation if a corresponding embedded disclosure policy is added, changed, or deleted.|  |
-|AS-AP-44-001 | RPRC_13 | A Registrar MAY decide that, during the registration process for PID Providers, QEAA Providers, PuB-EAA Provider, or non-qualified EAA Providers, as specified in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), a Provider of registration certificates associated to the Member State Registrar must create and sign or seal a registration certificate and issue it to the registering party. If so, that registration certificate SHALL comply with the requirements in the technical specification mentioned in RPRC_02.|  |
-|AS-AP-44-002 | RPRC_14 | If, during registration, a PID Provider, QEAA Provider, PuB-EAA Provider, or non-qualified EAA Provider received a registration certificate, it SHALL distribute it to all its service supply points.| A service supply point is a system at which a Wallet Unit can start the process of requesting and obtaining a PID or attestation. |
-|AS-AP-44-003 | RPRC_15 | The contents of a registration certificate issued to a PID Provider, a QEAA Provider, a PuB-EAA Provider, or a non-qualified EAA Provider SHALL contain the type(s) of attestation that this entity intends to issue to Wallet Units.|  |
-|AS-AP-44-004 | RPRC_22 | If a PID Provider or Attestation Provider received a registration certificate (see RPRC_14), it SHALL include the registration certificate in its Credential Issuer metadata used in the common OpenID4VCI protocol referenced in ISSU_01 and the extension thereof in [ETSI TS 119 472-3]. The registration certificate SHALL be included in the metadata by value, not by reference.| This ensures that no external requests are necessary to validate the PID Provider or Attestation Provider, and that issuance transactions are atomic and self-contained. |
-|AS-AP-44-005 | RPRC_22a | A PID Provider or Attestation Provider SHALL include the the following information in its Credential Issuer metadata used in the common OpenID4VCI protocol referenced in ISSU_01 and the extension thereof in [ETSI TS 119 472-3]: a) the user-friendly name of the PID Provider or Attestation Provider, b) the unique identifier of the PID Provider or Attestation Provider, c) a User-friendly description of the PID(s) or attestation(s) issued by this PID Provider or Attestation Provider, d) the URL of the Registrar of the PID Provider or Attestation Provider, and e) the attestation type(s) that the PID Provider or Attestation Provider intends to issue to Wallet Units.|  |
-|AS-AP-44-006 | RPRC_23 | A Wallet Unit SHALL verify that the type of attestation it wants to request from the PID Provider or Attestation Provider is registered by the relevant Registrar, according to ISSU_24a for PID Providers and ISSU_34a for Attestation Providers.| Unlike for Relying Parties, see RPRC_21, the Wallet Unit always carries out this verification, regardless of the preference of the User set as per RPRC_16. |
-|AS-AP-51-001 | ZKP_04 | A ZKP scheme SHOULD support the derivation of a verifiable User pseudonym, by combining an attribute value that is unique for the User with Relying Party-specific context (e.g., the Relying Party identifier) In addition to the generic functions defined in ZKP_01, for this use case, a ZKP scheme SHALL provide support for the following functions: (i) generation of a request for the issuance of an attestation that includes a secret attribute unique to the User, without revealing this attribute to the Attestation Provider, (ii) generation of an attestation presentation that includes a verifiable pseudonym derived from the secret attribute, a Relying Party identifier, and context-related information.| See section 4.1.5 of the Discussion Paper for Topic G. |
+<div class="eudi-hlr" id="AS-AP-07-001" markdown>
+<div class="eudi-hlr__id">AS-AP-07-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_01
+{: .eudi-hlr__meta }
+
+A PID Provider, QEAA Provider, or PuB-EAA Provider SHALL use one of the following methods for revocation of a PID, QEAA, or PuB-EAA: - Only issue short-lived attestations having a validity period of 24 hours or less, such that revocation will never be necessary, - Use an Attestation Status List mechanism specified per VCR_11, or - Use an Attestation Revocation List mechanism specified per VCR_11.
+
+*Note: The 24-hour period originates from [ETSI EN 319 411-1] V1.4.1, requirement REV-6.2.4-03A. This requires that the process of revocation must take at most 24 hours. Consequently, revocation may make no sense if the attestation is valid for less than 24 hours, because it may reach the end of its validity period before it is revoked.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-002" markdown>
+<div class="eudi-hlr__id">AS-AP-07-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_01a
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL use the method specified in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md) for maintaining the revocation status of the underlying objects referenced in a WIA or key attestation.
+
+*Note: The 'underlying object' is the object that is actually revoked by revoking the WIA or key attestation, i.e., the Wallet Instance in case of a WIA and a WSCA/WSCD or keystore in case of a key attestation.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-003" markdown>
+<div class="eudi-hlr__id">AS-AP-07-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_02
+{: .eudi-hlr__meta }
+
+For non-qualified EAAs, the relevant Rulebook SHALL specify whether that type of EAA must be revocable. If a non-qualified EAA type must be revocable, the relevant Rulebook SHALL determine which of the methods mentioned in VCR_01 must be implemented by the relevant EAA Providers for the revocation of such an EAA.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-004" markdown>
+<div class="eudi-hlr__id">AS-AP-07-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_03
+{: .eudi-hlr__meta }
+
+If a PID or attestation is revocable, the PID Provider of a given PID, or the Attestation Provider of a given attestation, SHALL be the only party in the EUDI Wallet ecosystem responsible for executing the revocation of that PID or attestation.
+
+*Note: A PID Provider or Attestation Provider MAY outsource the operation of the revocation process to a third party.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-005" markdown>
+<div class="eudi-hlr__id">AS-AP-07-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_03a
+{: .eudi-hlr__meta }
+
+The Wallet Provider of a given WIA or KA SHALL be the only party in the EUDI Wallet ecosystem responsible for maintaining the revocation status of the underlying object attested in that WIA or KA.
+
+*Note: A Wallet Provider MAY outsource the operation of the revocation process to a third party.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-006" markdown>
+<div class="eudi-hlr__id">AS-AP-07-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_04
+{: .eudi-hlr__meta }
+
+A PID Provider, Attestation Provider or Wallet Provider that revoked a PID, attestation, WIA, or KA SHALL NOT reverse the revocation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-007" markdown>
+<div class="eudi-hlr__id">AS-AP-07-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_05
+{: .eudi-hlr__meta }
+
+If a PID, attestation, WIA, or KA is revocable, the PID Provider, Attestation Provider, or Wallet Provider SHALL have a policy specifying under which conditions a PID, attestation, WIA, or KA it issued will be revoked.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-008" markdown>
+<div class="eudi-hlr__id">AS-AP-07-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_06
+{: .eudi-hlr__meta }
+
+If a PID or attestation is revocable, the PID Provider or Attestation Provider SHALL revoke a PID or attestation when its security has been compromised.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-009" markdown>
+<div class="eudi-hlr__id">AS-AP-07-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_07
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL revoke the Wallet Instance upon the explicit request of the User to revoke their Wallet Unit.
+
+*Note: See also WURevocation_07 and _10.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-010" markdown>
+<div class="eudi-hlr__id">AS-AP-07-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_07a
+{: .eudi-hlr__meta }
+
+If a PID is revocable, the PID Provider SHALL revoke that PID upon the explicit request of the User to whom the PID was issued.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-011" markdown>
+<div class="eudi-hlr__id">AS-AP-07-011<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_07b
+{: .eudi-hlr__meta }
+
+If an attestation is revocable, the Attestation Provider SHOULD revoke that attestation upon the explicit request of the User to whom the attestation was issued.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-012" markdown>
+<div class="eudi-hlr__id">AS-AP-07-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_07c
+{: .eudi-hlr__meta }
+
+If a PID is revocable, the PID Provider SHALL revoke that PID if the Wallet Unit on which it resides is revoked, in compliance with requirement WURevocation_18 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-013" markdown>
+<div class="eudi-hlr__id">AS-AP-07-013<span class="kw-may">MAY</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_07d
+{: .eudi-hlr__meta }
+
+If an attestation is revocable, the Attestation Provider MAY revoke that attestation if the Wallet Unit on which it resides is revoked, in compliance with requirement WURevocation_19 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-014" markdown>
+<div class="eudi-hlr__id">AS-AP-07-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_07e
+{: .eudi-hlr__meta }
+
+If a Wallet Provider uses the per-KA approach for key attestation revocation (see WUA_28), it SHALL revoke a WSCD or keystore upon the explicit request of the User to revoke their WSCD or keystore.
+
+*Note: a) The most likely cause of such a request would be that the WSCD or keystore is a local external smart card and the User lost their WSCD or keystore. b) In contrast, under the type-shared index approach (see WUA_28), revoking the WSCD or keystore is not a per-Wallet Unit action that can be triggered by user requests. c) See also WURevocation_07a.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-015" markdown>
+<div class="eudi-hlr__id">AS-AP-07-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_08
+{: .eudi-hlr__meta }
+
+If a PID is revocable, the PID Provider SHALL revoke a PID upon the death of the natural person who is the subject of the PID.
+
+*Note: a) In addition, in these circumstances the PID Provider also requests the Wallet Provider to revoke the Wallet Unit, see WURevocation_11. b) The topic of Wallet Units for legal persons, possibly containing a legal-person PID, has has been removed from this ARF in view of the development of a separate business wallet.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-016" markdown>
+<div class="eudi-hlr__id">AS-AP-07-016<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_09
+{: .eudi-hlr__meta }
+
+If a technical PID or attestation is revocable, the PID Provider or Attestation Provider SHALL revoke that PID or attestation if the value of one or more of the attributes in the corresponding logical PID or attestation was changed (including attributes being added or deleted) and it is still valid for at least 24 hours. Subsequently, if the User's contact details are known, the PID Provider or Attestation Provider SHOULD, via an out-of-band manner, notify the User about the revocation and ask the User to request re-issuance of the PID or attestation using their Wallet Unit.
+
+*Note: If the value of the attributes is determined by a party different from the Provider, such as an Authentic Source, the Provider is responsible for ensuring that this third party notifies them about such changes.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-017" markdown>
+<div class="eudi-hlr__id">AS-AP-07-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_10
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL implement the attestation revocation mechanisms specified per VCR_11 in their Wallet Solutions.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-018" markdown>
+<div class="eudi-hlr__id">AS-AP-07-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_11
+{: .eudi-hlr__meta }
+
+The Commission SHALL create or reference technical specifications providing all necessary details for PID Providers, Attestation Providers, and Wallet Providers to implement an Attestation Status List mechanism or an Attestation Revocation List mechanism for the PIDs, attestations, and WIAs and KAs they issue. These technical specifications SHALL also contain all details necessary for Relying Party Instances, Relying Parties, and Wallet Units interacting with other Wallet Units to use these mechanisms to verify the revocation status of PIDs, attestations, and WIAs and KAs.
+
+*Note: 'Attestation Status List' and 'Attestation Revocation List' are specific mechanisms, defined in Annex 1. Attestation Revocation Lists are sometimes referred to as 'Identifier Lists'.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-019" markdown>
+<div class="eudi-hlr__id">AS-AP-07-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_12
+{: .eudi-hlr__meta }
+
+If a Relying Party decides it needs to be able to verify the revocation status of PIDs or attestations, it SHALL support both the Attestation Status List mechanism and the Attestation Revocation List mechanism specified per VCR_11.
+
+*Note: Per VCR_13, it is recommended but not mandatory for a Relying Party to verify whether a PID or attestation is revoked.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-020" markdown>
+<div class="eudi-hlr__id">AS-AP-07-020<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_12a
+{: .eudi-hlr__meta }
+
+A PID Provider or Attestation Provider SHALL support both the Attestation Status List mechanism and the Attestation Revocation List mechanism specified per VCR_11 for verifying the revocation status of a WIA or KA.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-021" markdown>
+<div class="eudi-hlr__id">AS-AP-07-021<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_13
+{: .eudi-hlr__meta }
+
+A Relying Party Instance SHOULD verify the revocation status of a PID or attestation upon obtaining it from a Wallet Unit, following the steps specified per VCR_11. When a Relying Party considers deviating from this recommendation by not performing revocation checking, it SHALL perform a risk analysis considering all relevant factors for the use case, including risks to the User and risks to the Relying Party itself.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-022" markdown>
+<div class="eudi-hlr__id">AS-AP-07-022<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_14
+{: .eudi-hlr__meta }
+
+A Relying Party SHALL perform a risk analysis considering all relevant factors for the use case, including risks to the User and risks to the Relying Party itself, to determine whether it will accept or refuse a PID or attestation in case no reliable information regarding the revocation status of that PID or attestation is available.
+
+*Note: Examples of conditions under which no reliable revocation information is available are 1) The attestation does not contain revocation information (because it is not revocable). 2) The Relying Party Instance is offline and any cached status information is no longer valid. 3) The latest attestation status lists or attestation identifier lists provided by the PID Provider or Attestation Provider (i.e., available online) are no longer valid. 4) The Relying Party Instance is offline, but the use case requires up-to-date revocation information (instead of trusting cached information that is still valid.)*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-023" markdown>
+<div class="eudi-hlr__id">AS-AP-07-023<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_15
+{: .eudi-hlr__meta }
+
+A Relying Party Instance SHOULD NOT request the relevant Attestation Status List or Attestation Revocation List each time an attestation is presented to it by a Wallet Unit. Rather, the Relying Party operating the Relying Party Instance SHOULD download each new version of the list once, at a time and from a location unrelated to the presentation of a PID or attestation by a User. The Relying Party SHOULD then distribute the list to all of its Relying Party Instances, using an Relying Party-internal distribution mechanism. Each Relying Party Instance SHOULD cache the list, so that it can perform revocation checks without making an online request. The Relying Party SHOULD perform a risk analysis to determine the frequency with which it will download the revocation lists and the maximum caching period its Relying Party Instances will use.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-024" markdown>
+<div class="eudi-hlr__id">AS-AP-07-024<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_16
+{: .eudi-hlr__meta }
+
+A PID Provider, Attestation Provider or Wallet Provider SHALL NOT require the Relying Party or Relying Party Instance to authenticate itself before downloading an Attestation Status List or Attestation Revocation List.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-025" markdown>
+<div class="eudi-hlr__id">AS-AP-07-025<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_17
+{: .eudi-hlr__meta }
+
+When using an Attestation Status List for revocation, the PID Provider, Attestation Provider or Wallet Provider SHALL randomly assign the index for each PID or attestation, to prevent this index from becoming a correlator.
+
+*Note: Randomly assigning indices within a bitstring or byte array is more complicated than creating random identifiers (e.g. serial numbers) for attestations, as is needed for an Attestation Revocation List. This is because duplicate indices and unnecessarily long bitstrings or byte arrays must be prevented.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-026" markdown>
+<div class="eudi-hlr__id">AS-AP-07-026<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_18
+{: .eudi-hlr__meta }
+
+When using an Attestation Status List for revocation, the PID Provider, Attestation Provider, or Wallet Provider SHALL represent a sufficiently large number of PIDs, attestations, WIAs, or KAs on each Attestation Status List to ensure herd privacy.
+
+*Note: In this context, herd privacy means that if an entity requests a particular status list, the PID Provider, Attestation Provider, or Wallet Provider is not able to deduce which PID, attestation, WIA, or KA (likely) was presented to that entity. Complying with this requirement may be difficult in case the number of PIDs, attestations, WIAs, or KAs to be represented on the list is small. In such a case, decoy entries can be added to the list to obfuscate the real number of referenced PIDs, attestations, WIAs, or KAs.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-07-027" markdown>
+<div class="eudi-hlr__id">AS-AP-07-027<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: VCR_19
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHOULD regularly check the revocation status of its PIDs and attestations. In addition, the Wallet Unit SHOULD regularly check whether itself or any WSCD or keystore it uses has been revoked. In case of any revocation, the Wallet Unit SHALL notify the User accordingly.
+
+*Note: A Wallet Unit can check its own revocation status using its WIAs, and the revocation status of its WSCD and keystores using its key attestations.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-001" markdown>
+<div class="eudi-hlr__id">AS-AP-10-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_01a
+{: .eudi-hlr__meta }
+
+PID Providers and Attestation Providers SHALL support the OpenID4VCI protocol specified in [OpenID4VCI], as profiled in Sections 4 and 6 of [HAIP], and with additions and changes as documented in this Annex (see e.g. this Topic and [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)) and in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+*Note: For clarity: in [HAIP] v1.0, Section 6 implies that PID Providers and Attestation Providers must comply with the applicable requirements in [OpenID4VCI] Annex A.2 when issuing an attestation in ISO/IEC 18013-5-compliant format, and with the applicable requirements in [OpenID4VCI] Annex A.3 when issuing an attestation in SD-JWT VC format.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-002" markdown>
+<div class="eudi-hlr__id">AS-AP-10-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_02
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that their Wallet Solution supports the attestation formats specified in ISO/IEC 18013-5, see [ISO18013-5], and in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC], with additions and changes as documented in this Annex and in future technical specifications created by or on behalf of the Commission.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-003" markdown>
+<div class="eudi-hlr__id">AS-AP-10-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_03
+{: .eudi-hlr__meta }
+
+Wallet Units, PID Providers, and Attestation Providers SHALL support the [W3C Digital Credentials API](https://wicg.github.io/digital-credentials/) for the issuance of PIDs and attestations.
+
+*Note: This requirement implies that the following conditions will be satisfied: a) the DC API specification will become a W3C Recommendation, b) this specification will comply with the principles outlined in [Section 4.4.3.1](../../architecture-and-reference-framework-main.md#4431-introduction) of the ARF main document, c) this specification will be broadly supported by relevant browsers and operating systems, and d) the [OpenID4VCI] standard will specify how to use OpenID4VCI with the DC API.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-004" markdown>
+<div class="eudi-hlr__id">AS-AP-10-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_04
+{: .eudi-hlr__meta }
+
+The OpenID4VCI protocol referenced in requirement ISSU_01, or an EUDI Wallet-specific extension or profile thereof, SHALL enable PID Providers and Attestation Provider to issue to a Wallet Unit a batch of multiple PIDs or attestations that are simultaneously valid and contain the same attributes.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-005" markdown>
+<div class="eudi-hlr__id">AS-AP-10-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_05
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL support a process to activate a newly issued PID, in accordance with the requirements for LoA High in [Commission Implementing Regulation (EU) 2015/1502](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32015R1502) Section 2.2.2. The Wallet Unit SHALL NOT allow a User to use a non-activated PID.
+
+*Note: a) The goal of the activation process is to verify that the PID was delivered into the Wallet Unit and WSCA/WSCD of the User who is the subject of the PID. b) This requirement is not applicable for QEAAs, PuB-EAAs or non-qualified EAAs, since these are not identity means in the sense of Commission Implementing Regulation (EU) 2015/1502.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-006" markdown>
+<div class="eudi-hlr__id">AS-AP-10-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_06
+{: .eudi-hlr__meta }
+
+After a Wallet Unit receives a PID or an attestation from a PID Provider or Attestation Provider, it SHALL verify that the PID or attestation it received matches the PID or attestation requested by the Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-007" markdown>
+<div class="eudi-hlr__id">AS-AP-10-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_07
+{: .eudi-hlr__meta }
+
+After a Wallet Unit receives a PID from a PID Provider, it SHALL validate the signature of the PID using a trust anchor of the PID Provider provided in a LoTE made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].
+
+*Note: The Wallet Provider and PID Provider may be the same entity. In such a case, the remote WSCD used by the Wallet Provider may be the same hardware HSM that is also used by the PID Provider to sign PIDs. In such a situation, this requirement may look superfluous, since the same HSM would generate the signature and verify it. However, this is not true, since for security reasons the PID Provider and Wallet Provider must use proper partitioning and logical key segregation within the HSM. Therefore, this requirement also applies in such a situation.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-008" markdown>
+<div class="eudi-hlr__id">AS-AP-10-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_08
+{: .eudi-hlr__meta }
+
+After a Wallet Unit receives a QEAA from a QEAA Provider, it SHALL validate the qualified signature of the QEAA in accordance with Art. 32 of the [European Digital Identity Regulation]. For the verification, the Wallet Unit SHALL use a trust anchor provided in a QEAA Provider Trusted List made available in accordance with [Art. 22](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ.L_.2014.257.01.0073.01.ENG#d1e2162-73-1) of the [European Digital Identity Regulation].
+
+*Note: a) Requirements ISSU_07 to ISSU_10 are equivalent to requirements OIA_12 to OIA_15 in [Topic 1](./annex-2.02-high-level-requirements-by-topic.md#a231-topic-1-accessing-online-services-with-a-wallet-unit). b) These requirements imply that a Wallet Instance must be aware whether the attestation it is requesting from an issuer is a PID, a QEAA, a PuB-EAA, or a non-qualified EAA. These requirements also imply that the Wallet Unit must store trust anchors in such a way that, when it receives an issued attestation, it is able to distinguish between trust anchors usable either for PIDs, for QEAAs, for PuB-EAAs, or for non-qualified EAAs.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-009" markdown>
+<div class="eudi-hlr__id">AS-AP-10-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_09
+{: .eudi-hlr__meta }
+
+After a Wallet Unit receives a PuB-EAA from a PUB-EAA Provider, it SHALL validate the signature of a PuB-EAA using a trust anchor provided in a PUB-EAA Provider Trusted List made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-010" markdown>
+<div class="eudi-hlr__id">AS-AP-10-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_10
+{: .eudi-hlr__meta }
+
+After a Wallet Unit receives a non-qualified EAA from an EAA Provider, it SHALL validate the signature of the EAA if it has access to the trust anchors of the EAA Provider.
+
+*Note: For a non-qualified EAA, an Attestation Rulebook may be available, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)], explaining how EAA Providers distribute their trust anchors. However, it is not required for Wallet Units to be in possession of the trust anchors of all non-qualified EAA Providers, even when an Attestation Rulebook is available.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-011" markdown>
+<div class="eudi-hlr__id">AS-AP-10-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_11
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL request the User's approval before storing a PID or attestation obtained from a PID Provider or Attestation Provider. When requesting approval, the Wallet Instance SHALL display the contents of the PID or attestation to the User. The Wallet Instance SHALL also inform the User about the identity of the PID Provider or Attestation Provider, using the subject information in the PID Provider's or Attestation Provider's access certificate.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-012" markdown>
+<div class="eudi-hlr__id">AS-AP-10-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_11a
+{: .eudi-hlr__meta }
+
+In case a PID or attestation is issued in batches, the Wallet Unit SHALL verify that  all PIDs and attestations in a batch have the same attribute values and the same technical validity period.
+
+*Note: PIDs and attestations are issued in batches when Method A, Method B, or Method D is used, see ISSU_37, ISSU_43, ISSU_51.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-013" markdown>
+<div class="eudi-hlr__id">AS-AP-10-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_11b
+{: .eudi-hlr__meta }
+
+In case one or more of the verifications in ISSU_06 - ISSU_11a fail, the Wallet Unit SHALL immediately delete the PID or attestation it received. The Wallet Instance SHALL notify the User about the fact that issuance of the PID or attestation was not successful, including the reason for this failure.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-014" markdown>
+<div class="eudi-hlr__id">AS-AP-10-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_12
+{: .eudi-hlr__meta }
+
+A PID Provider or Attestation Provider SHALL offer its PIDs or attestations in all formats required in the PID Rulebook or the applicable Attestation Rulebook, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)].
+
+*Note: Examples include the mdoc format specified in [ISO/IEC 18013-5] and the SD-JWT VC-format specified in [SD-JWT VC].*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-015" markdown>
+<div class="eudi-hlr__id">AS-AP-10-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_12a
+{: .eudi-hlr__meta }
+
+When a User instructs their Wallet Unit to request a PID or attestation from a PID Provider or Attestation Provider, the Wallet Unit SHALL request that PID or attestation in all formats offered by the PID Provider or Attestation Provider.
+
+*Note: Examples include the mdoc format specified in [ISO/IEC 18013-5] and the SD-JWT VC-format specified in [SD-JWT VC].*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-016" markdown>
+<div class="eudi-hlr__id">AS-AP-10-016<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_12b
+{: .eudi-hlr__meta }
+
+The WSCA/WSCD or a keystore SHALL generate a new key pair for a new PID or attestation on request of the Wallet Instance, unless that PID or attestation is issued synchronously in a remote HSM architecture. This generation request MAY be done either prior to the issuance of any PID or attestation, or during the issuance process.
+
+*Note: a) See also WUA_05 and WUA_05a. b) In case of synchronous issuing in a remote HSM architecture, re-use of an existing key pair within a limited period of time can be acceptable, based on the PID Provider's or Attestation Provider's issuance security policy. This is similar to a choice between Method A or Method B (see ISSU_37 and ISSU_38) when issuing PIDs or attestations non-synchronously.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-017" markdown>
+<div class="eudi-hlr__id">AS-AP-10-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_12c
+{: .eudi-hlr__meta }
+
+The expiration date of a PID SHALL be no later than the end of the revocation maintenance periods of the WIA and the KA presented as part of the PID issuance process.
+
+*Note: This requirement is an implication of WURevocation_18 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation) and WUA_29-WUA_31. If the PID would be valid beyond the period for which the Wallet Provider has committed to maintaining the revocation status of the Wallet Instance and the WSCD or keystore, the PID Provider would not be able to fulfil its obligation to regularly check whether the Wallet Instance and WSCD or keystore have been revoked for the full PID validity period.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-018" markdown>
+<div class="eudi-hlr__id">AS-AP-10-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_12d
+{: .eudi-hlr__meta }
+
+If an Attestation Provider supports revocation chaining for its attestations per WURevocation_19 in [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation), the expiration date of an attestation SHALL be no later than the end of the revocation maintenance periods of the WIA and the KA (if applicable) presented as part of the attestation issuance process.
+
+*Note: See note in ISSU_12c.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-019" markdown>
+<div class="eudi-hlr__id">AS-AP-10-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_13
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL ensure that at least one PID Provider is willing to issue a PID complying with [PID Rulebook] to Users of the Wallet Units it provides.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-020" markdown>
+<div class="eudi-hlr__id">AS-AP-10-020<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_14
+{: .eudi-hlr__meta }
+
+A PID Provider SHALL ensure that all PIDs it issues to Wallet Units comply with the requirements specified in [PID Rulebook].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-021" markdown>
+<div class="eudi-hlr__id">AS-AP-10-021<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_15
+{: .eudi-hlr__meta }
+
+A PID Provider SHALL support the OpenID4VCI protocol referenced in ISSU_01 for issuing PIDs.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-022" markdown>
+<div class="eudi-hlr__id">AS-AP-10-022</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_16
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-023" markdown>
+<div class="eudi-hlr__id">AS-AP-10-023<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_17
+{: .eudi-hlr__meta }
+
+A PID Provider SHALL implement device binding for all PIDs it issues, meaning it SHALL ensure that a PID is cryptographically bound to the WSCA/WSCD included in the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation).
+
+*Note: Device binding is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT-VC].*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-024" markdown>
+<div class="eudi-hlr__id">AS-AP-10-024<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_18
+{: .eudi-hlr__meta }
+
+A PID Provider SHALL verify the identity of the subject of the PID in compliance with Level of Assurance (LoA) High requirements.
+
+*Note: These requirements will be determined by the relevant eID scheme.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-025" markdown>
+<div class="eudi-hlr__id">AS-AP-10-025<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_18a
+{: .eudi-hlr__meta }
+
+A PID Provider SHALL ensure that the attributes attested in the PID issued are valid for the identified PID subject at any point of time of PID validity.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-026" markdown>
+<div class="eudi-hlr__id">AS-AP-10-026<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_19
+{: .eudi-hlr__meta }
+
+For the verification of a WIA or KA, a PID Provider SHALL accept the trust anchors in the Wallet Provider LoTE(s) it needs.
+
+*Note: a) The Wallet Provider LoTE is explained in [Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates). b) It is not mandatory for a PID Provider to accept all Wallet Provider LoTEs, if there are multiple. This is because it is not mandatory for a PID Provider to accept all certified Wallet Solutions in the EUDI Wallet ecosystem. Each PID Provider will choose which LoTEs they need to subscribe to.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-027" markdown>
+<div class="eudi-hlr__id">AS-AP-10-027<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_19a
+{: .eudi-hlr__meta }
+
+A PID Provider SHALL support all Wallet Solutions recognised under the corresponding notified eID scheme, meaning that it is willing and able to issue a PID to a Wallet Unit on request of the User.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-028" markdown>
+<div class="eudi-hlr__id">AS-AP-10-028<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_20
+{: .eudi-hlr__meta }
+
+To inform its potential PID subjects about the Wallet Solution(s) they can use for requesting a PID, a PID Provider SHALL publish a list of supported Wallet Solutions in such a way that it can be easily found, for example on the PID Provider's website.
+
+*Note: This a policy requirement rather than a technical requirement.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-029" markdown>
+<div class="eudi-hlr__id">AS-AP-10-029<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_21
+{: .eudi-hlr__meta }
+
+Before issuing a PID, a PID Provider SHALL verify the Wallet Unit's WIA and KA using a trust anchor registered in the Wallet Provider LoTE. Moreover, it SHALL verify that the Wallet Instance referenced in the WIA has not been revoked, and that the WSCD referenced in the KA has not been revoked.
+
+*Note: a) For WIAs and KAs, see [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation) and [Topic 38](./annex-2.02-high-level-requirements-by-topic.md#a2322-topic-38-wallet-unit-revocation). b) [CIR 2024/2977], Article 3 (9), also allows another authentication mechanism in accordance with an electronic identity scheme notified at assurance level high. However, the ARF does not further specify such other authentication mechanisms, which means that in general they will not be interoperable.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-030" markdown>
+<div class="eudi-hlr__id">AS-AP-10-030<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_22
+{: .eudi-hlr__meta }
+
+A PID Provider SHALL sign its Credential Issuer metadata as specified in section 12.2.3 of [OpenID4VCI]. To do so, the PID Provider SHALL use the private key corresponding to the public key in its access certificate. The PID Provider SHALL include its access certificate, as well as all intermediate certificate(s) leading up to the trust anchor of the corresponding Access Certificate Authority (see ISSU_33) in the LoTE, in the ``x5c`` parameter in the JOSE header of the JSON Web Signature for the metadata.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-031" markdown>
+<div class="eudi-hlr__id">AS-AP-10-031</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_22a
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-032" markdown>
+<div class="eudi-hlr__id">AS-AP-10-032</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_22b
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-033" markdown>
+<div class="eudi-hlr__id">AS-AP-10-033<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_23
+{: .eudi-hlr__meta }
+
+For the verification of a PID Provider's access certificates, a Wallet Unit SHALL accept the trust anchors in the LoTE(s) of Access Certificate Authorities it needs.
+
+*Note: a) Access Certificate Authority LoTEs are explained in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-034" markdown>
+<div class="eudi-hlr__id">AS-AP-10-034<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_23a
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL support at least one PID Provider, meaning that its Wallet Units SHALL be capable of requesting the issuance of a PID from these PID Provider(s), and that the Wallet Provider has agreed with the PID Provider(s) that the PID Provider(s) will process such a request according to the agreed rules and procedures.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-035" markdown>
+<div class="eudi-hlr__id">AS-AP-10-035<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_23b
+{: .eudi-hlr__meta }
+
+Prior to or during installation of a Wallet Instance, the Wallet Provider SHALL notify the User about the PID Provider(s) that are supported by the Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-036" markdown>
+<div class="eudi-hlr__id">AS-AP-10-036<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_24
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL authenticate and validate the access certificate of the PID Provider before requesting the issuance of a PID. The Wallet Unit SHALL verify that the access certificate is authentic and is valid at the time of validation, and that the issuer of the access certificate is included in an Access Certificate Authority LoTE.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-037" markdown>
+<div class="eudi-hlr__id">AS-AP-10-037<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_24a
+{: .eudi-hlr__meta }
+
+Before requesting the issuance of a PID, the Wallet Unit SHALL verify that the PID Provider is indeed a registered PID Provider. To do so, the Wallet Unit SHALL a) Inspect the ``entitlement`` member in the registration certificate of the PID Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``entitlement``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``entitlement`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the PID Provider is indeed registered as a PID Provider, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of a PID.
+
+*Note: The information in the ``entitlement`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the PID Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-038" markdown>
+<div class="eudi-hlr__id">AS-AP-10-038<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_24b
+{: .eudi-hlr__meta }
+
+Before requesting the issuance of a PID, the Wallet Unit SHALL verify whether the PID Provider properly registered for the issuance of PIDs. To do so, the Wallet Unit SHALL a) Inspect the ``providesAttestations`` member in the registration certificate of the PID Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``providesAttestations``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``providesAttestations`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the PID Provider registered for the issuance of PIDs, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of a PID.
+
+*Note: a) The information in the ``providesAttestations``  member included in the Credential Issuer Metadata (3rd option above) is self-declared by the PID Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful. b) It may be argued that this verification is superfluous, since an entity registered as a PID Provider (ISSU_24a) by definition is registered for issuing PIDs. However, this verification was added to ensure that Wallet Unit can use the same verification process for PIDs as for other attestations (see ISSU_34b), as well as to ensure that in the future, it is possible to distinguish between different types of PID if needed, where not all PID Providers are registered to issue all types of PID.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-039" markdown>
+<div class="eudi-hlr__id">AS-AP-10-039<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_25
+{: .eudi-hlr__meta }
+
+An Attestation Provider SHALL ensure all attestations issued to Wallet Units comply with the requirements specified in the applicable Rulebook, as described in [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-040" markdown>
+<div class="eudi-hlr__id">AS-AP-10-040<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_26
+{: .eudi-hlr__meta }
+
+An Attestation Provider SHALL support the OpenID4VCI protocol referenced in ISSU_01 for issuing attestations.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-041" markdown>
+<div class="eudi-hlr__id">AS-AP-10-041<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_27
+{: .eudi-hlr__meta }
+
+An Attestation Provider SHOULD implement device binding for all attestations it issues. If an issued attestation is device-bound, the Attestation Provider SHALL ensure that the attestation is cryptographically bound to a WSCA/WSCD or a keystore available to the Wallet Unit, as specified in [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation).
+
+*Note: a) Device binding is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT-VC]. b) Implementing mdoc authentication is mandatory in [ISO/IEC 18013-5] and therefore, it is mandatory for attestations complying with that standard. c) See ISSU_27d.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-042" markdown>
+<div class="eudi-hlr__id">AS-AP-10-042<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_27a
+{: .eudi-hlr__meta }
+
+If the subject of the attestation is a natural person, an Attestation Provider SHALL verify the identity of the subject of the attestation, in compliance with applicable requirements and in accordance with relevant standards or Implementing Regulations.
+
+*Note: Not every attestation has a natural person as its subject. For example, a holiday voucher may be valid for any User that can present it to a Relying Party and therefore has no subject. This is comparable to the concept of a 'bearer token'.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-043" markdown>
+<div class="eudi-hlr__id">AS-AP-10-043<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_27b
+{: .eudi-hlr__meta }
+
+If applicable, an Attestation Provider SHALL ensure that the attributes attested in the attestation issued are valid for the identified attestation subject.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-044" markdown>
+<div class="eudi-hlr__id">AS-AP-10-044<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_27c
+{: .eudi-hlr__meta }
+
+The Attestation Provider SHALL verify that the User requesting the attestation has the right to receive it.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-045" markdown>
+<div class="eudi-hlr__id">AS-AP-10-045<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_27d
+{: .eudi-hlr__meta }
+
+An Attestation Provider issuing device-bound attestations SHALL indicate the desired level of security for the private key storage and for User authentication in its Credential Issuer metadata, according to [OpenID4VCI] section 12.2.4 and Appendix D.2.
+
+*Note: See also WIAM_14b, WIAM_14c, and WUA_05 and WUA_05a.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-046" markdown>
+<div class="eudi-hlr__id">AS-AP-10-046<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_28
+{: .eudi-hlr__meta }
+
+For the verification of a WIA or KA, an Attestation Provider SHALL accept the trust anchors in the Wallet Provider LoTE.
+
+*Note: The Wallet Provider LoTE is explained in [Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-047" markdown>
+<div class="eudi-hlr__id">AS-AP-10-047<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_29
+{: .eudi-hlr__meta }
+
+A QEAA Provider or PuB-EAA Provider SHALL support all Wallet Solutions, except in case the attestation in question is a Strong User Authentication (SUA) attestation as meant in [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments) and the Wallet Provider does not support processing of the transactional data associated with the SUA attestation. Except for such cases, A QEAA Provider or PuB-EAA Provider SHALL NOT discriminate between Wallet Solutions when processing a request for the issuance of an attestation.
+
+*Note: This requirement is not applicable for non-qualified EAA Providers. For example, a non-qualified EAA Provider may choose to issue attestations in the format specified in [W3C VCDM], see ARB_01a. In that case, it will support only those Wallet Solutions that have implemented this attestation format.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-048" markdown>
+<div class="eudi-hlr__id">AS-AP-10-048<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_30
+{: .eudi-hlr__meta }
+
+Before issuing a device-bound attestation, an Attestation Provider SHALL verify the Wallet Unit's key attestation using a trust anchor registered in the Wallet Provider LoTE. Moreover, it SHALL verify that the WSCD or keystore referenced in the KA has not been revoked.
+
+*Note: This requirement applies specifically to the KA received during device-bound attestation issuance. The corresponding requirement for verifying the WIA is ISSU_30a.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-049" markdown>
+<div class="eudi-hlr__id">AS-AP-10-049<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_30a
+{: .eudi-hlr__meta }
+
+Before issuing an attestation, an Attestation Provider SHALL: - verify that the Wallet Provider mentioned in the Wallet Unit's WIA is present in the Wallet Provider LoTE. - authenticate and validate the WIA using the trust anchor(s) registered for the Wallet Provider in that LoTE.
+
+*Note: This requirement applies to both device-bound and non-device-bound attestations*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-050" markdown>
+<div class="eudi-hlr__id">AS-AP-10-050</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_31
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-051" markdown>
+<div class="eudi-hlr__id">AS-AP-10-051<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_32
+{: .eudi-hlr__meta }
+
+An Attestation Provider SHALL sign its Credential Issuer metadata as specified in section 12.2.3 of [OpenID4VCI]. To do so, the Attestation Provider SHALL use the private key corresponding to the public key in its access certificate. The Attestation Provider SHALL include its access certificate, as well as all intermediate certificate(s) leading up to the trust anchor of the corresponding Access Certificate Authority  in the LoTE (see ISSU_33), in the ``x5c`` parameter in the JOSE header of the JSON Web Signature for the metadata.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-052" markdown>
+<div class="eudi-hlr__id">AS-AP-10-052</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_32a
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-053" markdown>
+<div class="eudi-hlr__id">AS-AP-10-053<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_33
+{: .eudi-hlr__meta }
+
+For the verification of access certificates, a Wallet Unit SHALL accept only the trust anchors in all LoTE(s) for Access Certificate Authorities.
+
+*Note: Access Certificate Authority LoTEs are explained in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-054" markdown>
+<div class="eudi-hlr__id">AS-AP-10-054<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_33a
+{: .eudi-hlr__meta }
+
+For the verification of the registration certificates of Attestation Providers, a Wallet Unit SHALL accept only the trust anchors in all LoTE(s) for Providers of registration certificates.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-055" markdown>
+<div class="eudi-hlr__id">AS-AP-10-055<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_33b
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL support all Attestation Providers, except possibly if the attestation in question is a Strong User Authentication (SUA) attestation as meant in [Topic 20](./annex-2.02-high-level-requirements-by-topic.md#a2313-topic-20-strong-user-authentication-for-electronic-payments) and the Wallet Provider chooses to not support processing of the transactional data associated with that attestation. Except for such cases, Wallet Units SHALL be capable of requesting the issuance of a QEAA, PuB-EAA, or non-qualified EAA from all Attestation Providers at the User's request.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-056" markdown>
+<div class="eudi-hlr__id">AS-AP-10-056<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_34
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL authenticate and validate the access certificate of the Attestation Provider before requesting the issuance of an attestation. The Wallet Unit SHALL verify that the access certificate is authentic and is valid at the time of validation, and that the issuer of the access certificate is in the Access Certificate Authority LoTE(s), as documented in [[Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties)].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-057" markdown>
+<div class="eudi-hlr__id">AS-AP-10-057<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_34a
+{: .eudi-hlr__meta }
+
+Before requesting the issuance of an attestation, the Wallet Unit SHALL verify that the Attestation Provider is a registered QEAA Provider, PuB-EAA Provider, or EAA Provider. To do so, the Wallet Unit SHALL a) Inspect the ``entitlement`` member in the registration certificate of the Attestation Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``entitlement``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``entitlement`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the Attestation Provider is indeed registered as a QEAA Provider, PuB-EAA Provider, or EAA Provider, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of an attestation.
+
+*Note: The information in the ``entitlement`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the Attestation Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-058" markdown>
+<div class="eudi-hlr__id">AS-AP-10-058<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_34b
+{: .eudi-hlr__meta }
+
+Before requesting the issuance of an attestation, the Wallet Unit SHALL verify whether the Provider properly registered for the issuance of the type of attestation that the User wants to obtain. To do so, the Wallet Unit SHALL a) Inspect the ``providesAttestations`` member in the registration certificate of the Attestation Provider, if provided in the Credential Issuer Metadata per [ETSI TS 119 472-3] section 4.2.3, and verify the authenticity of the registration certificate. b) If no registration certificate is present, query the responsible Registrar for the registered value of ``providesAttestations``, using the URI in the Credential Issuer Metadata, if possible. c) If querying the Registrar is not possible, optionally inspect the ``providesAttestations`` member included in the Credential Issuer Metadata itself per [ETSI TS 119 472-3] section 4.2.3. If this procedure does not confirm that the Attestation Provider registered for the relevant type of attestation, the Wallet Unit SHALL display a warning to the User, and SHALL NOT request the issuance of an attestation.
+
+*Note: The information in the ``providesAttestation`` member included in the Credential Issuer Metadata (3rd option above) is self-declared by the Attestation Provider. It is up to the Wallet Provider to decide to trust this information if the registration certificate is not available and querying the registry is not successful.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-059" markdown>
+<div class="eudi-hlr__id">AS-AP-10-059<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_35
+{: .eudi-hlr__meta }
+
+A PID Provider or Attestation Provider SHALL ensure that all unique elements in a PID or attestation have a negligible chance of having the same value across all PIDs or attestations issued by that Provider. This SHALL include at least a) the salt used for hashing every attribute, b) the hash values of all attributes, c) the attestation identifier or index used for revocation purposes (if applicable), d) the attestation public key used for device binding (if applicable), and e) the value of the Attestation Provider signature.
+
+*Note: a) The list of unique elements is based on [ISO/IEC 18013-5] and [SD-JWT VC]. b) This requirement can be achieved, for example, by ensuring that salt values, indexes and attestation identifiers are pseudo-random numbers generated by a cryptographically secure pseudo-random number generator (CSPRNG).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-060" markdown>
+<div class="eudi-hlr__id">AS-AP-10-060<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_35a
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL ensure that all unique elements in a  WIA or KA have a negligible chance of having the same value across all WIAs and KAs issued by that Wallet Provider and intended to be presented to different PID Providers or Attestation Providers. This SHALL include at least a) the attestation identifier or index, unless the per-KA index approach meant in WUA_28 is used,  b) the WIA or KA public key, and c) the value of the Wallet Provider signature over the WIA or KA.
+
+*Note:  In other words, the following do not have to be unique: i) WIAs presented to the same PID Provider or Attestation Provider; and ii) the revocation reference in a KA under the type-shared index approach (see WUA_28). However, under the per-KA index approach (see WUA_28), the KA revocation reference is unique per KA or per KA-issuer pair and is subject to this requirement.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-061" markdown>
+<div class="eudi-hlr__id">AS-AP-10-061<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_35b
+{: .eudi-hlr__meta }
+
+After issuing a PID, attestation, KA, or WIA, a PID Provider, Attestation Provider or Wallet Provider SHALL discard the values of all unique elements, including at least the ones mentioned in requirement ISSU_35 or ISSU_35a (as applicable) above, as well as any timestamps, as soon as they are no longer needed. The Provider SHALL NOT communicate these values to any other party inside or outside the EUDI Wallet ecosystem.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-062" markdown>
+<div class="eudi-hlr__id">AS-AP-10-062<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_36
+{: .eudi-hlr__meta }
+
+When issuing PIDs, attestations, or WIAs or KAs in a batch to a Wallet Unit, a PID Provider, Attestation Provider, or Wallet Provider SHALL ensure that the timestamps in these PIDs, attestations, or WIAs and KAs do not enable Relying Parties to conclude that they are part of the same batch (and therefore belong to the same User).
+
+*Note: a) This can be done, for example, by making timestamps sufficiently imprecise that a high number of batches, each issued to a different Wallet Unit, share the same timestamp values (herd privacy). b) This requirement does not apply to timestamps included in the attestation as selectively disclosable attributes, see ISSU_36a.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-063" markdown>
+<div class="eudi-hlr__id">AS-AP-10-063<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_36a
+{: .eudi-hlr__meta }
+
+If the exact time of the issuance of an attestation or the beginning or end of its validity period is relevant for the use case, the applicable Rulebook SHALL specify one or more selectively disclosable attribute(s) containing a timestamp with the required precision.
+
+*Note: a) An example of this may be a vehicle registration attestation indicating the date and time (down to the second) at which a car changed ownership and therefore legal responsibility. b) This requirement ensures that requirement ISSU_36 can be complied with without running into challenges related to the use case.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-064" markdown>
+<div class="eudi-hlr__id">AS-AP-10-064<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_37
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL ensure that its Wallet Solution supports the following methods for limiting the number of times a User can present the same technical PID or attestation to Relying Parties: Method A (Once-only attestations, as specified in requirement ISSU_43 - ISSU_47) and Method B (Limited-time attestations, as specified in requirement ISSU_48 - ISSU_50). In addition, a Wallet Provider MAY ensure that its Wallet Solution supports Method C (Rotating-batch attestations, as specified in requirement ISSU_51 - ISSU_54) or Method D (Per-Relying Party attestations, as specified in requirement ISSU_55 - ISSU_57).
+
+*Note: Wallet Solutions, PID Providers, Attestation Providers, and Wallet Providers are free to define and use other methods as well. However, such other methods are out of scope of the ARF.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-065" markdown>
+<div class="eudi-hlr__id">AS-AP-10-065<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_38
+{: .eudi-hlr__meta }
+
+A PID Provider or Attestation Provider SHALL have a policy describing which method(s) (i.e,  A, B, C, and/or D) it will use to limit the number of times a Wallet Unit may present a single technical PID or attestation. For each supported method, the policy SHALL also specify how the values for respective parameters for that method, such as technical validity period and batch size, will be chosen. The goal of the policy SHALL be to ensure that the risk of linkability is mitigated to an acceptable level, given the (expected) usage of the logical PID or attestation by the User. To determine what an acceptable level of risk is, the PID Provider or Attestation Provider SHALL carry out a risk analysis regarding linkability.
+
+*Note: a) If an Attestation Provider issues multiple attestation types, these requirements apply for each type of attestation separately. b) [Technical Specification 3] specifies that WIAs and KAs shall be sent to a PID Provider or Attestation Provider only once. In other words, for WIAs and KAs, the use of Method A is mandatory.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-066" markdown>
+<div class="eudi-hlr__id">AS-AP-10-066<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_39
+{: .eudi-hlr__meta }
+
+PID Providers and Attestation Providers SHALL include the ``credential_reuse_policy`` parameter, specified in section 4.2.4.2 of [ETSI TS 119 472-3], in their Credential Issuer Metadata to specify which of the methods A, B, C, or D the Wallet Unit must use for the logical PID or attestation issued. Indicated methods SHALL be ordered by preference.
+
+*Note: See also ISSU_40.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-067" markdown>
+<div class="eudi-hlr__id">AS-AP-10-067<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_39a
+{: .eudi-hlr__meta }
+
+Wallet Units SHALL support the ``credential_reuse_policy`` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3] and SHALL present each technical PID and attestation in accordance with the values set for this parameter by the relevant PID Provider or Attestation Provider.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-068" markdown>
+<div class="eudi-hlr__id">AS-AP-10-068<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_40
+{: .eudi-hlr__meta }
+
+A PID Provider or Attestation Provider SHALL indicate in their OpenID4VCI Issuer metadata that either method A or method B must be used for a given type of PID or attestation. In addition, a PID Provider or Attestation Provider MAY indicate that it prefers using method C and/or method D over method A or method B, by including the methods in the metadata in the appropriate order. In such a case, a Wallet Unit supporting method C and/or method D SHALL use that method, while a Wallet Unit not supporting these methods SHALL use method A or method B, as applicable.
+
+*Note: a) This requirement implies that a PID Provider or Attestation Provider must not include both method A and method B in its metadata.  b) Example: An Attestation Provider indicates methods {D, C, A} in its metadata, in that order. A Wallet Unit that supports methods C and D (as well as A and B) then uses method D for this type of attestation. A Wallet Unit supporting methods A, B and C uses method C. A Wallet Unit supporting only methods A and B uses method A.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-069" markdown>
+<div class="eudi-hlr__id">AS-AP-10-069<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_40a
+{: .eudi-hlr__meta }
+
+When implementing any of the methods mentioned in ISSU_37, a  Wallet Unit, PID Provider, or Attestation Provider SHALL comply with the applicable requirements in [ETSI TS 119 472-3], section 4.2.4.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-070" markdown>
+<div class="eudi-hlr__id">AS-AP-10-070<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_41
+{: .eudi-hlr__meta }
+
+To the maximum extent possible, Wallet Providers, PID Providers, and Attestation Providers SHALL ensure that Users do not notice which of the methods A, B, C, or D is used for their PIDs and attestations.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-071" markdown>
+<div class="eudi-hlr__id">AS-AP-10-071<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_42
+{: .eudi-hlr__meta }
+
+To the maximum extent possible, Wallet Providers, PID Providers, and Attestation Providers SHALL ensure that no User action is needed for the re-issuance of WIAs or KAs, PIDs, or attestations.
+
+*Note: For the topic of re-issuance, see also the [Discussion Paper for Topic B](../../discussion-topics/b-re-issuance-and-batch-issuance-of-pids-and-attestations.md).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-072" markdown>
+<div class="eudi-hlr__id">AS-AP-10-072<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_43
+{: .eudi-hlr__meta }
+
+If Method A is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue technical PIDs or attestations in batches to the Wallet Unit. All PIDs or attestations in a batch SHALL have the same attribute values and the same technical validity period.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-073" markdown>
+<div class="eudi-hlr__id">AS-AP-10-073<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_44
+{: .eudi-hlr__meta }
+
+If Method A is used, the Wallet Unit SHALL present each technical PID or attestation only once to a Relying Party that requests the corresponding logical PID or attestation, except when it has fallen back to Method B as specified in ISSU_47.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-074" markdown>
+<div class="eudi-hlr__id">AS-AP-10-074<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_45
+{: .eudi-hlr__meta }
+
+If Method A is used, the Wallet Unit SHALL have a lower limit for the number of unused technical PIDs or attestations it holds for each logical PID or attestation, and SHALL request the issuance of a new batch when this limit is reached. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the value of the lower limit and the size of the batch to be requested, using the ``credential_reuse_policy`` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-075" markdown>
+<div class="eudi-hlr__id">AS-AP-10-075<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_46
+{: .eudi-hlr__meta }
+
+If Method A is used and the Wallet Unit must request a new batch of technical PIDs or attestations but is not able to do so (for instance because it is offline), the Wallet Unit SHALL warn the User that they are about to lose the possibility to present the corresponding logical PID or attestation to Relying Parties, and request them to connect their device to the internet.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-076" markdown>
+<div class="eudi-hlr__id">AS-AP-10-076<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_47
+{: .eudi-hlr__meta }
+
+If Method A is used and the Wallet Unit has run out of unused technical PIDs or attestations, but is not able to request a new batch, it SHALL fall back to method B (see ISSU_48 - ISSU_50). This means that, when requested by a Relying Party or Attestation Provider, the Wallet Unit SHALL again present one of the already used technical PIDs or attestations. The Wallet Unit SHALL return to using method A as soon as it is able to go online and request a new batch of PIDs or attestations.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-077" markdown>
+<div class="eudi-hlr__id">AS-AP-10-077<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_48
+{: .eudi-hlr__meta }
+
+If Method B is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue a single technical PID or attestation to the Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-078" markdown>
+<div class="eudi-hlr__id">AS-AP-10-078<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_49
+{: .eudi-hlr__meta }
+
+If Method B is used, the Wallet Unit SHALL present a technical PID or attestation multiple times to the same Relying Party or to different Relying Parties, when a Relying Party requests the corresponding logical PID or attestation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-079" markdown>
+<div class="eudi-hlr__id">AS-AP-10-079<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_50
+{: .eudi-hlr__meta }
+
+If Method B is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to re-issue a technical PID or attestation some time before the one existing in the Wallet Unit expires. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the moment at which the Wallet Unit must request the re-issuance of a technical PID or attestation, relative to the expiration date of the existing one. To do so, the  PID Provider or Attestation Provider SHALL use the `credential_reuse_policy` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3].
+
+*Note: It is the responsibility of the Relying Party receiving a PID or attestation to validate whether a presented technical PID or attestation is temporally valid. A Wallet Unit is allowed to present a PID or attestation even if its expiration date is in the past.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-080" markdown>
+<div class="eudi-hlr__id">AS-AP-10-080<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_51
+{: .eudi-hlr__meta }
+
+If Method C is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to issue technical PIDs or attestations in batches to the Wallet Unit. All PIDs or attestations in a batch SHALL have the same attribute values and the same technical validity period.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-081" markdown>
+<div class="eudi-hlr__id">AS-AP-10-081<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_52
+{: .eudi-hlr__meta }
+
+If Method C is used, the Wallet Unit SHALL present each technical PID or attestation in a batch once to a Relying Party that requests the corresponding logical PID or attestation, in a random order. When all PIDs or attestations in a batch have been presented once, the Wallet Unit SHALL reset the batch, and start presenting each PID or attestation in the batch again, in a random order. The Wallet Unit SHALL continue doing this until it receives a new batch, see ISSU_54.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-082" markdown>
+<div class="eudi-hlr__id">AS-AP-10-082</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_53
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-083" markdown>
+<div class="eudi-hlr__id">AS-AP-10-083<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_54
+{: .eudi-hlr__meta }
+
+If Method C is used, the Wallet Unit SHALL request the PID Provider or Attestation Provider to re-issue a batch of technical PIDs or attestations some time before the batch in the Wallet Unit expires. The PID Provider or Attestation Provider SHALL inform the Wallet Unit about the size of the batch and about the moment at which the Wallet Unit must request the re-issuance of a batch, relative to the expiration date of the existing batch.  To do so, the  PID Provider or Attestation Provider SHALL use the `credential_reuse_policy` Credential Issuer Metadata parameter specified in section 4.2.4.2 of [ETSI TS 119 472-3].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-084" markdown>
+<div class="eudi-hlr__id">AS-AP-10-084<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_55
+{: .eudi-hlr__meta }
+
+If Method D is used, the Wallet Unit SHALL present a different technical PID or attestation to each different Relying Party that requests the corresponding logical PID or attestation. This means that it SHALL comply with all requirements for Method A for such Relying Parties.
+
+*Note: This means the Wallet Unit presents an unused technical attestation to each new Relying Party that request the logical attestation, and it requests a new batch of technical attestations if the number of remaining unused attestations goes below the lower limit. If for some reason requesting a new batch is not successful and the Wallet Unit runs out of unused technical attestations, it re-uses one of the already used technical attestations.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-085" markdown>
+<div class="eudi-hlr__id">AS-AP-10-085<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_56
+{: .eudi-hlr__meta }
+
+If Method D is used and a given Relying Party requests attributes from a given logical  PID or attestation multiple times, the Wallet Unit MAY present the same technical PID or attestation to this Relying Party each time. If it does, it SHALL comply with all requirements for Method B for such a Relying Party.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-086" markdown>
+<div class="eudi-hlr__id">AS-AP-10-086</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_56a
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-087" markdown>
+<div class="eudi-hlr__id">AS-AP-10-087<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_57
+{: .eudi-hlr__meta }
+
+If Method D is used, the Wallet Unit SHALL keep track of which technical PID or attestation it has presented to which Relying Party.
+
+*Note: To do so, the Wallet Unit can use the unique RP identifier from the extension of the presentation request meant in RPRC_19a.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-088" markdown>
+<div class="eudi-hlr__id">AS-AP-10-088</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_57a
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-089" markdown>
+<div class="eudi-hlr__id">AS-AP-10-089<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_58
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL give its User the option to manually initiate a re-issuance process for any of the logical PIDs or attestations in their Wallet Unit. If the User uses this option, the Wallet Unit SHALL attempt to start the re-issuance process immediately, and SHALL notify the User if it did not succeed in requesting re-issuance.
+
+*Note: a) This requirement does not apply for KAs or WIAs, since Users must not be involved in their management. b) In the case of a PID or an attestation bound to the WSCA/WSCD, the Wallet Unit will request the User to authenticate to the WSCA/WSCD (see WIAM_14). In case of an attestation bound to a keystore, no additional User authentication is needed, see WIAM_15c.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-090" markdown>
+<div class="eudi-hlr__id">AS-AP-10-090<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_59
+{: .eudi-hlr__meta }
+
+After a successful re-issuance, a Wallet Unit SHALL compare the attribute values of the re-issued technical PID or attestation with those of the existing technical PID or attestation, and SHALL notify the User in case of any differences.
+
+*Note: a) This requirement does not apply for KAs or WIAs, since Users must not be involved in their management. b) The point of this requirement is to allow the User to detect errors in the attribute values in the new attestation. The follow-up process in case of errors is not defined. Presumably, the User can contact the Attestation Provider to discuss the fact that it apparently holds false attribute values for the User, and as a result, the Attestation Provider may decide to revoke the attestation.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-091" markdown>
+<div class="eudi-hlr__id">AS-AP-10-091<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_60
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL gracefully handle situations in which re-issuance of a PID, attestation, KA, or WIA fails or is refused by the PID Provider, Attestation Provider, or Wallet Provider, for example by attempting a retry after an appropriate delay.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-092" markdown>
+<div class="eudi-hlr__id">AS-AP-10-092<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_61
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL support PID or attestation first-time batch issuance with a single User authentication, regardless of the size of the batch.
+
+*Note:  See also requirement WIAM_14.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-093" markdown>
+<div class="eudi-hlr__id">AS-AP-10-093<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_62
+{: .eudi-hlr__meta }
+
+If a technical PID or attestation was successfully re-issued because the value of one or more of its attributes was changed (including attributes being added or deleted), a Wallet Unit SHALL no longer present the (now obsolete) pre-existing technical PID or attestation, and SHOULD delete it.
+
+*Note: a) It is up to the Wallet Unit, possibly using metadata provided by the PID Provider or Attestation Provider using the [OpenID4VCI] protocol, to determine the technical PID or attestation to be deleted. b) Additionally, per requirement VCR_09, the PID Provider or Attestation Provider revokes the pre-existing technical PID or attestation.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-094" markdown>
+<div class="eudi-hlr__id">AS-AP-10-094<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_63
+{: .eudi-hlr__meta }
+
+PID Providers and Attestation Providers, and Wallet Units SHALL support the features of [OpenID4VCI] enabling the re-issuance of PIDs and attestations.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-095" markdown>
+<div class="eudi-hlr__id">AS-AP-10-095<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_64
+{: .eudi-hlr__meta }
+
+PID Providers, Attestation Providers, and Wallet Units SHALL support the features of [OpenID4VCI] enabling the batch issuance of technical PIDs or attestations.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-096" markdown>
+<div class="eudi-hlr__id">AS-AP-10-096<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_65
+{: .eudi-hlr__meta }
+
+A PID Provider or an Attestation Provider of device-bound attestations SHALL verify that a re-issued technical PID or device-bound attestation is issued to the same Wallet Unit as the existing PID or attestation.
+
+*Note: A PID Provider or Attestation Provider can do so by issuing a device-bound refresh token to the Wallet Instance during the original issuance of the PID or attestation, and requiring that the Wallet Instance uses it to obtain a fresh access token during re-issuance; see [OpenID4VCI] section 14.5. The PID Provider or Attestation Provider needs to be able to trust that the Wallet Instance handles the refresh tokens in a secure way, so that an attacker cannot use them from another Wallet Instance. This requires trust in the (continued) security and integrity of both the original Wallet Instance and the other Wallet Instance. This trust is provided by providing the PID Provider or Attestation Provider with a valid KA for the new Wallet Unit during re-issuance, and by enabling the PID Provider or Attestation Provider to verify that the original Wallet Unit has not been revoked.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-097" markdown>
+<div class="eudi-hlr__id">AS-AP-10-097</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_66
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-098" markdown>
+<div class="eudi-hlr__id">AS-AP-10-098<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_67
+{: .eudi-hlr__meta }
+
+A PID Provider SHALL have a policy governing all aspects of PID issuance and management. The policy SHALL comply with at least the extended normalised certificate policy (‘NCP+’) requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of PIDs rather than public key certificates.
+
+*Note: A common dedicated policy for issuing PIDs may be developed in the future. If so, this requirement will be changed to refer to it.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-099" markdown>
+<div class="eudi-hlr__id">AS-AP-10-099<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_68
+{: .eudi-hlr__meta }
+
+PID Providers SHALL ensure that the certificates they use for signing PIDs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 4.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-100" markdown>
+<div class="eudi-hlr__id">AS-AP-10-100<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_69
+{: .eudi-hlr__meta }
+
+A QEAA Provider SHALL have a policy governing all aspects of QEAA issuance and management. The policy SHALL comply with at least the policy for qualified certificates issued to a natural person where the private key and the related certificate reside on a QSCD (‘QCP-n-qscd’) or qualified certificates issued to a legal person where the private key and the related certificate reside on a QSCD (‘QCP-l-qscd’) requirements as specified in [ETSI EN 319 411-2], insofar applicable for the issuance of QEAAs rather than public key certificates.
+
+*Note: A common dedicated policy for issuing QEAAs may be developed in the future. If so, this requirement will be changed to refer to it.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-101" markdown>
+<div class="eudi-hlr__id">AS-AP-10-101<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_70
+{: .eudi-hlr__meta }
+
+QEAA Providers SHALL ensure that the certificates they use for signing QEAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 7.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-102" markdown>
+<div class="eudi-hlr__id">AS-AP-10-102<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_71
+{: .eudi-hlr__meta }
+
+Providers of non-qualified EAAs SHALL ensure that the certificates they use for signing EAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 6.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-103" markdown>
+<div class="eudi-hlr__id">AS-AP-10-103<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_72
+{: .eudi-hlr__meta }
+
+A PuB-EAA Provider SHALL have a policy governing all aspects of PuB-EAA issuance and management. The policy SHALL comply with at least the extended normalised certificate policy (‘NCP+’) requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of PuB-EAAs rather than public key certificates.
+
+*Note: A common dedicated policy for issuing PuB-EAAs may be developed in the future. If so, this requirement will be changed to refer to it*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-10-104" markdown>
+<div class="eudi-hlr__id">AS-AP-10-104<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_73
+{: .eudi-hlr__meta }
+
+PuB-EAAs Providers SHALL ensure that the certificates they use for signing PuB-EAAs comply with all applicable requirements in [ETSI TS 119 412-6], in particular Clause 8.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-12-001" markdown>
+<div class="eudi-hlr__id">AS-AP-12-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_01
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL specify that one or more of the following two common format(s) must be used for these attestations: - The format specified in ISO/IEC 18013-5, see [ISO18013-5]. - The format specified in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-18-001" markdown>
+<div class="eudi-hlr__id">AS-AP-18-001<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ACP_03
+{: .eudi-hlr__meta }
+
+A Cryptographic Binding of Attestations scheme SHOULD be implemented using a Zero-Knowledge Proof mechanism that satisfies the requirements specified in [Topic 53](./annex-2.02-high-level-requirements-by-topic.md#a2331-topic-53-zero-knowledge-proofs).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-18-002" markdown>
+<div class="eudi-hlr__id">AS-AP-18-002</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ACP_06
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-18-003" markdown>
+<div class="eudi-hlr__id">AS-AP-18-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ACP_07
+{: .eudi-hlr__meta }
+
+Before making a request according to ACP_05, an Attestation Provider SHALL verify that the new attestation indeed belongs to the User of the existing PID or attestation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-28-001" markdown>
+<div class="eudi-hlr__id">AS-AP-28-001</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: LP_02
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-42-001" markdown>
+<div class="eudi-hlr__id">AS-AP-42-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QTSPAS_01
+{: .eudi-hlr__meta }
+
+In accordance with [ETSI TS 119 478] and [Technical Specification 11], Member States SHALL define: - discovery mechanisms that enable QTSPs to request information about Authentic Sources or designated intermediaries recognised at the national level. This includes information regarding the attributes of a natural or legal person for which the Authentic Source or designated intermediary is considered a primary source, or for which it is recognised as authentic in accordance with Union law or national law, including administrative practices. - procedures for QTSPs to request the verification of attributes from Authentic Sources.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-42-002" markdown>
+<div class="eudi-hlr__id">AS-AP-42-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QTSPAS_02
+{: .eudi-hlr__meta }
+
+An Authentic Source in the public sector, or its designated intermediary, SHALL implement an interface complying with [ETSI TS 119 478] and [Technical Specification 11] for receiving verification requests and sending responses. For each received request, the Authentic Source SHALL - identify and authenticate the requestor in such a way that it can subsequently determine whether the requestor is a QTSP issuing qualified electronic attestation of attributes, for example by means of a lookup in the QTSP Trusted List. - authenticate the User and obtain their approval, if it is legally obliged to do so, in addition to the User authentication and approval already performed by the QTSP according to QTSPAS_08. - verify whether the attribute values claimed by the QTSP match the values held by the Authentic Source and, finally, - respond with one of the following for each attribute: +'match', if the attribute value held for this User by the Authentic Source is identical to the value claimed by the QTSP, + 'no match', if the attribute value held for this User by the Authentic Source is not identical to the value claimed by the QTSP, including if the Authentic Source is the authentic source for this attribute but does not hold a value for this User, +'unknown', if the Authentic Source is not the authentic source for this attribute.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-42-003" markdown>
+<div class="eudi-hlr__id">AS-AP-42-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QTSPAS_03
+{: .eudi-hlr__meta }
+
+An Authentic Source or designated intermediary SHALL respond to a verification request for attributes by any QTSP issuing qualified electronic attestation of attributes.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-42-004" markdown>
+<div class="eudi-hlr__id">AS-AP-42-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QTSPAS_04
+{: .eudi-hlr__meta }
+
+An Authentic Source or designated intermediary SHALL implement the technical specifications mentioned in QTSPAS_01, so that the QTSP will receive the result of the verification of the requested attributes as described in QTSPAS_02. If the verification is deferred, the response to the QTSP SHALL include the maximum time that it will take to verify the requested attributes, and a unique identifier that the QTSP SHALL use to obtain the result of the verification.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-42-005" markdown>
+<div class="eudi-hlr__id">AS-AP-42-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QTSPAS_05
+{: .eudi-hlr__meta }
+
+A QTSP SHALL send an attribute verification request directly to the Authentic Source or designated intermediary recognised at national level, after discovering it using the mechanisms specified the technical specifications mentioned in QTSPAS_01.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-42-006" markdown>
+<div class="eudi-hlr__id">AS-AP-42-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QTSPAS_06
+{: .eudi-hlr__meta }
+
+Member States SHALL specify the processes and mechanisms to designate the Authentic Sources or intermediaries recognised at national level in accordance with Union or national law, allowing these Authentic Sources or intermediaries to verify the attributes presented to them by QTSPs.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-42-007" markdown>
+<div class="eudi-hlr__id">AS-AP-42-007</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QTSPAS_07
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-42-008" markdown>
+<div class="eudi-hlr__id">AS-AP-42-008</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QTSPAS_07a
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-42-009" markdown>
+<div class="eudi-hlr__id">AS-AP-42-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: QTSPAS_08
+{: .eudi-hlr__meta }
+
+A QTSP SHALL obtain approval from the User to verify the authenticity of the attributes, before requesting the verification of those attributes by the relevant Authentic Source or designated intermediary.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-43-001" markdown>
+<div class="eudi-hlr__id">AS-AP-43-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: EDP_11
+{: .eudi-hlr__meta }
+
+An Attestation Provider SHALL revoke an attestation if a corresponding embedded disclosure policy is added, changed, or deleted.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-44-001" markdown>
+<div class="eudi-hlr__id">AS-AP-44-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_13
+{: .eudi-hlr__meta }
+
+A Registrar MAY decide that, during the registration process for PID Providers, QEAA Providers, PuB-EAA Provider, or non-qualified EAA Providers, as specified in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), a Provider of registration certificates associated to the Member State Registrar must create and sign or seal a registration certificate and issue it to the registering party. If so, that registration certificate SHALL comply with the requirements in the technical specification mentioned in RPRC_02.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-44-002" markdown>
+<div class="eudi-hlr__id">AS-AP-44-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_14
+{: .eudi-hlr__meta }
+
+If, during registration, a PID Provider, QEAA Provider, PuB-EAA Provider, or non-qualified EAA Provider received a registration certificate, it SHALL distribute it to all its service supply points.
+
+*Note: A service supply point is a system at which a Wallet Unit can start the process of requesting and obtaining a PID or attestation.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-44-003" markdown>
+<div class="eudi-hlr__id">AS-AP-44-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_15
+{: .eudi-hlr__meta }
+
+The contents of a registration certificate issued to a PID Provider, a QEAA Provider, a PuB-EAA Provider, or a non-qualified EAA Provider SHALL contain the type(s) of attestation that this entity intends to issue to Wallet Units.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-44-004" markdown>
+<div class="eudi-hlr__id">AS-AP-44-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_22
+{: .eudi-hlr__meta }
+
+If a PID Provider or Attestation Provider received a registration certificate (see RPRC_14), it SHALL include the registration certificate in its Credential Issuer metadata used in the common OpenID4VCI protocol referenced in ISSU_01 and the extension thereof in [ETSI TS 119 472-3]. The registration certificate SHALL be included in the metadata by value, not by reference.
+
+*Note: This ensures that no external requests are necessary to validate the PID Provider or Attestation Provider, and that issuance transactions are atomic and self-contained.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-44-005" markdown>
+<div class="eudi-hlr__id">AS-AP-44-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_22a
+{: .eudi-hlr__meta }
+
+A PID Provider or Attestation Provider SHALL include the the following information in its Credential Issuer metadata used in the common OpenID4VCI protocol referenced in ISSU_01 and the extension thereof in [ETSI TS 119 472-3]: a) the user-friendly name of the PID Provider or Attestation Provider, b) the unique identifier of the PID Provider or Attestation Provider, c) a User-friendly description of the PID(s) or attestation(s) issued by this PID Provider or Attestation Provider, d) the URL of the Registrar of the PID Provider or Attestation Provider, and e) the attestation type(s) that the PID Provider or Attestation Provider intends to issue to Wallet Units.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-44-006" markdown>
+<div class="eudi-hlr__id">AS-AP-44-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_23
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL verify that the type of attestation it wants to request from the PID Provider or Attestation Provider is registered by the relevant Registrar, according to ISSU_24a for PID Providers and ISSU_34a for Attestation Providers.
+
+*Note: Unlike for Relying Parties, see RPRC_21, the Wallet Unit always carries out this verification, regardless of the preference of the User set as per RPRC_16.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-AP-51-001" markdown>
+<div class="eudi-hlr__id">AS-AP-51-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ZKP_04
+{: .eudi-hlr__meta }
+
+A ZKP scheme SHOULD support the derivation of a verifiable User pseudonym, by combining an attribute value that is unique for the User with Relying Party-specific context (e.g., the Relying Party identifier) In addition to the generic functions defined in ZKP_01, for this use case, a ZKP scheme SHALL provide support for the following functions: (i) generation of a request for the issuance of an attestation that includes a secret attribute unique to the User, without revealing this attribute to the Attestation Provider, (ii) generation of an attestation presentation that includes a verifiable pseudonym derived from the secret attribute, a Relying Party identifier, and context-related information.
+
+*Note: See section 4.1.5 of the Discussion Paper for Topic G.*
+
+</div>
+</div>
+
 
 ---
 
@@ -589,30 +7166,305 @@ as statements of fact.
 *EUDI Wallet. They cover how they must register, authenticate themselves to the*
 *wallet, request user attributes, and handle user data.*
 
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
-|EW-PIO-01-020 | OIA_12 | For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a PID using a trust anchor provided in a PID Provider LoTE made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].|  |
-|AS-RP-01-002 | OIA_16 | When receiving a PID or attestation, a Relying Party Instance SHALL discard the values of all unique elements, including at least the ones mentioned in requirement ISSU_35 in [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), as well as any timestamps, as soon as they are no longer needed. The Relying Party Instance SHALL NOT communicate these values to the Relying Party or to any other party inside or outside the EUDI Wallet ecosystem.|  |
-|AS-RP-01-003 | OIA_17 | A Relying Party Instance SHOULD verify the device-binding signature or Message Authentication Code provided in the presentation response of the Wallet Unit during the presentation of a PID or device-bound attestation, following the steps specified per [ISO/IEC 18013-5] or [SD-JWT VC], as applicable.|  |
-|AS-RP-06-001 | RPA_02a | Empty|  |
-|AS-RP-48-001 | DATA_DLT_02 | A Wallet Unit SHALL support at least the following possibilities to send a data erasure request to a Relying Party: a) Open a URL in an external browser to ask for the deletion of data in a web form provided by the Relying Party, b) Open an external mail client and start a draft e-mail to the Relying Party, with a suitable template text, c) open an external phone client and start a phone call. Depending on whether a Relying Party URL, e-mail address, and/or phone number was logged for the relevant attestation presentation transaction (see requirement DASH_03 in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency)), the Wallet Unit SHALL offer the User to use one or more of these possibilities.|  |
-|AS-RP-48-002 | DATA_DLT_02a | If the User initiates sending a data erasure request for a particular attestation presentation transaction, but no Relying Party URL, e-mail address, or telephone number is available in the log for that transaction, the Wallet Unit SHALL connect to the URL of the online service of the Registrar indicated in the log to obtain this information. The Wallet Unit SHALL inform the User that it must connect to the Registrar to look up the contact information it needs to send a data deletion request.| This situation may occur if there was no registration certificate in the presentation request and the User did not request the Wallet Unit to obtain the information registered about the Relying Party from the Registrar. See RPRC_16 - RPRC_18 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties). |
-|AS-RP-48-003 | DATA_DLT_03 | A Wallet Instance SHALL provide a function where the User may select one Relying Party to which a data deletion request must be submitted.|  |
-|AS-RP-48-004 | DATA_DLT_06 | For the initiation of a data deletion request, the log SHALL contain at least: - Date and time of the initiation of the request, - Name and unique identifier of the Relying Party to which the request was made, - Attributes requested to be deleted.|  |
-|AS-RP-48-005 | DATA_DLT_07 | Before executing a data deletion request, a Relying Party SHALL authenticate the requesting User (or the request itself), using appropriate authentication mechanisms of its own choosing. The Relying Party SHOULD use the authentication or signature facilities offered by the User's Wallet Unit for this purpose.|  |
-|AS-RP-51-001 | RPI_01 | An intermediary SHALL register as a Relying Party, in accordance with all requirements in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), while indicating it intends to act as an intermediary.| a) This implies that an intermediary obtains an access certificate containing its own name and unique Relying Party identifier. b) An intermediary may also obtain a registration certificate according to [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), but this certificate will not be used for intermediated transactions. c) An entity that registered as an intermediary may also register as a Relying Party in its own capacity. In such a case, it will receive one or more registration certificates for its intended use(s), and will use one of these certificates when interacting with a Wallet Unit. |
-|AS-RP-51-002 | RPI_02 | Empty|  |
-|AS-RP-51-003 | RPI_03 | An intermediary SHALL register each intermediated Relying Party it is acting on behalf of at a Registrar in the Member State where the intermediated Relying Party is established, according all requirements in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties). If a Provider of registration certificates associated with the Registrar issues registration certificates, the intermediary SHALL receive a registration certificate for each of the registered intended uses of the intermediated Relying Party.|  |
-|AS-RP-51-004 | RPI_04 | When registering an intermediated Relying Party, an intermediary SHALL provide legally valid evidence that this Relying Party will indeed use the services of this intermediary to interact with Wallet Units. The Registrar SHALL verify this evidence, and, if it is found to be correct, SHALL register the relationship between the intermediary and the intermediated Relying Party.| Such evidence may, for instance, be a contract between the intermediary and the intermediated Relying Party. |
-|AS-RP-51-005 | RPI_05 | When an intermediated Relying Party asks its intermediary to request some attributes from a Wallet Unit, it SHALL specify a) its user-friendly name, b) its unique identifier, c) the URL of its Registrar, d) the identifier of its intended use, e) a User-friendly description of its intended use. In addition, if the intermediated Relying Party has registration certificates, it SHALL indicate which single registration certificate the intermediary must include in the presentation request.| a) See RPRC_19a for why the intermediary needs this information. b) Since a), b) and c) will not change for each request, specification of this information can be done once. The same is true for d) and e) if the intermediated Relying Party has only one registered intended use. |
-|AS-RP-51-006 | RPI_06 | When requested by an intermediated Relying Party, an intermediary SHALL request a presentation of attributes from a specific Wallet Unit. In the request, the intermediary SHALL include the intermediary's access certificate meant in requirement RPI_01 and the registration certificate of the Relying Party, as meant in RPI_03, if available. In addition, whether or not a registration certificate is available, the intermediary SHALL include in the request the information about the intermediated Relying Party required in RPRC_19a.|  |
-|AS-RP-51-007 | RPI_06a | Empty|  |
-|AS-RP-51-008 | RPI_07 | In case a Wallet Unit receives a presentation request from an intermediary on behalf of an intermediated Relying Party, it SHALL display the trade names of the intermediary and the intermediary Service to the User when asking for User approval, as described in RPA_07.| a) This is in addition to the trade names of the intermediated Relying Party and its Service, which are required per RPA_06. b) In this case, the trade names of the intermediary and its Service are included in the access certificate presented by the Relying Party Instance, whereas the trade names of the intermediated Relying Party and its Service are included in the extension of the presentation request (see RPRC_19a), and in the registration certificate if available. If these names are different from those in the access certificate, the Wallet Unit knows that the presentation request is from an intermediary on behalf of an intermediated Relying Party. |
-|AS-RP-51-009 | RPI_07a | In case a Wallet Unit receives a presentation request from an intermediary on behalf of an intermediated Relying Party, and if the User indicated that they want to verify the information registered about this Relying Party (according to RPRC_16), the Wallet Unit SHALL verify that that the contractual relationship between the Relying Party and the intermediary is indeed registered by the responsible Registrar according to RPI_04, see also RPRC_04. If this verification fails, the Wallet Unit SHALL notify the User when asking for User consent.| The Wallet Unit can either do this by inspecting the registration certificate (if available) or by querying the Registrar. |
-|AS-RP-51-010 | RPI_07b | Empty|  |
-|AS-RP-51-011 | RPI_08 | When a Wallet Unit presents to an intermediary any User attributes from a PID or attestation, the intermediary SHALL, after successfully carrying out the verifications in RPI_09, forward these attributes (only) to the Relying Party on behalf of which the presentation request was made. If any of the verifications in RPI_09 fail, the intermediary SHALL NOT forward any attributes to the Relying Party.|  |
-|AS-RP-51-012 | RPI_09 | When a Wallet Unit presents to an intermediary any attributes from a PID or attestation, the intermediary SHALL verify the authenticity of the PID or attestation, its revocation status, device binding and User binding, as well as any combined presentation of attributes, if applicable, as specified in this ARF and if agreed with the Relying Party.| This ARF does not mandate that a Relying Party must carry out all of these verifications. Therefore, the intermediary and any Relying Party using its services must agree on what verifications the intermediary will carry out. |
-|AS-RP-51-013 | RPI_10 | The intermediary SHALL delete any PIDs or attestations it obtained from the Wallet Unit, including any User attributes, completely and immediately after it has sent the User attributes to the intermediated Relying Party. If the intermediary does not send any User attributes to the intermediated Relying Party, for example because one of the verifications in RPI_09 failed, the intermediary SHALL delete the PIDs or attestations completely and immediately as soon as it has completed all necessary verifications.|  |
+<div class="eudi-hlr" id="EW-PIO-01-020" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-020<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_12
+{: .eudi-hlr__meta }
+
+For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a PID using a trust anchor provided in a PID Provider LoTE made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-01-002" markdown>
+<div class="eudi-hlr__id">AS-RP-01-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_16
+{: .eudi-hlr__meta }
+
+When receiving a PID or attestation, a Relying Party Instance SHALL discard the values of all unique elements, including at least the ones mentioned in requirement ISSU_35 in [Topic 10](./annex-2.02-high-level-requirements-by-topic.md#a237-topic-10-issuing-a-pid-or-attestation-to-a-wallet-unit), as well as any timestamps, as soon as they are no longer needed. The Relying Party Instance SHALL NOT communicate these values to the Relying Party or to any other party inside or outside the EUDI Wallet ecosystem.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-01-003" markdown>
+<div class="eudi-hlr__id">AS-RP-01-003<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_17
+{: .eudi-hlr__meta }
+
+A Relying Party Instance SHOULD verify the device-binding signature or Message Authentication Code provided in the presentation response of the Wallet Unit during the presentation of a PID or device-bound attestation, following the steps specified per [ISO/IEC 18013-5] or [SD-JWT VC], as applicable.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-06-001" markdown>
+<div class="eudi-hlr__id">AS-RP-06-001</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPA_02a
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-48-001" markdown>
+<div class="eudi-hlr__id">AS-RP-48-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DATA_DLT_02
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL support at least the following possibilities to send a data erasure request to a Relying Party: a) Open a URL in an external browser to ask for the deletion of data in a web form provided by the Relying Party, b) Open an external mail client and start a draft e-mail to the Relying Party, with a suitable template text, c) open an external phone client and start a phone call. Depending on whether a Relying Party URL, e-mail address, and/or phone number was logged for the relevant attestation presentation transaction (see requirement DASH_03 in [Topic 19](./annex-2.02-high-level-requirements-by-topic.md#a2312-topic-19-user-navigation-requirements-dashboard-logs-for-transparency)), the Wallet Unit SHALL offer the User to use one or more of these possibilities.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-48-002" markdown>
+<div class="eudi-hlr__id">AS-RP-48-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DATA_DLT_02a
+{: .eudi-hlr__meta }
+
+If the User initiates sending a data erasure request for a particular attestation presentation transaction, but no Relying Party URL, e-mail address, or telephone number is available in the log for that transaction, the Wallet Unit SHALL connect to the URL of the online service of the Registrar indicated in the log to obtain this information. The Wallet Unit SHALL inform the User that it must connect to the Registrar to look up the contact information it needs to send a data deletion request.
+
+*Note: This situation may occur if there was no registration certificate in the presentation request and the User did not request the Wallet Unit to obtain the information registered about the Relying Party from the Registrar. See RPRC_16 - RPRC_18 in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-48-003" markdown>
+<div class="eudi-hlr__id">AS-RP-48-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DATA_DLT_03
+{: .eudi-hlr__meta }
+
+A Wallet Instance SHALL provide a function where the User may select one Relying Party to which a data deletion request must be submitted.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-48-004" markdown>
+<div class="eudi-hlr__id">AS-RP-48-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DATA_DLT_06
+{: .eudi-hlr__meta }
+
+For the initiation of a data deletion request, the log SHALL contain at least: - Date and time of the initiation of the request, - Name and unique identifier of the Relying Party to which the request was made, - Attributes requested to be deleted.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-48-005" markdown>
+<div class="eudi-hlr__id">AS-RP-48-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: DATA_DLT_07
+{: .eudi-hlr__meta }
+
+Before executing a data deletion request, a Relying Party SHALL authenticate the requesting User (or the request itself), using appropriate authentication mechanisms of its own choosing. The Relying Party SHOULD use the authentication or signature facilities offered by the User's Wallet Unit for this purpose.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-001" markdown>
+<div class="eudi-hlr__id">AS-RP-51-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_01
+{: .eudi-hlr__meta }
+
+An intermediary SHALL register as a Relying Party, in accordance with all requirements in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), while indicating it intends to act as an intermediary.
+
+*Note: a) This implies that an intermediary obtains an access certificate containing its own name and unique Relying Party identifier. b) An intermediary may also obtain a registration certificate according to [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), but this certificate will not be used for intermediated transactions. c) An entity that registered as an intermediary may also register as a Relying Party in its own capacity. In such a case, it will receive one or more registration certificates for its intended use(s), and will use one of these certificates when interacting with a Wallet Unit.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-002" markdown>
+<div class="eudi-hlr__id">AS-RP-51-002</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_02
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-003" markdown>
+<div class="eudi-hlr__id">AS-RP-51-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_03
+{: .eudi-hlr__meta }
+
+An intermediary SHALL register each intermediated Relying Party it is acting on behalf of at a Registrar in the Member State where the intermediated Relying Party is established, according all requirements in [Topic 44](./annex-2.02-high-level-requirements-by-topic.md#a2326-topic-44-registration-certificates-for-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties). If a Provider of registration certificates associated with the Registrar issues registration certificates, the intermediary SHALL receive a registration certificate for each of the registered intended uses of the intermediated Relying Party.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-004" markdown>
+<div class="eudi-hlr__id">AS-RP-51-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_04
+{: .eudi-hlr__meta }
+
+When registering an intermediated Relying Party, an intermediary SHALL provide legally valid evidence that this Relying Party will indeed use the services of this intermediary to interact with Wallet Units. The Registrar SHALL verify this evidence, and, if it is found to be correct, SHALL register the relationship between the intermediary and the intermediated Relying Party.
+
+*Note: Such evidence may, for instance, be a contract between the intermediary and the intermediated Relying Party.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-005" markdown>
+<div class="eudi-hlr__id">AS-RP-51-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_05
+{: .eudi-hlr__meta }
+
+When an intermediated Relying Party asks its intermediary to request some attributes from a Wallet Unit, it SHALL specify a) its user-friendly name, b) its unique identifier, c) the URL of its Registrar, d) the identifier of its intended use, e) a User-friendly description of its intended use. In addition, if the intermediated Relying Party has registration certificates, it SHALL indicate which single registration certificate the intermediary must include in the presentation request.
+
+*Note: a) See RPRC_19a for why the intermediary needs this information. b) Since a), b) and c) will not change for each request, specification of this information can be done once. The same is true for d) and e) if the intermediated Relying Party has only one registered intended use.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-006" markdown>
+<div class="eudi-hlr__id">AS-RP-51-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_06
+{: .eudi-hlr__meta }
+
+When requested by an intermediated Relying Party, an intermediary SHALL request a presentation of attributes from a specific Wallet Unit. In the request, the intermediary SHALL include the intermediary's access certificate meant in requirement RPI_01 and the registration certificate of the Relying Party, as meant in RPI_03, if available. In addition, whether or not a registration certificate is available, the intermediary SHALL include in the request the information about the intermediated Relying Party required in RPRC_19a.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-007" markdown>
+<div class="eudi-hlr__id">AS-RP-51-007</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_06a
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-008" markdown>
+<div class="eudi-hlr__id">AS-RP-51-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_07
+{: .eudi-hlr__meta }
+
+In case a Wallet Unit receives a presentation request from an intermediary on behalf of an intermediated Relying Party, it SHALL display the trade names of the intermediary and the intermediary Service to the User when asking for User approval, as described in RPA_07.
+
+*Note: a) This is in addition to the trade names of the intermediated Relying Party and its Service, which are required per RPA_06. b) In this case, the trade names of the intermediary and its Service are included in the access certificate presented by the Relying Party Instance, whereas the trade names of the intermediated Relying Party and its Service are included in the extension of the presentation request (see RPRC_19a), and in the registration certificate if available. If these names are different from those in the access certificate, the Wallet Unit knows that the presentation request is from an intermediary on behalf of an intermediated Relying Party.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-009" markdown>
+<div class="eudi-hlr__id">AS-RP-51-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_07a
+{: .eudi-hlr__meta }
+
+In case a Wallet Unit receives a presentation request from an intermediary on behalf of an intermediated Relying Party, and if the User indicated that they want to verify the information registered about this Relying Party (according to RPRC_16), the Wallet Unit SHALL verify that that the contractual relationship between the Relying Party and the intermediary is indeed registered by the responsible Registrar according to RPI_04, see also RPRC_04. If this verification fails, the Wallet Unit SHALL notify the User when asking for User consent.
+
+*Note: The Wallet Unit can either do this by inspecting the registration certificate (if available) or by querying the Registrar.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-010" markdown>
+<div class="eudi-hlr__id">AS-RP-51-010</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_07b
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-011" markdown>
+<div class="eudi-hlr__id">AS-RP-51-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_08
+{: .eudi-hlr__meta }
+
+When a Wallet Unit presents to an intermediary any User attributes from a PID or attestation, the intermediary SHALL, after successfully carrying out the verifications in RPI_09, forward these attributes (only) to the Relying Party on behalf of which the presentation request was made. If any of the verifications in RPI_09 fail, the intermediary SHALL NOT forward any attributes to the Relying Party.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-012" markdown>
+<div class="eudi-hlr__id">AS-RP-51-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_09
+{: .eudi-hlr__meta }
+
+When a Wallet Unit presents to an intermediary any attributes from a PID or attestation, the intermediary SHALL verify the authenticity of the PID or attestation, its revocation status, device binding and User binding, as well as any combined presentation of attributes, if applicable, as specified in this ARF and if agreed with the Relying Party.
+
+*Note: This ARF does not mandate that a Relying Party must carry out all of these verifications. Therefore, the intermediary and any Relying Party using its services must agree on what verifications the intermediary will carry out.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="AS-RP-51-013" markdown>
+<div class="eudi-hlr__id">AS-RP-51-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPI_10
+{: .eudi-hlr__meta }
+
+The intermediary SHALL delete any PIDs or attestations it obtained from the Wallet Unit, including any User attributes, completely and immediately after it has sent the User attributes to the intermediated Relying Party. If the intermediary does not send any User attributes to the intermediated Relying Party, for example because one of the verifications in RPI_09 failed, the intermediary SHALL delete the PIDs or attestations completely and immediately as soon as it has completed all necessary verifications.
+
+</div>
+</div>
+
 
 ---
 
@@ -624,41 +7476,460 @@ as statements of fact.
 *ensure the entire system works together seamlessly across borders. This covers*
 *how different components talk to each other.*
 
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
-|EW-PIO-01-001 | OIA_01 | A Wallet Unit SHALL support [OpenID4VP] for remote presentation flows and [ISO/IEC 18013-5] for proximity presentation flows, to receive and respond to presentation requests for person identification data (PID) and attestations by Relying Parties.|  |
-|EW-PIO-01-002 | OIA_02 | A Wallet Unit SHALL support proving cryptographic device binding between the WSCA/WSCD or a keystore included in the Wallet Unit and a PID or attestation, in accordance with [SD-JWT VC] or [ISO/IEC 18013-5].| Such a mechanism is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT VC]. |
-|EW-PIO-01-003 | OIA_03 | When issuing, presenting, or verifying an attestation, Wallet Units, PID Providers, Attestation Providers, and Relying Parties SHALL only use cryptographic algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].|  |
-|EW-PIO-01-004 | OIA_03a | Wallet Providers SHALL ensure that their Wallet Solution supports the protocol specified in 'OpenID for Verifiable Presentations', see [OpenID4VP], with additions and changes as documented in this Annex and in technical specifications referenced in this Annex.|  |
-|EW-PIO-01-005 | OIA_03b | For remote presentation flows using redirects, when the format of the requested attestation complies with [ISO/IEC 18013-5], Relying Parties and Wallet Units SHALL comply with the requirements in [HAIP] Sections 5, 5.1 and 5.3.1, as well as with the 'ISO mdocs' profile in Section 6.| a) '[HAIP] Section 5' refers only to the requirements directly under the Section 5 heading. This does not include sections 5.1, 5.2, and 5.3. b) For clarity: in [HAIP] v1.0, the 'ISO mdocs profile' implies that Relying Parties and Wallet Units must comply with the applicable requirements in [OpenID4VP] Annex B.2. |
-|EW-PIO-01-006 | OIA_03c |  For remote presentation flows using redirects, when the format of the requested attestation complies with [SD-JWT VC], Relying Parties and Wallet Units SHALL comply with the requirements in [HAIP] Sections 5, 5.1, and 5.3.2, as well as with the 'IETF SD-JWT VCs' profile in Section 6.| a) '[HAIP] Section 5' refers only to the requirements directly under the Section 5 heading. This does not include sections 5.1, 5.2, and 5.3. b) For clarity: in [HAIP] v1.0 Section 6, the 'IETF SD-JWT VCs profile' implies that Relying Parties and Wallet Units must comply with the requirements in [OpenID4VP] Annex B.3, as well as with the requirements in Section 6.1. |
-|EW-PIO-01-007 | OIA_04 | A Wallet Unit SHALL verify and process PID or attestation presentation requests from Relying Parties in accordance with the protocols and interfaces specified in [OpenID4VP] for remote flows.|  |
-|EW-PIO-01-008 | OIA_05 | After verifying and processing a PID or attestation request, the Wallet Unit SHALL display to the User the identity of the requesting Relying Party and the requested attributes.|  |
-|EW-PIO-01-009 | OIA_06 | A Wallet Unit SHALL present the requested attributes only after having received the User's approval.| See also OIA_07. |
-|EW-PIO-01-010 | OIA_07 | A Wallet Unit SHALL support selective disclosure of attributes from PIDs and attestations to be presented to the requesting Relying Parties.|  |
-|EW-PIO-01-011 | OIA_08 | Wallet Units and Relying Party Instances SHALL support the [W3C Digital Credentials API]](<https://wicg.github.io/digital-credentials/>) for remote presentation flows, provided that a) this API is a W3C Recommendation, b) this API complies with the expectations outlined in [Chapter 3](../../discussion-topics/f-digital-credential-api.md#3-expectations-from-the-digital-credentials-api) of the Topic F discussion paper, and c) this API is broadly supported by relevant browsers and operating systems.|  |
-|EW-PIO-01-012 | OIA_08a | If Wallet Units and Relying Party Instances do not support the [W3C Digital Credentials API], they SHALL implement adequate mitigations for the challenges described in [Section 4.4.3.1](../../architecture-and-reference-framework-main.md#4431-introduction) of the ARF main document.|  |
-|EW-PIO-01-013 | OIA_08b | If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL, by default (see OIA_08d), disclose the presence of all stored attestations (meaning their attestation type) to the Digital Credentials API framework, but it SHALL NOT disclose the presence of attributes in these attestations, nor their values.| The latter restriction applies even if such disclosure would enhance the services provided by the operating system to the Wallet Unit, for example, attestation selection in the context of the Digital Credentials API. |
-|EW-PIO-01-014 | OIA_08c | If a Relying Party supports the [W3C Digital Credentials API], the Relying Party's presentation request MAY be processed by the browser and/or the operating system for searching available attestations, for preventing fraud targeting the User, or for troubleshooting purposes. Moreover, the request SHOULD be processed by the browser and/or the Operating System for User security purposes. However, the request SHALL NOT be processed by the browser and/or the operating system for market analysis purposes (including as a secondary purpose) or for the browser's and/or the operating system's own purposes.|  |
-|EW-PIO-01-015 | OIA_08d | If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL provide a global User setting to disable the disclosure of stored attestations to the Digital Credentials API framework, as described in OIA_08b. When this setting is set to disable disclosure, the Wallet Unit SHOULD subsequently enable the User to select individual attestations to be disclosed to the DC API.| If this setting is set to disable disclosure and the User does not subsequently select any individual attestations to be disclosed, the Wallet Unit will not disclose any attributes at all. As a result, presentation requests sent using the DC API will likely fail. |
-|EW-PIO-01-016 | OIA_08e | If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL use the CTAP-Hybrid flow only if the expectations outlined in Chapter 4 of the [Topic F discussion paper](../../discussion-topics/f-digital-credential-api.md) are met.|  |
-|EW-PIO-01-017 | OIA_09 | For remote presentation flows the Wallet Unit SHALL ensure that the attributes included in the presented attestation are accessible only to the Relying Party Instance, by encrypting the presentation response.|  |
-|EW-PIO-01-018 | OIA_10 | For both proximity and remote presentation flows, if a Wallet Unit contains multiple PIDs having the same encoding (e.g. ISO/IEC 18013-5 or SD-JWT VC-compliant) and a Relying Party requests a PID having that encoding, the Wallet Unit SHALL ask the User which of these PIDs they want to present, unless the Wallet Unit can decide from context.| This requirement is not about multiple technical PIDs corresponding to a single logical PID, but to different logical PIDs whose technical PIDs have the same encoding. Probably, these logical PIDs are issued by different PID Providers. |
-|EW-PIO-01-019 | OIA_11 | For both proximity and remote presentation flows, if a Wallet Unit contains multiple attestations having the same encoding (e.g. ISO/IEC 18013-5 or SD-JWT VC-compliant) and the same attestation type, and a Relying Party requests an attestation having that type and encoding, the Wallet Unit SHALL ask the User which of these attestations they want to present, unless the Wallet Unit can decide from context.| a) Attestation types are explained in [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)]. b) See note to OIA_10, which applies mutatis mutandis. |
-|EW-PIO-01-021 | OIA_13 | For both proximity and remote presentation flows, a Relying Party SHALL validate the qualified signature of a QEAA in accordance with Art.32 of the [European Digital Identity Regulation]. For the verification, the Relying Party SHALL use a trust anchor provided in a QEAA Provider Trusted List made available in accordance with [Art. 22](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ.L_.2014.257.01.0073.01.ENG#d1e2162-73-1) of the [European Digital Identity Regulation].|  |
-|EW-PIO-01-022 | OIA_14 | For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a PuB-EAA using a trust anchor provided in a PUB-EAA Provider Trusted List made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].|  |
-|EW-PIO-01-023 | OIA_15 | For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a non-qualified EAA using a trust anchor provided according to the mechanism(s) specified in the applicable Rulebook, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)].| a) OIA_12 - OIA_15 imply that a Relying Party Instance must know if the attestation it is requesting from a Wallet Instance is a PID, a QEAA, a PuB-EAA, or a non-qualified EAA. These requirements also imply that the Relying Party Instance must store trust anchors in such a way that, at the time of verification, it is able to distinguish between trust anchors usable either for PIDs, for QEAAs, for PuB-EAAs, or for non-qualified EAAs. |
-|EW-PIO-10-001 | ISSU_01 | Wallet Providers SHALL ensure that their Wallet Solution supports the OpenID4VCI protocol specified in [OpenID4VCI], as profiled in Sections 4 and 6 of [HAIP], and with additions and changes as documented in this Annex (see e.g. this Topic and [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)) and in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).| For clarity: in [HAIP] v1.0, Section 6 implies that Wallet Units must comply with the applicable requirements in [OpenID4VCI] Annex A.2 when requesting the issuance of an attestation in ISO/IEC 18013-5-compliant format, and with the applicable requirements in [OpenID4VCI] Annex A.3 when requesting the issuance of an attestation in SD-JWT VC format. |
-|EW-PIO-24-001 | ProxId_01 | To enable identification using proximity flows, Wallet Units SHALL support device retrieval as specified in ISO/IEC 18013-5 for presenting PID or attestation attributes. Wallet Units SHALL comply with the requirements for mDLs and mdocs ISO/IEC 18013-5.| Nominally, ISO/IEC 18013-5 is intended only for mDLs and mDL readers. The corresponding standard for mobile documents in general (including Wallet Units with the EUDI Wallet ecosystem) will be ISO/IEC 23220-4, which is based on ISO/IEC 18013-5. However, the latter standard is not finished yet and therefore cannot be referenced at the moment. To guarantee interoperability between Wallet Units and Relying Party Instances in proximity scenarios, it is necessary to make choices from among the possibilities specified in ISO/IEC 18013-5. Making the same choices as for mDLs ensure this. |
-|EW-PIO-24-002 | ProxId_01a | If a Relying Party supports using proximity flows, its Relying Party Instances SHALL support device retrieval as specified in ISO/IEC 18013-5 for requesting PID or attestation attributes. Such Relying Party Instances SHALL comply with the requirements for mDL readers and mdoc readers in ISO/IEC 18013-5.| See note to ProxId_01. Support for proximity flows by Relying Parties is not mandatory. |
-|EW-PIO-24-003 | ProxId_02 | Wallet Units, PID Providers, Attestation Providers, Wallet Providers, and Relying Parties SHALL NOT support server retrieval as specified in ISO/IEC 18013-5 for requesting and presenting PID or attestation attributes.| Using server retrieval, a Relying Party would request User attributes directly from a PID Provider or Attestation Provider, after having received an authentication and/or authorisation token from the User's Wallet Unit. |
-|EW-PIO-24-004 | ProxId_03 | A Wallet Unit SHALL present the presentation request and the identity of the Relying Party to the User when processing the request.|  |
-|EW-PIO-24-005 | ProxId_04 | A Wallet Unit SHALL request its User to approve the presentation of attributes from their Wallet Unit for proximity identification before presenting them to the Relying Party or Verifier Wallet Unit.|  |
-|EW-PIO-24-006 | ProxId_05 | A Wallet Unit SHALL transmit the requested User attributes to the requesting Relying Party Instance securely in accordance with ISO/IEC 18013-5 for proximity flows.|  |
-|EW-PIO-24-007 | ProxId_06 | Empty|  |
-|EW-PIO-29-001 | RP_02 | An Attestation Provider issuing representation attestations to a natural person representing another natural person SHALL ensure that either the attestations are short-lived or that all entities which, according to applicable law, must have the ability to request revocation of such attestations, are able to do so.|  |
-|EW-PIO-30-001 | W2W_08 | A Verifier Wallet Unit and a Holder Wallet Unit SHALL support attestation presentation only in proximity, meaning they SHALL support only [ISO/IEC 18013-5] to communicate.|  |
-|EW-PIO-43-001 | EDP_09 | An Attestation Provider SHALL include an embedded disclosure policy (if any) by value in the Issuer metadata related to the attestation, in compliance with the [OpenID4VCI] issuance protocol or an extension thereof specified in the technical specification mentioned in EDP_08.|  |
+<div class="eudi-hlr" id="EW-PIO-01-001" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_01
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL support [OpenID4VP] for remote presentation flows and [ISO/IEC 18013-5] for proximity presentation flows, to receive and respond to presentation requests for person identification data (PID) and attestations by Relying Parties.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-002" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_02
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL support proving cryptographic device binding between the WSCA/WSCD or a keystore included in the Wallet Unit and a PID or attestation, in accordance with [SD-JWT VC] or [ISO/IEC 18013-5].
+
+*Note: Such a mechanism is called 'mdoc authentication' in [ISO/IEC 18013-5] and 'key binding' in [SD-JWT VC].*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-003" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_03
+{: .eudi-hlr__meta }
+
+When issuing, presenting, or verifying an attestation, Wallet Units, PID Providers, Attestation Providers, and Relying Parties SHALL only use cryptographic algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-004" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_03a
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that their Wallet Solution supports the protocol specified in 'OpenID for Verifiable Presentations', see [OpenID4VP], with additions and changes as documented in this Annex and in technical specifications referenced in this Annex.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-005" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_03b
+{: .eudi-hlr__meta }
+
+For remote presentation flows using redirects, when the format of the requested attestation complies with [ISO/IEC 18013-5], Relying Parties and Wallet Units SHALL comply with the requirements in [HAIP] Sections 5, 5.1 and 5.3.1, as well as with the 'ISO mdocs' profile in Section 6.
+
+*Note: a) '[HAIP] Section 5' refers only to the requirements directly under the Section 5 heading. This does not include sections 5.1, 5.2, and 5.3. b) For clarity: in [HAIP] v1.0, the 'ISO mdocs profile' implies that Relying Parties and Wallet Units must comply with the applicable requirements in [OpenID4VP] Annex B.2.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-006" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_03c
+{: .eudi-hlr__meta }
+
+ For remote presentation flows using redirects, when the format of the requested attestation complies with [SD-JWT VC], Relying Parties and Wallet Units SHALL comply with the requirements in [HAIP] Sections 5, 5.1, and 5.3.2, as well as with the 'IETF SD-JWT VCs' profile in Section 6.
+
+*Note: a) '[HAIP] Section 5' refers only to the requirements directly under the Section 5 heading. This does not include sections 5.1, 5.2, and 5.3. b) For clarity: in [HAIP] v1.0 Section 6, the 'IETF SD-JWT VCs profile' implies that Relying Parties and Wallet Units must comply with the requirements in [OpenID4VP] Annex B.3, as well as with the requirements in Section 6.1.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-007" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_04
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL verify and process PID or attestation presentation requests from Relying Parties in accordance with the protocols and interfaces specified in [OpenID4VP] for remote flows.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-008" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_05
+{: .eudi-hlr__meta }
+
+After verifying and processing a PID or attestation request, the Wallet Unit SHALL display to the User the identity of the requesting Relying Party and the requested attributes.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-009" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_06
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL present the requested attributes only after having received the User's approval.
+
+*Note: See also OIA_07.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-010" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_07
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL support selective disclosure of attributes from PIDs and attestations to be presented to the requesting Relying Parties.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-011" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_08
+{: .eudi-hlr__meta }
+
+Wallet Units and Relying Party Instances SHALL support the [W3C Digital Credentials API]](<https://wicg.github.io/digital-credentials/>) for remote presentation flows, provided that a) this API is a W3C Recommendation, b) this API complies with the expectations outlined in [Chapter 3](../../discussion-topics/f-digital-credential-api.md#3-expectations-from-the-digital-credentials-api) of the Topic F discussion paper, and c) this API is broadly supported by relevant browsers and operating systems.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-012" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_08a
+{: .eudi-hlr__meta }
+
+If Wallet Units and Relying Party Instances do not support the [W3C Digital Credentials API], they SHALL implement adequate mitigations for the challenges described in [Section 4.4.3.1](../../architecture-and-reference-framework-main.md#4431-introduction) of the ARF main document.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-013" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_08b
+{: .eudi-hlr__meta }
+
+If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL, by default (see OIA_08d), disclose the presence of all stored attestations (meaning their attestation type) to the Digital Credentials API framework, but it SHALL NOT disclose the presence of attributes in these attestations, nor their values.
+
+*Note: The latter restriction applies even if such disclosure would enhance the services provided by the operating system to the Wallet Unit, for example, attestation selection in the context of the Digital Credentials API.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-014" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_08c
+{: .eudi-hlr__meta }
+
+If a Relying Party supports the [W3C Digital Credentials API], the Relying Party's presentation request MAY be processed by the browser and/or the operating system for searching available attestations, for preventing fraud targeting the User, or for troubleshooting purposes. Moreover, the request SHOULD be processed by the browser and/or the Operating System for User security purposes. However, the request SHALL NOT be processed by the browser and/or the operating system for market analysis purposes (including as a secondary purpose) or for the browser's and/or the operating system's own purposes.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-015" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_08d
+{: .eudi-hlr__meta }
+
+If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL provide a global User setting to disable the disclosure of stored attestations to the Digital Credentials API framework, as described in OIA_08b. When this setting is set to disable disclosure, the Wallet Unit SHOULD subsequently enable the User to select individual attestations to be disclosed to the DC API.
+
+*Note: If this setting is set to disable disclosure and the User does not subsequently select any individual attestations to be disclosed, the Wallet Unit will not disclose any attributes at all. As a result, presentation requests sent using the DC API will likely fail.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-016" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-016<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_08e
+{: .eudi-hlr__meta }
+
+If a Wallet Unit supports the [W3C Digital Credentials API], it SHALL use the CTAP-Hybrid flow only if the expectations outlined in Chapter 4 of the [Topic F discussion paper](../../discussion-topics/f-digital-credential-api.md) are met.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-017" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_09
+{: .eudi-hlr__meta }
+
+For remote presentation flows the Wallet Unit SHALL ensure that the attributes included in the presented attestation are accessible only to the Relying Party Instance, by encrypting the presentation response.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-018" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_10
+{: .eudi-hlr__meta }
+
+For both proximity and remote presentation flows, if a Wallet Unit contains multiple PIDs having the same encoding (e.g. ISO/IEC 18013-5 or SD-JWT VC-compliant) and a Relying Party requests a PID having that encoding, the Wallet Unit SHALL ask the User which of these PIDs they want to present, unless the Wallet Unit can decide from context.
+
+*Note: This requirement is not about multiple technical PIDs corresponding to a single logical PID, but to different logical PIDs whose technical PIDs have the same encoding. Probably, these logical PIDs are issued by different PID Providers.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-019" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_11
+{: .eudi-hlr__meta }
+
+For both proximity and remote presentation flows, if a Wallet Unit contains multiple attestations having the same encoding (e.g. ISO/IEC 18013-5 or SD-JWT VC-compliant) and the same attestation type, and a Relying Party requests an attestation having that type and encoding, the Wallet Unit SHALL ask the User which of these attestations they want to present, unless the Wallet Unit can decide from context.
+
+*Note: a) Attestation types are explained in [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)]. b) See note to OIA_10, which applies mutatis mutandis.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-021" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-021<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_13
+{: .eudi-hlr__meta }
+
+For both proximity and remote presentation flows, a Relying Party SHALL validate the qualified signature of a QEAA in accordance with Art.32 of the [European Digital Identity Regulation]. For the verification, the Relying Party SHALL use a trust anchor provided in a QEAA Provider Trusted List made available in accordance with [Art. 22](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ.L_.2014.257.01.0073.01.ENG#d1e2162-73-1) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-022" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-022<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_14
+{: .eudi-hlr__meta }
+
+For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a PuB-EAA using a trust anchor provided in a PUB-EAA Provider Trusted List made available in accordance with [[Topic 31](./annex-2.02-high-level-requirements-by-topic.md#a2320-topic-31-notification-and-publication-of-pid-provider-wallet-provider-attestation-provider-access-certificate-authority-and-provider-of-registration-certificates)].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-01-023" markdown>
+<div class="eudi-hlr__id">EW-PIO-01-023<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: OIA_15
+{: .eudi-hlr__meta }
+
+For both proximity and remote presentation flows, a Relying Party SHALL validate the signature of a non-qualified EAA using a trust anchor provided according to the mechanism(s) specified in the applicable Rulebook, see [[Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks)].
+
+*Note: a) OIA_12 - OIA_15 imply that a Relying Party Instance must know if the attestation it is requesting from a Wallet Instance is a PID, a QEAA, a PuB-EAA, or a non-qualified EAA. These requirements also imply that the Relying Party Instance must store trust anchors in such a way that, at the time of verification, it is able to distinguish between trust anchors usable either for PIDs, for QEAAs, for PuB-EAAs, or for non-qualified EAAs.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-10-001" markdown>
+<div class="eudi-hlr__id">EW-PIO-10-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ISSU_01
+{: .eudi-hlr__meta }
+
+Wallet Providers SHALL ensure that their Wallet Solution supports the OpenID4VCI protocol specified in [OpenID4VCI], as profiled in Sections 4 and 6 of [HAIP], and with additions and changes as documented in this Annex (see e.g. this Topic and [Topic 9](./annex-2.02-high-level-requirements-by-topic.md#a236-topic-9-wallet-unit-attestation-and-wallet-instance-attestation)) and in [Technical Specification 3](../../technical-specifications/ts3-wallet-unit-attestation.md).
+
+*Note: For clarity: in [HAIP] v1.0, Section 6 implies that Wallet Units must comply with the applicable requirements in [OpenID4VCI] Annex A.2 when requesting the issuance of an attestation in ISO/IEC 18013-5-compliant format, and with the applicable requirements in [OpenID4VCI] Annex A.3 when requesting the issuance of an attestation in SD-JWT VC format.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-24-001" markdown>
+<div class="eudi-hlr__id">EW-PIO-24-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ProxId_01
+{: .eudi-hlr__meta }
+
+To enable identification using proximity flows, Wallet Units SHALL support device retrieval as specified in ISO/IEC 18013-5 for presenting PID or attestation attributes. Wallet Units SHALL comply with the requirements for mDLs and mdocs ISO/IEC 18013-5.
+
+*Note: Nominally, ISO/IEC 18013-5 is intended only for mDLs and mDL readers. The corresponding standard for mobile documents in general (including Wallet Units with the EUDI Wallet ecosystem) will be ISO/IEC 23220-4, which is based on ISO/IEC 18013-5. However, the latter standard is not finished yet and therefore cannot be referenced at the moment. To guarantee interoperability between Wallet Units and Relying Party Instances in proximity scenarios, it is necessary to make choices from among the possibilities specified in ISO/IEC 18013-5. Making the same choices as for mDLs ensure this.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-24-002" markdown>
+<div class="eudi-hlr__id">EW-PIO-24-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ProxId_01a
+{: .eudi-hlr__meta }
+
+If a Relying Party supports using proximity flows, its Relying Party Instances SHALL support device retrieval as specified in ISO/IEC 18013-5 for requesting PID or attestation attributes. Such Relying Party Instances SHALL comply with the requirements for mDL readers and mdoc readers in ISO/IEC 18013-5.
+
+*Note: See note to ProxId_01. Support for proximity flows by Relying Parties is not mandatory.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-24-003" markdown>
+<div class="eudi-hlr__id">EW-PIO-24-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ProxId_02
+{: .eudi-hlr__meta }
+
+Wallet Units, PID Providers, Attestation Providers, Wallet Providers, and Relying Parties SHALL NOT support server retrieval as specified in ISO/IEC 18013-5 for requesting and presenting PID or attestation attributes.
+
+*Note: Using server retrieval, a Relying Party would request User attributes directly from a PID Provider or Attestation Provider, after having received an authentication and/or authorisation token from the User's Wallet Unit.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-24-004" markdown>
+<div class="eudi-hlr__id">EW-PIO-24-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ProxId_03
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL present the presentation request and the identity of the Relying Party to the User when processing the request.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-24-005" markdown>
+<div class="eudi-hlr__id">EW-PIO-24-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ProxId_04
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL request its User to approve the presentation of attributes from their Wallet Unit for proximity identification before presenting them to the Relying Party or Verifier Wallet Unit.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-24-006" markdown>
+<div class="eudi-hlr__id">EW-PIO-24-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ProxId_05
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL transmit the requested User attributes to the requesting Relying Party Instance securely in accordance with ISO/IEC 18013-5 for proximity flows.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-24-007" markdown>
+<div class="eudi-hlr__id">EW-PIO-24-007</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ProxId_06
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-29-001" markdown>
+<div class="eudi-hlr__id">EW-PIO-29-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RP_02
+{: .eudi-hlr__meta }
+
+An Attestation Provider issuing representation attestations to a natural person representing another natural person SHALL ensure that either the attestations are short-lived or that all entities which, according to applicable law, must have the ability to request revocation of such attestations, are able to do so.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-30-001" markdown>
+<div class="eudi-hlr__id">EW-PIO-30-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: W2W_08
+{: .eudi-hlr__meta }
+
+A Verifier Wallet Unit and a Holder Wallet Unit SHALL support attestation presentation only in proximity, meaning they SHALL support only [ISO/IEC 18013-5] to communicate.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-PIO-43-001" markdown>
+<div class="eudi-hlr__id">EW-PIO-43-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: EDP_09
+{: .eudi-hlr__meta }
+
+An Attestation Provider SHALL include an embedded disclosure policy (if any) by value in the Issuer metadata related to the attestation, in compliance with the [OpenID4VCI] issuance protocol or an extension thereof specified in the technical specification mentioned in EDP_08.
+
+</div>
+</div>
+
 
 ---
 
@@ -669,117 +7940,1508 @@ as statements of fact.
 *ensuring that the information exchanged is consistent and understandable across*
 *the entire ecosystem.*
 
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
-|EW-DM-03-01 | PID_01 | PIDs and PID Providers SHALL comply with all requirements in [PID Rulebook].|  |
-|EW-DM-03-02 | PID_02 | A PID Provider SHALL issue any PID in both the format specified in ISO/IEC 18013-5 [ISO/IEC 18013-5] and the format specified in [SD-JWT VC].| [CIR 2024/2977] mentions the W3C Verifiable Credentials Data Model v1.1 instead of [SD-JWT VC]. The latest stable version of this standard is [W3C VCDM 2.0]. However, W3C VCDM is not a complete specification of an attestation format. In particular, it does not specify a specific proof method to be used. Without additional specification, such as those in [W3C VC-JOSE-COSE] or [W3C VC Data Integrity], and making further choices, it is impossible to implement a PID based on W3C VCDM. This Rulebook considers [SD-JWT VC] to essentially be such an additional specification. See also [Section 5.4.4](../../architecture-and-reference-framework-main.md#544-w3c-verifiable-credentials) of the ARF main document. |
-|EW-DM-03-03 | PID_03 | The portrait in a PID SHALL consist of a single portrait image in JPEG format. The portrait image SHALL comply with the quality requirements for a Full Frontal Image Type in ISO/IEC 19794-5 clauses 8.2, 8.3, and 8.4. However, the attribute portrait SHALL NOT comply with the format requirements in ISO/IEC 19794-5 clauses 8.1 and 8.5, meaning it SHALL NOT contain any of the headers or blocks specified in clause 5 except for the image data itself (a JPEG).|  |
-|EW-DM-03-04 | PID_04 | PID Providers SHALL use "eu.europa.ec.eudi.pid.1" as the attestation type for ISO/IEC 18013-5-compliant PIDs.| a) This identifier uses the general format [Reverse Domain].[Domain Specific Extension]. Since the European Commission controls the domain ec.europa.eu, this attestation type identifier will not collide with any attestation type identifiers defined by other organisations in other Attestation Rulebooks. b) The version number 1 in this identifier is used to distinguish between the first version of the PID, defined in the [PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md), and any future version, which will then have an incremented version number. |
-|EW-DM-03-05 | PID_05 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL use the value "eu.europa.ec.eudi.pid.1" for the identifier of the namespace for the PID attributes specified in [Section 4.2 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md).| a) The version number 1 allows for future extension(s) or change(s) of the ISO/IEC 18013-5-compliant PID attributes. b) This namespace has the same value as the attestation type specified in requirement PID_04. This is allowed according to ISO/IEC 18013-5. |
-|EW-DM-03-06 | PID_06 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider MAY include attributes that are not defined in the [PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md). If so, these attributes SHALL be defined within a domestic PID namespace as meant in requirement ARB_10 in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks). The PID Provider SHALL generate the identifier for this domestic PID namespace by appending the applicable ISO 3166-1 alpha-2 country code or the ISO 3166-2 region code, separated by a period, to the PID namespace identifier specified in PID_05, excluding the version number. The PID Provider MAY include a version number in the domestic PID namespace identifier.| For example, the identifier of the first domestic PID namespace for Germany could be "eu.europa.ec.eudi.pid.de.1". |
-|EW-DM-03-07 | PID_07 | A PID Provider that defines a domestic namespace SHALL publish the namespace, including all attribute identifiers, their definition, presence and encoding format, in an Attestation Rulebook complying with all applicable requirements in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks).|  |
-|EW-DM-03-08 | PID_08 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL include both the attributes and the metadata specified in [CIR 2024/2977] in the PID as issuer-signed data elements.| This implies that technically speaking, there is no difference between these attributes and metadata. |
-|EW-DM-03-09 | PID_09 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL encode each attribute or metadata in the PID as specified in the third column of the tables in [Section 4.2.1 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md).|  |
-|EW-DM-03-10 | PID_10 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL encode each attribute or metadata in the PID in Concise Binary Object Representation (CBOR) according to [RFC 8949].|  |
-|EW-DM-03-11 | PID_11 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL ensure that each PID contains at most one attribute with the same attribute identifier.|  |
-|EW-DM-03-12 | PID_12 | When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL ensure that the value of all attributes and metadata in the PID is valid at the value of the timestamp in the validFrom element in the MSO, see [ISO/IEC 18013-5] clause 9.1.2.4.| The value of the age_over_18, age_over_NN, or age_in_years attributes, if present, changes whenever the User to whom the person identification data relates has a relevant birthday. The value of many other attributes will also change over time. |
-|EW-DM-03-13 | PID_13 | If a PID Provider issues PIDs compliant with [ISO/IEC 18013-5] and containing the `issuance_date` or `expiry_date` attributes, the PID Provider SHALL have a policy for determining the value of these attributes relative to the `validFrom` and `validUntil` elements in the MSO, see [ISO/IEC 18013-5] clause 9.1.2.4.| See the notes to the `issuance_date` and `expiry_date` attributes in [PID Rulebook]. Examples of aspects to be considered in the policy may include (but are not limited to) the following:  1)  If an `issuance_date` or `expiry_date` is encoded as a `full-date` (rather than a `tdate`), it has no time element. However, `validFrom` and `validUntil` contain a time element, which is expressed in UTC. Therefore, comparing `expiry_date` to `validUntil`, for instance, may give ambiguous results in case the local time is not equal to UTC. The policy should ensure that situations are avoided where the User can legitimately expect (based on the values of `issuance_date` and `expiry_date` shown by the Wallet Unit when displaying the PID) that they can use their PID, while in reality its technical validity period (as determined by `validFrom` and `validUntil`) has not yet begun or has ended. 2) The exact meaning of `issuance_date` and `expiry_date` depends on local law and regulations. For example, in some jurisdictions an identity document whose `expiry_date` is in the past may by law still be used for identification for some purposes. However, this requires that the PID is still valid according to the `validFrom` and `validUntil` timestamps in the MSO. 3) A local requirement may exist stating that `issuance_date` and `expiry_date` must be identical to the dates on an existing physical document of the User. |
-|EW-DM-03-14 | PID_14 | A PID Provider issuing [SD-JWT VC]-compliant PIDs SHALL include the vct claim in their PIDs, where the vct claim SHALL be a URN within the `urn:eudi:pid:` namespace. The type indicated by the vct claim SHALL be `urn:eudi:pid:1` for the type defined in this document or a domestic type that extends it.|  |
-|EW-DM-03-15 | PID_15 | Empty|  |
-|EW-DM-03-16 | PID_16 | A PID Provider that defines a domestic type SHALL publish information about the type, including all claim identifiers, their definition, presence and encoding format, in an Attestation Rulebook complying with all applicable requirements in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks).|  |
-|EW-DM-03-17 | PID_17 | When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL include both the attributes and the metadata specified in [CIR 2024/2977] in the PID as claims.| This implies that technically speaking, there is no difference between these attributes and metadata. |
-|EW-DM-03-18 | PID_18 | When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL encode each attribute or metadata in the PID as specified in the tables in [Section 5.2 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md).|  |
-|EW-DM-03-19 | PID_19 | When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL ensure that the value of all attributes and metadata in the PID is valid at the value of the timestamp in the nbf claim, if present.| The value of the age-related claims, if present, changes whenever the User to whom the person identification data relates has a relevant birthday. The value of many other attributes will also change over time. |
-|EW-DM-03-20 | PID_20 | If a PID Provider issues PIDs compliant with [SD-JWT VC] and containing the `date_of_issuance` or `date_of_expiry` claims, the PID Provider SHALL have a policy for determining the value of these claims relative to the `nbf` and `exp` claims in the SD-JWT VC, see [SD-JWT VC] section 3.2.2.2.| See the notes to the `date_of_issuance` and `date_of_expiry` attributes in [PID Rulebook]. Examples of aspects to be considered in the policy may include (but are not limited to) the following: 1) `date_of_issuance` and `date_of_expiry` claims do not have a time element. However, `nbf` and `exp` express a time relative to UTC. Therefore, comparing `date_of_expiry` to `exp`, for instance, may give ambiguous results in case the local time is not equal to UTC. The policy should ensure that situations are avoided where the User can legitimately expect (based on the value of `date_of_issuance` and `date_of_expiry` shown by the Wallet Unit when displaying the PID) that they can use their PID, while in reality its technical validity period (as determined by `nbf` and `exp`) has not yet begun or has ended. 2) The exact meaning of `date_of_issuance` and `date_of_expiry` depends on local law and regulations. For example, in some jurisdictions an identity document whose `date_of_expiry` is in the past may by law still be used for identification for some purposes. However, this requires that the PID is still valid according to the `nbf` and `exp` timestamps in the SD_JWT VC. 3) A local requirement may exist stating that `date_of_issuance` and `date_of_expiry` must be identical to the dates on an existing physical document of the User. |
-|EW-DM-03-21 | PID_21 | When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL make all claims (i.e., all top-level properties, all nested properties, and all array entries) selectively disclosable individually, except those claims defined as non-selectively disclosable in [SD-JWT VC].|  |
-|EW-DM-04-001 | mDL_01 | mDLs and mDL Providers SHALL comply with all requirements in [mDL Rulebook].|  |
-|EW-DM-12-001 | ARB_01a | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHALL specify that one or more of the following three common format(s) must be used for these attestations: - The format specified in ISO/IEC 18013-5, see [ISO18013-5]. - The format specified in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC]. - The format specified in W3C Verifiable Credentials Data Model, see [W3C VCDM v2.0].|  |
-|EW-DM-12-002 | ARB_01b | The Scheme Provider for an Attestation Rulebook describing attestations using the format specified in [SD-JWT VC] SHALL ensure that these attestations comply with the 'IETF SD-JWT VC Profile' specified in [HAIP] Section 6.1.|  |
-|EW-DM-12-003 | ARB_02 | The Scheme Provider for an Attestation Rulebook SHALL analyse whether it must be possible for a User to present that type of attestation when the Wallet Unit and the Relying Party are in proximity and attestations are presented without using the internet. If so, the Attestation Rulebook SHALL specify that the attestations must be issued in the ISO/IEC 18013-5-compliant mdoc format.| In theory, it is possible to use SD-JWT VC-compliant attestations in proximity use cases. In practice, however, the only protocol available to request and present SD-JWT VC-compliant attestations between a Wallet Unit and a Relying Party Instance is OpenID4VP. That protocol cannot be used without internet connectivity. |
-|EW-DM-12-004 | ARB_03 | The Scheme Provider for an Attestation Rulebook MAY specify in the Attestation Rulebook that that type of attestation must be issued in the [SD-JWT VC]-compliant format, provided the [SD-JWT VC] specification has been approved by an EU standardisation body or by the European Digital Identity Cooperation Group established pursuant to [Article 46e](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e4536-1-1)(1) of the [European Digital Identity Regulation].|  |
-|EW-DM-12-005 | ARB_04 | If an Attestation Rulebook specifies that a type of attestation can be issued in a format compliant with [W3C VCDM v2.0], the Scheme Provider for that Attestation Rulebook SHALL ensure the Rulebook references one or more documents specifying in detail how a Relying Party can request attributes from a such an attestation, and how a User can selectively disclose attributes from such an attestation. Moreover, these referenced documents SHALL be approved by an EU standardisation body or by the European Digital Identity Cooperation Group established pursuant to [Article 46e](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e4536-1-1)(1) of the [European Digital Identity Regulation].|  |
-|EW-DM-12-006 | ARB_05 | The Scheme Provider for an Attestation Rulebook SHALL specify a value for the attestation type, which SHALL be unique within the scope of the EUDI Wallet ecosystem.| In ISO/IEC 18013-5, the attestation type is called 'document type' and is included as a ``docType`` key-value pair in both the mdoc request and the mdoc response. Also, a method for generating unique attestation type values is recommended. In OpenID4VP, the attestation type is included in the ``meta`` property of a Credential Query in a presentation request. In [SD-JWT VC], the attestation type is called 'SD-JWT VC type' and is included as a ``vct`` claim in the SD-JWT VC. |
-|EW-DM-12-007 | ARB_06 | The Scheme Provider for an Attestation Rulebook SHALL define all attributes that an attestation of that type may contain. This definition SHALL first describe the semantics of each attribute in an encoding-independent manner and SHALL subsequently for each attribute specify an ISO/IEC 18013-5-compliant format, an SD-JWT VC-compliant format, or both, as needed given the choices made according to ARB_01 - ARB_04.|  |
-|EW-DM-12-008 | ARB_06a | For ISO/IEC 18013-5-compliant attestations, the Attestation Rulebook SHALL define each attribute within an attribute namespace. An attribute namespace SHALL fully define the identifier, the syntax, and the semantics of each attribute within that namespace. An attribute namespace SHALL have an identifier that is unique within the scope of the EUDI Wallet ecosystem, and each attribute identifier SHALL be unique within that namespace.| In ISO/IEC 18013-5, namespaces are discussed and a method for generating unique namespace identifiers is recommended. |
-|EW-DM-12-009 | ARB_06b | For [SD-JWT VC]-compliant attestations, the Scheme Provider for the Attestation Rulebook SHALL ensure that each claim name is either: - included in the IANA registry for JWT claims, - is a Public Name as defined in [RFC 7519], or is a Private Name specific to the attestation type.| [SD-JWT VC] does not discuss how to avoid conflicting claim names. Since SD-JWTs are a special kind of JWTs, the methods specified in RFC 7519 are applicable. |
-|EW-DM-12-010 | ARB_07 | When determining the attributes to be included in a new attestation type, the Scheme Provider for the applicable Attestation Rulebook SHOULD consider referring to attributes that are already included in the catalogue of attributes specified in [Topic 25](./annex-2.02-high-level-requirements-by-topic.md#a2315-topic-25-unified-definition-and-controlled-vocabularies-for-attributes) or specified in an attestation scheme included in the catalogue of attestation schemes specified in [Commission Implementing Regulation 2025/1569](http://data.europa.eu/eli/reg_impl/2025/1569/oj), rather than unnecessarily re-defining all attributes.|  |
-|EW-DM-12-011 | ARB_08 | The Scheme Provider for an Attestation Rulebook SHOULD, when specifying a new attribute, take into consideration existing conventions for attribute identifier values and attribute syntaxes.| These conventions may depend on the format of the attestation, i.e., CBOR for ISO/IEC 18013-5-compliant attestations or JSON for SD-JWT VC-compliant attestations. |
-|EW-DM-12-012 | ARB_09 | The Scheme Provider for an Attestation Rulebook SHALL specify, for each attribute in the attestation, whether the presence of that attribute is mandatory, optional, or conditional.|  |
-|EW-DM-12-013 | ARB_10 | The Scheme Provider for an Attestation Rulebook for an ISO/IEC 18013-5 compliant attestation MAY define a domestic namespace to specify attributes that are specific to that Rulebook and are not included in the applicable EU-wide or sectoral namespace. All requirements for namespaces in this Topic SHALL also apply for domestic namespaces.|  |
-|EW-DM-12-014 | ARB_11 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook an attribute as meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point a) and [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point a) of the [European Digital Identity Regulation]. This attribute SHALL reference the technical specification meant in ARB_25.|  |
-|EW-DM-12-015 | ARB_12 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include an attribute in the Rulebook indicating that the attestation is an EAA. This attribute SHALL reference the technical specification meant in ARB_25.|  |
-|EW-DM-12-016 | ARB_13 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point b) of the [European Digital Identity Regulation].|  |
-|EW-DM-12-017 | ARB_14 | The Scheme Provider for an attestation Rulebook describing a type of attestation that is a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point b) of the [European Digital Identity Regulation].|  |
-|EW-DM-12-018 | ARB_15 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point b) of the [European Digital Identity Regulation].|  |
-|EW-DM-12-019 | ARB_16 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point c) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e46-55-1) point c) of the [European Digital Identity Regulation].|  |
-|EW-DM-12-020 | ARB_17 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point c) of the [European Digital Identity Regulation].|  |
-|EW-DM-12-021 | ARB_18 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point e) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point e) of the [European Digital Identity Regulation].|  |
-|EW-DM-12-022 | ARB_19 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point e) of the [European Digital Identity Regulation].|  |
-|EW-DM-12-023 | ARB_20 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the location meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point h) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point h) of the [European Digital Identity Regulation]. This location SHALL indicate at least the URL at which a machine-readable version of the trust anchor to be used for verifying the QEAA or PuB-EAA can be found or looked up.|  |
-|EW-DM-12-024 | ARB_21 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes or metadata representing the location at which a machine-readable version of the trust anchor to be used for verifying the EAA can be found or looked up.| What this location indicates precisely is dependent on the nature of the mechanism used for distributing trust anchors - see requirement ARB_26. |
-|EW-DM-12-025 | ARB_22 | The Scheme Provider for an Attestation Rulebook SHALL specify all technical details necessary to ensure interoperability, security, and privacy of that attestation.| An Attestation Rulebook may also specify requirements regarding how the Wallet Unit must display the attestation and the attributes in it to the User. |
-|EW-DM-12-026 | ARB_23 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL specify which of the revocation mechanisms specified in [Topic 7](./annex-2.02-high-level-requirements-by-topic.md#a235-topic-7-attestation-revocation-and-revocation-checking) SHALL be supported by that attestation.|  |
-|EW-DM-12-027 | ARB_24 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHALL specify whether that type of EAA must be revocable. If an EAA type must be revocable, the relevant Rulebook SHALL determine which of the revocation mechanisms specified in [Topic 7](./annex-2.02-high-level-requirements-by-topic.md#a235-topic-7-attestation-revocation-and-revocation-checking) SHALL be supported by that attestation.|  |
-|EW-DM-12-028 | ARB_25 | An Attribute Schema Provider SHALL include in its Attestation Rulebook the attribute ``attestation_legal_category``, specified in the [Attestation Rulebook Template](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/template/attestation-rulebook-template.md), with the appropriate value as specified in the Template.| This attribute contains the indication meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point a) and [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point a). |
-|EW-DM-12-029 | ARB_26 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD define in the Rulebook the mechanism(s) allowing a Relying Party to obtain, in a trustworthy manner, the trust anchor(s) of the EAA Providers issuing this type of EAA.| [Technical Specification 11](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts11-interfaces-and-formats-for-catalogue-of-attributes-and-catalogue-of-schemes.md), section 4.3.1, recommends the use of the List of trusted entities (LoTE) data model as defined in [ETSI TS 119 602](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/issues/278) for non-qualified EAAs. |
-|EW-DM-12-030 | ARB_27 | Empty|  |
-|EW-DM-12-031 | ARB_28 | An Attribute Scheme Provider MAY specify an attribute in an Attestation Rulebook that indicates whether the Attestation Provider during attestation issuance requested a cryptographic binding (as specified in [Topic 18](./annex-2.02-high-level-requirements-by-topic.md#a2311-topic-18-combined-presentations-of-attributes)) between the new attestation and an existing PID or attestation. If present in a Rulebook, the identifier for this attribute SHALL be ``cryptographically_bound_to``, and its contents SHALL be an attestation type or vct (see ARB_05).| The meaning of this attribute, if present, is that this attestation is cryptographically bound to one or more attestations of the given attestation type or vct on this Wallet Unit. If a Relying Party receives this attribute from a Wallet Unit, it can subsequently request the Wallet Unit to send a proof of cryptographic binding between the attestation and an attestation indicated in the ``cryptographically_bound_to`` attribute. |
-|EW-DM-12-032 | ARB_29 | The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA, PuB-EAA, or non-qualified EAA SHOULD ensure that the structure and contents of the Attestation Rulebook follow the descriptions in the [Attestation Rulebook template](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/template/attestation-rulebook-template.md).|  |
-|EW-DM-12-033 | ARB_30 | If an Attestation Rulebook specifies a [SD-JWT VC]-compliant attestation, the Scheme Provider for that Attestation Rulebook SHALL specify for all claims (i.e., all top-level properties, all nested properties, and all array entries) whether an Attestation Provider MUST, MAY, or MUST NOT make that claim selectively disclosable.| a) This requirement does not apply to claims defined as non-selectively disclosable in [SD-JWT VC]. b) There will be use cases where a specific claim must not be disclosed without simultaneously disclosing one or more other claims. Such cases should be solved by making all of these claims members of the same JSON object (or elements of the same JSON array). That JSON object (or array) is then the claim that must be selectively disclosable, while the nested properties (or individual array elements) must not be selectively disclosable. c) This requirement does not apply to [ISO/IEC 18013-5]-compliant attestations, since in such attestations, by definition all data elements are selectively disclosable, while none of the key-value pairs or array elements inside a data element (if any) are selectively disclosable. |
-|EW-DM-12-034 | ARB_31 | If an Attestation Rulebook specifies a [SD-JWT VC]-compliant attestation, the Scheme Provider for that Attestation Rulebook SHOULD consider defining a Type Metadata Document for it, as defined in Chapter 6 of [SD-JWT VC]. If the Scheme Provider defines such a document, it SHOULD contain the Claim Selective Disclosure Metadata (defined in Section 9.3 of [SD-JWT VC]) for each of the claims, in order to specify if that claim is selectively disclosable (see requirement ARB_30).| Although a Type Metadata Document is a highly technical document, defining it has a number of advantages for developers, Attestation Providers, Relying Parties, and Wallet Units, as spelled out in Chapter 6 of [SD-JWT VC]. |
-|EW-DM-12-035 | ARB_32 | Empty|  |
-|EW-DM-12-036 | ARB_33 | If a Scheme Provider for an Attestation Rulebook registers an attestation scheme in the catalogue of attestation schemes meant in [Commission Implementing Regulation 2025/1569](http://data.europa.eu/eli/reg_impl/2025/1569/oj), Article 8, the registration SHALL include a reference to the corresponding Attestation Rulebook.| By definition, an attestation scheme is machine-readable, whereas an Attestation Rulebook is human-readable. |
-|EW-DM-12-037 | ARB_34 | The Scheme Provider for an Attestation Rulebook SHALL specify whether that attestation is device-bound or not.|  |
-|EW-DM-28-001 | LP_03 | Empty|  |
-|EW-DM-31-001 | RPACANot_06 | If an Access Certificate Authority is suspended or cancelled (see requirement GenNot_05 above), that Access Certificate Authority SHALL immediately revoke all of its temporally valid access certificates.| This implies that if an intermediary obtained its access certificates from an Access Certificate Authority that is suspended or cancelled, any intermediated Relying Party depending on that intermediary will not be able to request attributes from Wallet Units, even though its registration is still valid. Such an intermediated Relying Party will either have to transit to another intermediary (which has access certificates issued by an active Access Certification Authority) or wait until the original intermediary obtains new access certificates either from another Access CA or from the original one, once that CA can continue its operations. |
-|EW-DM-31-002 | TLPub_03 | The publication of the information referred to in TLPub_01 SHALL take place over a secure channel protecting the authenticity and integrity of the published information.|  |
-|EW-DM-31-003 | TLPub_04 | The technical system mentioned in TLPub_01 SHALL NOT require authentication or prior registration and authorisation of any entity wishing to retrieve the published information.|  |
-|EW-DM-31-004 | TLPub_05 | The information referred to in TLPub_01 SHALL be published in an electronically signed or sealed form that is suitable for automated processing, and in a human-readable format, e.g., through introspection and display facilities, over an authenticated channel.|  |
-|EW-DM-38-001 | WURevocation_03 | A Wallet Provider SHALL have a policy governing all aspects of WIA and KA issuance and management. The policy SHALL distinguish between WIAs, KAs for WSCA/WSCDs, and KAs for keystores. For KAs describing a WSCA/WSCD, the policy SHALL comply with at least the extended normalised certificate policy ('NCP+') requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of KAs rather than public key certificates. For KAs describing a keystore, the policy SHALL comply with at least the normalised certificate policy ('NCP') requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of KAs rather than public key certificates.|  |
-|EW-DM-38-002 | WURevocation_04 | Empty|  |
-|EW-DM-38-003 | WURevocation_05 | Empty|  |
-|EW-DM-38-004 | WURevocation_06 | Empty|  |
-|EW-DM-38-018 | WURevocation_07a | To revoke a WSCD or keystore of a Wallet Unit, the Wallet Provider SHALL, in the status list(s) for WSCDs and keystores, set the `revoked` status at all index positions mentioned in the KAs describing that WSCD or keystore.| For this requirement, it does not matter whether each index in the status list(s) for WSCDs and keystores refers to a type of WSCD or keystore or to an individual WSCD or keystore. |
-|EW-DM-38-006 | WURevocation_08 | Empty|  |
-|EW-DM-38-016 | WURevocation_15 | Empty|  |
-|EW-DM-38-018 | WURevocation_17 | Empty|  |
-|EW-DM-38-019 | WURevocation_19a | Empty|  |
-|EW-DM-38-020 | WURevocation_19b | Empty|  |
-|EW-DM-38-021 | WURevocation_20 | Empty|  |
-|EW-DM-38-022 | WURevocation_21 | Empty|  |
-|EW-DM-43-001 | EDP_04 | Empty|  |
-|EW-DM-44-001 | RPRC_01 | Providers of registration certificates SHALL comply with all relevant requirements in [ETSI TS 119 475].|  |
-|EW-DM-44-002 | RPRC_02 | Empty|  |
-|EW-DM-44-003 | RPRC_03 | The contents of a registration certificate SHALL include at least the information required in Annex V of the [CIR 2025/848](https://data.europa.eu/eli/reg_impl/2025/848/oj) regarding registration of wallet-relying parties.|  |
-|EW-DM-44-004 | RPRC_04 | If the subject of the registration certificate uses the services of an intermediary (see [Topic 52](./annex-2.02-high-level-requirements-by-topic.md#a2330-topic-52-relying-party-intermediaries)), the 'association to the intermediary' mentioned in Annex I (15) of [CIR 2025/848] SHALL consist of the user-friendly name and unique identifier of this intermediary, as meant in requirements Reg_31 and Reg_32.| This name and identifier are identical to those in the access certificate of the intermediary. |
-|EW-DM-44-005 | RPRC_04a | Empty|  |
-|EW-DM-44-006 | RPRC_05 | If the subject of the registration certificate is not a Relying Party (i.e. in the terms of CIR 2025/848, a Service Provider), the certificate SHALL NOT contain the intended use as meant in Annex I (9) and (10) of CIR 2025/848.| A PID Provider or Attestation Provider may request attributes from the Wallet Unit during issuance. If so, it registers as both a Service Provider and an Attestation Provider, and consequently its registration certificate contains its intended use. |
-|EW-DM-44-007 | RPRC_06 | The contents of a registration certificate SHALL include a name for the subject of the certificate, in a format suitable for presenting to a User.| a) A Wallet Unit needs the name of a Relying Party at least when requesting User approval according to [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] b) This name is identical to the name in the access certificate(s) of the entity, see Reg_31. |
-|EW-DM-44-008 | RPRC_07 | The contents of a registration certificate SHALL include an EU-wide unique identifier for the subject of the certificate.| a) A Wallet Unit needs an identifier for a Relying Party at least to allow the User to send a report of suspicious Relying Party presentation requests to a data protection authority according to [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data). b) The EU-wide unique identifier could, for example, be a concatenated list of one or more registered official Relying Party identifiers listed in Annex I(3) of the [CIR 2025/848](https://data.europa.eu/eli/reg_impl/2025/848/oj) regarding registration of Wallet Relying Parties, expressed in the semantic form defined in [ETSI EN 319 412-1] sections 5.1.4 or 5.1.5. c) This identifier is identical to the identifier in the access certificate(s) of the entity, see Reg_32. |
-|EW-DM-44-009 | RPRC_08 | The EU-wide unique identifier meant in RPRC_07 SHALL be identical in all registration certificates issued for a given entity.| In case the registration certificates issued to an intermediated Relying Party are held and presented by an intermediary, the entity meant in this requirement is the intermediated Relying Party. An intermediary may obtain and hold registration certificates with a different unique identifier for other intermediated Relying Parties. |
-|EW-DM-44-010 | RPRC_09 | A Member State Registrar MAY decide that, during the registration process for Relying Parties, as specified in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), a Provider of registration certificates associated to the Registrar must create and sign or seal one or more registration certificates. If the Registrar decides to do so, the Provider of registration certificates SHALL create and sign or seal a separate registration certificate for each intended use registered by each Relying Party, and issue it to the Relying Party. Each registration certificate SHALL comply with the requirements in the technical specification mentioned in RPRC_02.| See also [Topic 52](./annex-2.02-high-level-requirements-by-topic.md#a2330-topic-52-relying-party-intermediaries). |
-|EW-DM-44-011 | RPRC_10 | If, during registration, a Relying Party received one or more registration certificates, it SHALL distribute these to all its Relying Party Instances.|  |
-|EW-DM-44-012 | RPRC_11 | The contents of a registration certificate issued to a Relying Party SHALL at least one of the following: a) the URL of a web form provided by the Relying Party, which Users can use to send data deletion requests, b) an e-mail address of the Relying Party, on which the Relying Party is prepared to receive data deletion requests from Users, c) a telephone number of the Relying Party, on which the Relying Party is prepared to receive data deletion requests from Users.| See [Topic 48](./annex-2.02-high-level-requirements-by-topic.md#a2327-topic-48-blueprint-for-requesting-data-deletion-to-relying-parties) for more information about data deletion requests. |
-|EW-DM-44-013 | RPRC_12 | The contents of a registration certificate issued to a Relying Party SHALL contain the name and country of the Data Protection Authority supervising the Relying Party. In addition, the registration certificate SHALL contain at least one of the following: a) the URL of a web form provided by the DPA, which Users can use to report suspicious attribute presentation requests. b) an e-mail address of the DPA, on which the DPA is prepared to receive reports about suspicious attribute presentation requests from Users, c) a telephone number of the DPA, on which the DPA is prepared to receive reports about suspicious attribute presentation requests from Users.| See [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data) for more information about reporting suspicious attribute presentation requests. |
-|EW-DM-44-014 | RPRC_16 | A Wallet Unit SHALL offer the User the possibility to indicate whether the User wants the Wallet Unit to go online to the competent Registrar if that is needed to verify the information registered about the Relying Party. The Wallet Unit SHALL inform the User that this implies that the Registrar learns about the User's interaction with the Relying Party. The Wallet Unit SHALL also inform the User that not requesting this information from the Registrar means that the Wallet Unit has no way to verify the information included by the Relying Party in the presentation request.| a) The Wallet Unit can offer this choice to the User either during a presentation transaction in case no registration certificate was received, or as a general User setting. b) If the User indicates they don't want this, the Wallet Unit will not verify the registered information in case there is no registration certificate, see RPRC_18a. However, if there is a registration certificate, the Wallet Unit will always verify the information in the certificate, per RPRC_17. |
-|EW-DM-44-015 | RPRC_17 | If the Relying Party sends a registration certificate to the Wallet Unit in a presentation request, the Wallet Unit SHALL verify the authenticity and validity of the registration certificate according to the technical specification meant in RPRC_02. If the certificate is inauthentic or expired, the Wallet Unit SHALL, when asking for User approval according to RPA_07, notify the User that it could not obtain the information registered about the entity.|  |
-|EW-DM-44-016 | RPRC_18 | If the User indicated that they want the Wallet Unit to go online to the competent Registrar if needed to verify the information registered about the Relying Party (see RPRC_16), and the Relying Party did not send a registration certificate to the Wallet Unit, the Wallet Unit SHALL connect to the URL of the online service of the Registrar to obtain this information. If the Wallet Unit cannot connect to this URL or if it cannot verify the authenticity and validity of the registered information, it SHALL, when asking for User approval according to RPA_07, notify the User that it could not obtain the information registered about the Relying Party.| The URL of the Registrar is included in the extension of the presentation request, see RPRC_19a. |
-|EW-DM-44-017 | RPRC_18a | If the User indicated that they do not want the Wallet Unit to go online to the competent Registrar, the Wallet Unit SHALL NOT do so, even in case the Relying Party did not send a registration certificate to the Wallet Unit in the presentation request.| This requirement is not applicable in case the Wallet Unit is interacting with a PID Provider or an Attestation Provider. If a PID Provider or an Attestation Provider does not provide a registration certificate, the Wallet Unit must verify their entitlements at the competent Registrar, see ISSU_24a and ISSU_34a. |
-|EW-DM-44-018 | RPRC_19 | If a Relying Party Instance received one or more registration certificates (see RPRC_10), it SHALL include a single registration certificate applicable for its current intended use in each presentation request to a Wallet Unit, according to the applicable standard's extension mentioned in RPRC_20. The registration certificate SHALL be included in the request by value, not by reference. The Relying Party Instance SHALL do so both in proximity and remote presentation flows.|  This ensures that no external requests are necessary to validate the Relying Party. |
-|EW-DM-44-019 | RPRC_19a | A Relying Party Instance SHALL include in each presentation request the following information, according to the applicable standard's extension mentioned in RPRC_20a: a) the user-friendly name of the Relying Party, b) the unique identifier of the Relying Party, c) a User-friendly description of the intended use of the Relying Party, d) the URL of the Registrar of the Relying Party, and e) the identifier of the intended use of the Relying Party.| Including items a) and b) enables the Wallet Unit to show to the User the name of the Relying Party. Including c) enables the Wallet Unit to inform the User about the intended use. Including c) and d) enables the Wallet Unit, if desired by the User, to request from the Registrar the attributes registered by the Relying Party for this intended use, as well as the corresponding privacy policy and other registered information. See [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md) for the definition of this information. Note that in case the Relying Party Instance is operated by an intermediary, items a) - e) pertain to the intermediated Relying Party, see also RPI_06. |
-|EW-DM-44-020 | RPRC_20 | Relying Party Instances and Wallet Units SHALL support the extension for [ISO/IEC 18013-5] or the extension for [OpenID4VP], as specified in [ETSI TS 119 472-2] and amended by a CIR in preparation, as applicable, for transferring a single Relying Party registration certificate from a Relying Party Instance to a Wallet Unit.| The correct CIR will be referenced here when it is published. |
-|EW-DM-44-021 | RPRC_20a | Relying Party Instances and Wallet Units SHALL support the extension for [ISO/IEC 18013-5] or the extension for [OpenID4VP], as specified in [ETSI TS 119 472-2] and amended by a CIR in preparation, as applicable, for transferring the information listed in RPRC_19a from a Relying Party Instance to a Wallet Unit.| The correct CIR will be referenced here when it is published. |
-|EW-DM-44-022 | RPRC_21 | If the User indicated that they want to verify the information registered about a Relying Party and the Wallet Unit retrieved this information either from the registration certificate or from the online service of the Registrar (see RPRC_16 - RPRC_18), it SHALL verify that all attributes requested in the presentation request are included in the list of attributes registered by the Registrar. If the outcome of the verification is negative, the Wallet Unit SHALL, when asking for User approval according to RPA_07, notify the User about the requested attributes that the Relying Party did not register.|  |
-|EW-DM-50-001 | RPT_DPA_03 | Empty|  |
-|EW-DM-50-002 | RPT_DPA_05a | For a report sent to a DPA, the log SHALL contain at least: a) the date and time when the report was sent, b) the name and country of the DPA, and c) the channel and contact information used for initiating sending the report, i.e., the URL, e-mail address, or phone number of the DPA.|  |
-|EW-DM-51-001 | ZKP_01 | A ZKP scheme SHALL provide support for the following generic functions, while hiding all attributes of PIDs or attestations: (i) generation of a proof that an (some) attribute(s) having a specific value is (are) included in a PID or attestation, (ii) generation of a proof that a PID or attestation is within its validity period, (iii) generation of a proof that a PID or attestation has not been revoked, and (iv) generation of a proof that a PID or device-bound attestation is bound to a key stored in the WSCA/WSCD or in a keystore of the Wallet Unit. Additionally, a ZKP scheme SHOULD provide support for the following function, which SHOULD be used only when hiding the PID Provider or Attestation Provider is necessary: (v) generation of a proof that a PID or attestation has been issued by a trusted PID Provider or Attestation Provider, without revealing the PID Provider or Attestation Provider.| See section 4.1.1 of the Discussion Paper for Topic G. |
-|EW-DM-51-002 | ZKP_02 | A ZKP scheme SHALL support proving possession of attestation of a given type.| See section 4.1.2 and 4.1.3 of the Discussion Paper for Topic G. |
-|EW-DM-51-003 | ZKP_03 | A ZKP scheme SHOULD support the privacy-preserving binding of an attestation to a PID. In addition to the generic functions defined in ZKP_01, for this use case, a ZKP scheme SHALL provide support for the following functions: (i) generation of a proof that the Wallet Unit stores an attestation and a PID and that the attestation includes a specific attribute, having a specific value, which is also present in the PID.| See section 4.1.4 of the Discussion Paper for Topic G. |
-|EW-DM-51-004 | ZKP_05 | A ZKP scheme SHALL be usable in both remote and proximity presentation flows. While the inclusion of ZKP will introduce computational and verification delays, these delays SHALL NOT critically undermine or defeat the purpose of the Relying Party service (e.g. because of a critical impact on the User experience of the Wallet Unit).|  |
-|EW-DM-51-005 | ZKP_06 | A ZKP scheme SHOULD be able to generate proofs for already issued PIDs and attestations in the formats specified in [ISO/IEC 18013-5] or [SD-JWT VC].|  |
-|EW-DM-51-006 | ZKP_07 | A ZKP scheme SHALL NOT introduce any additional communication or information that could be used to track or link User activity during, before, or after proof generation.|  |
-|EW-DM-51-007 | ZKP_08 | A ZKP scheme SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].|  |
-|EW-DM-51-008 | ZKP_09 | Use of a ZKP scheme SHALL NOT prevent the Wallet Unit's ability to provide User authentication with Level of Assurance High.|  |
+<div class="eudi-hlr" id="EW-DM-03-01" markdown>
+<div class="eudi-hlr__id">EW-DM-03-01<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_01
+{: .eudi-hlr__meta }
+
+PIDs and PID Providers SHALL comply with all requirements in [PID Rulebook].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-02" markdown>
+<div class="eudi-hlr__id">EW-DM-03-02<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_02
+{: .eudi-hlr__meta }
+
+A PID Provider SHALL issue any PID in both the format specified in ISO/IEC 18013-5 [ISO/IEC 18013-5] and the format specified in [SD-JWT VC].
+
+*Note: [CIR 2024/2977] mentions the W3C Verifiable Credentials Data Model v1.1 instead of [SD-JWT VC]. The latest stable version of this standard is [W3C VCDM 2.0]. However, W3C VCDM is not a complete specification of an attestation format. In particular, it does not specify a specific proof method to be used. Without additional specification, such as those in [W3C VC-JOSE-COSE] or [W3C VC Data Integrity], and making further choices, it is impossible to implement a PID based on W3C VCDM. This Rulebook considers [SD-JWT VC] to essentially be such an additional specification. See also [Section 5.4.4](../../architecture-and-reference-framework-main.md#544-w3c-verifiable-credentials) of the ARF main document.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-03" markdown>
+<div class="eudi-hlr__id">EW-DM-03-03<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_03
+{: .eudi-hlr__meta }
+
+The portrait in a PID SHALL consist of a single portrait image in JPEG format. The portrait image SHALL comply with the quality requirements for a Full Frontal Image Type in ISO/IEC 19794-5 clauses 8.2, 8.3, and 8.4. However, the attribute portrait SHALL NOT comply with the format requirements in ISO/IEC 19794-5 clauses 8.1 and 8.5, meaning it SHALL NOT contain any of the headers or blocks specified in clause 5 except for the image data itself (a JPEG).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-04" markdown>
+<div class="eudi-hlr__id">EW-DM-03-04<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_04
+{: .eudi-hlr__meta }
+
+PID Providers SHALL use "eu.europa.ec.eudi.pid.1" as the attestation type for ISO/IEC 18013-5-compliant PIDs.
+
+*Note: a) This identifier uses the general format [Reverse Domain].[Domain Specific Extension]. Since the European Commission controls the domain ec.europa.eu, this attestation type identifier will not collide with any attestation type identifiers defined by other organisations in other Attestation Rulebooks. b) The version number 1 in this identifier is used to distinguish between the first version of the PID, defined in the [PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md), and any future version, which will then have an incremented version number.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-05" markdown>
+<div class="eudi-hlr__id">EW-DM-03-05<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_05
+{: .eudi-hlr__meta }
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL use the value "eu.europa.ec.eudi.pid.1" for the identifier of the namespace for the PID attributes specified in [Section 4.2 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md).
+
+*Note: a) The version number 1 allows for future extension(s) or change(s) of the ISO/IEC 18013-5-compliant PID attributes. b) This namespace has the same value as the attestation type specified in requirement PID_04. This is allowed according to ISO/IEC 18013-5.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-06" markdown>
+<div class="eudi-hlr__id">EW-DM-03-06<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_06
+{: .eudi-hlr__meta }
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider MAY include attributes that are not defined in the [PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md). If so, these attributes SHALL be defined within a domestic PID namespace as meant in requirement ARB_10 in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks). The PID Provider SHALL generate the identifier for this domestic PID namespace by appending the applicable ISO 3166-1 alpha-2 country code or the ISO 3166-2 region code, separated by a period, to the PID namespace identifier specified in PID_05, excluding the version number. The PID Provider MAY include a version number in the domestic PID namespace identifier.
+
+*Note: For example, the identifier of the first domestic PID namespace for Germany could be "eu.europa.ec.eudi.pid.de.1".*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-07" markdown>
+<div class="eudi-hlr__id">EW-DM-03-07<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_07
+{: .eudi-hlr__meta }
+
+A PID Provider that defines a domestic namespace SHALL publish the namespace, including all attribute identifiers, their definition, presence and encoding format, in an Attestation Rulebook complying with all applicable requirements in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-08" markdown>
+<div class="eudi-hlr__id">EW-DM-03-08<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_08
+{: .eudi-hlr__meta }
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL include both the attributes and the metadata specified in [CIR 2024/2977] in the PID as issuer-signed data elements.
+
+*Note: This implies that technically speaking, there is no difference between these attributes and metadata.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-09" markdown>
+<div class="eudi-hlr__id">EW-DM-03-09<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_09
+{: .eudi-hlr__meta }
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL encode each attribute or metadata in the PID as specified in the third column of the tables in [Section 4.2.1 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-10" markdown>
+<div class="eudi-hlr__id">EW-DM-03-10<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_10
+{: .eudi-hlr__meta }
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL encode each attribute or metadata in the PID in Concise Binary Object Representation (CBOR) according to [RFC 8949].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-11" markdown>
+<div class="eudi-hlr__id">EW-DM-03-11<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_11
+{: .eudi-hlr__meta }
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL ensure that each PID contains at most one attribute with the same attribute identifier.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-12" markdown>
+<div class="eudi-hlr__id">EW-DM-03-12<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_12
+{: .eudi-hlr__meta }
+
+When issuing a PID compliant with [ISO/IEC 18013-5], a PID Provider SHALL ensure that the value of all attributes and metadata in the PID is valid at the value of the timestamp in the validFrom element in the MSO, see [ISO/IEC 18013-5] clause 9.1.2.4.
+
+*Note: The value of the age_over_18, age_over_NN, or age_in_years attributes, if present, changes whenever the User to whom the person identification data relates has a relevant birthday. The value of many other attributes will also change over time.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-13" markdown>
+<div class="eudi-hlr__id">EW-DM-03-13<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_13
+{: .eudi-hlr__meta }
+
+If a PID Provider issues PIDs compliant with [ISO/IEC 18013-5] and containing the `issuance_date` or `expiry_date` attributes, the PID Provider SHALL have a policy for determining the value of these attributes relative to the `validFrom` and `validUntil` elements in the MSO, see [ISO/IEC 18013-5] clause 9.1.2.4.
+
+*Note: See the notes to the `issuance_date` and `expiry_date` attributes in [PID Rulebook]. Examples of aspects to be considered in the policy may include (but are not limited to) the following:  1)  If an `issuance_date` or `expiry_date` is encoded as a `full-date` (rather than a `tdate`), it has no time element. However, `validFrom` and `validUntil` contain a time element, which is expressed in UTC. Therefore, comparing `expiry_date` to `validUntil`, for instance, may give ambiguous results in case the local time is not equal to UTC. The policy should ensure that situations are avoided where the User can legitimately expect (based on the values of `issuance_date` and `expiry_date` shown by the Wallet Unit when displaying the PID) that they can use their PID, while in reality its technical validity period (as determined by `validFrom` and `validUntil`) has not yet begun or has ended. 2) The exact meaning of `issuance_date` and `expiry_date` depends on local law and regulations. For example, in some jurisdictions an identity document whose `expiry_date` is in the past may by law still be used for identification for some purposes. However, this requires that the PID is still valid according to the `validFrom` and `validUntil` timestamps in the MSO. 3) A local requirement may exist stating that `issuance_date` and `expiry_date` must be identical to the dates on an existing physical document of the User.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-14" markdown>
+<div class="eudi-hlr__id">EW-DM-03-14<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_14
+{: .eudi-hlr__meta }
+
+A PID Provider issuing [SD-JWT VC]-compliant PIDs SHALL include the vct claim in their PIDs, where the vct claim SHALL be a URN within the `urn:eudi:pid:` namespace. The type indicated by the vct claim SHALL be `urn:eudi:pid:1` for the type defined in this document or a domestic type that extends it.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-15" markdown>
+<div class="eudi-hlr__id">EW-DM-03-15</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_15
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-16" markdown>
+<div class="eudi-hlr__id">EW-DM-03-16<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_16
+{: .eudi-hlr__meta }
+
+A PID Provider that defines a domestic type SHALL publish information about the type, including all claim identifiers, their definition, presence and encoding format, in an Attestation Rulebook complying with all applicable requirements in [Topic 12](./annex-2.02-high-level-requirements-by-topic.md#a239-topic-12-attestation-rulebooks).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-17" markdown>
+<div class="eudi-hlr__id">EW-DM-03-17<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_17
+{: .eudi-hlr__meta }
+
+When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL include both the attributes and the metadata specified in [CIR 2024/2977] in the PID as claims.
+
+*Note: This implies that technically speaking, there is no difference between these attributes and metadata.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-18" markdown>
+<div class="eudi-hlr__id">EW-DM-03-18<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_18
+{: .eudi-hlr__meta }
+
+When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL encode each attribute or metadata in the PID as specified in the tables in [Section 5.2 of the PID Rulebook](../annex-3/annex-3.01-pid-rulebook.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-19" markdown>
+<div class="eudi-hlr__id">EW-DM-03-19<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_19
+{: .eudi-hlr__meta }
+
+When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL ensure that the value of all attributes and metadata in the PID is valid at the value of the timestamp in the nbf claim, if present.
+
+*Note: The value of the age-related claims, if present, changes whenever the User to whom the person identification data relates has a relevant birthday. The value of many other attributes will also change over time.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-20" markdown>
+<div class="eudi-hlr__id">EW-DM-03-20<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_20
+{: .eudi-hlr__meta }
+
+If a PID Provider issues PIDs compliant with [SD-JWT VC] and containing the `date_of_issuance` or `date_of_expiry` claims, the PID Provider SHALL have a policy for determining the value of these claims relative to the `nbf` and `exp` claims in the SD-JWT VC, see [SD-JWT VC] section 3.2.2.2.
+
+*Note: See the notes to the `date_of_issuance` and `date_of_expiry` attributes in [PID Rulebook]. Examples of aspects to be considered in the policy may include (but are not limited to) the following: 1) `date_of_issuance` and `date_of_expiry` claims do not have a time element. However, `nbf` and `exp` express a time relative to UTC. Therefore, comparing `date_of_expiry` to `exp`, for instance, may give ambiguous results in case the local time is not equal to UTC. The policy should ensure that situations are avoided where the User can legitimately expect (based on the value of `date_of_issuance` and `date_of_expiry` shown by the Wallet Unit when displaying the PID) that they can use their PID, while in reality its technical validity period (as determined by `nbf` and `exp`) has not yet begun or has ended. 2) The exact meaning of `date_of_issuance` and `date_of_expiry` depends on local law and regulations. For example, in some jurisdictions an identity document whose `date_of_expiry` is in the past may by law still be used for identification for some purposes. However, this requires that the PID is still valid according to the `nbf` and `exp` timestamps in the SD_JWT VC. 3) A local requirement may exist stating that `date_of_issuance` and `date_of_expiry` must be identical to the dates on an existing physical document of the User.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-03-21" markdown>
+<div class="eudi-hlr__id">EW-DM-03-21<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: PID_21
+{: .eudi-hlr__meta }
+
+When issuing a PID compliant with [SD-JWT VC], a PID Provider SHALL make all claims (i.e., all top-level properties, all nested properties, and all array entries) selectively disclosable individually, except those claims defined as non-selectively disclosable in [SD-JWT VC].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-04-001" markdown>
+<div class="eudi-hlr__id">EW-DM-04-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: mDL_01
+{: .eudi-hlr__meta }
+
+mDLs and mDL Providers SHALL comply with all requirements in [mDL Rulebook].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-001" markdown>
+<div class="eudi-hlr__id">EW-DM-12-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_01a
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHALL specify that one or more of the following three common format(s) must be used for these attestations: - The format specified in ISO/IEC 18013-5, see [ISO18013-5]. - The format specified in SD-JWT-based Verifiable Credentials (SD-JWT VC), see [SD-JWT-VC]. - The format specified in W3C Verifiable Credentials Data Model, see [W3C VCDM v2.0].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-002" markdown>
+<div class="eudi-hlr__id">EW-DM-12-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_01b
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing attestations using the format specified in [SD-JWT VC] SHALL ensure that these attestations comply with the 'IETF SD-JWT VC Profile' specified in [HAIP] Section 6.1.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-003" markdown>
+<div class="eudi-hlr__id">EW-DM-12-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_02
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook SHALL analyse whether it must be possible for a User to present that type of attestation when the Wallet Unit and the Relying Party are in proximity and attestations are presented without using the internet. If so, the Attestation Rulebook SHALL specify that the attestations must be issued in the ISO/IEC 18013-5-compliant mdoc format.
+
+*Note: In theory, it is possible to use SD-JWT VC-compliant attestations in proximity use cases. In practice, however, the only protocol available to request and present SD-JWT VC-compliant attestations between a Wallet Unit and a Relying Party Instance is OpenID4VP. That protocol cannot be used without internet connectivity.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-004" markdown>
+<div class="eudi-hlr__id">EW-DM-12-004<span class="kw-may">MAY</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_03
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook MAY specify in the Attestation Rulebook that that type of attestation must be issued in the [SD-JWT VC]-compliant format, provided the [SD-JWT VC] specification has been approved by an EU standardisation body or by the European Digital Identity Cooperation Group established pursuant to [Article 46e](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e4536-1-1)(1) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-005" markdown>
+<div class="eudi-hlr__id">EW-DM-12-005<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_04
+{: .eudi-hlr__meta }
+
+If an Attestation Rulebook specifies that a type of attestation can be issued in a format compliant with [W3C VCDM v2.0], the Scheme Provider for that Attestation Rulebook SHALL ensure the Rulebook references one or more documents specifying in detail how a Relying Party can request attributes from a such an attestation, and how a User can selectively disclose attributes from such an attestation. Moreover, these referenced documents SHALL be approved by an EU standardisation body or by the European Digital Identity Cooperation Group established pursuant to [Article 46e](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e4536-1-1)(1) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-006" markdown>
+<div class="eudi-hlr__id">EW-DM-12-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_05
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook SHALL specify a value for the attestation type, which SHALL be unique within the scope of the EUDI Wallet ecosystem.
+
+*Note: In ISO/IEC 18013-5, the attestation type is called 'document type' and is included as a ``docType`` key-value pair in both the mdoc request and the mdoc response. Also, a method for generating unique attestation type values is recommended. In OpenID4VP, the attestation type is included in the ``meta`` property of a Credential Query in a presentation request. In [SD-JWT VC], the attestation type is called 'SD-JWT VC type' and is included as a ``vct`` claim in the SD-JWT VC.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-007" markdown>
+<div class="eudi-hlr__id">EW-DM-12-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_06
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook SHALL define all attributes that an attestation of that type may contain. This definition SHALL first describe the semantics of each attribute in an encoding-independent manner and SHALL subsequently for each attribute specify an ISO/IEC 18013-5-compliant format, an SD-JWT VC-compliant format, or both, as needed given the choices made according to ARB_01 - ARB_04.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-008" markdown>
+<div class="eudi-hlr__id">EW-DM-12-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_06a
+{: .eudi-hlr__meta }
+
+For ISO/IEC 18013-5-compliant attestations, the Attestation Rulebook SHALL define each attribute within an attribute namespace. An attribute namespace SHALL fully define the identifier, the syntax, and the semantics of each attribute within that namespace. An attribute namespace SHALL have an identifier that is unique within the scope of the EUDI Wallet ecosystem, and each attribute identifier SHALL be unique within that namespace.
+
+*Note: In ISO/IEC 18013-5, namespaces are discussed and a method for generating unique namespace identifiers is recommended.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-009" markdown>
+<div class="eudi-hlr__id">EW-DM-12-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_06b
+{: .eudi-hlr__meta }
+
+For [SD-JWT VC]-compliant attestations, the Scheme Provider for the Attestation Rulebook SHALL ensure that each claim name is either: - included in the IANA registry for JWT claims, - is a Public Name as defined in [RFC 7519], or is a Private Name specific to the attestation type.
+
+*Note: [SD-JWT VC] does not discuss how to avoid conflicting claim names. Since SD-JWTs are a special kind of JWTs, the methods specified in RFC 7519 are applicable.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-010" markdown>
+<div class="eudi-hlr__id">EW-DM-12-010<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_07
+{: .eudi-hlr__meta }
+
+When determining the attributes to be included in a new attestation type, the Scheme Provider for the applicable Attestation Rulebook SHOULD consider referring to attributes that are already included in the catalogue of attributes specified in [Topic 25](./annex-2.02-high-level-requirements-by-topic.md#a2315-topic-25-unified-definition-and-controlled-vocabularies-for-attributes) or specified in an attestation scheme included in the catalogue of attestation schemes specified in [Commission Implementing Regulation 2025/1569](http://data.europa.eu/eli/reg_impl/2025/1569/oj), rather than unnecessarily re-defining all attributes.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-011" markdown>
+<div class="eudi-hlr__id">EW-DM-12-011<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_08
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook SHOULD, when specifying a new attribute, take into consideration existing conventions for attribute identifier values and attribute syntaxes.
+
+*Note: These conventions may depend on the format of the attestation, i.e., CBOR for ISO/IEC 18013-5-compliant attestations or JSON for SD-JWT VC-compliant attestations.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-012" markdown>
+<div class="eudi-hlr__id">EW-DM-12-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_09
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook SHALL specify, for each attribute in the attestation, whether the presence of that attribute is mandatory, optional, or conditional.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-013" markdown>
+<div class="eudi-hlr__id">EW-DM-12-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_10
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook for an ISO/IEC 18013-5 compliant attestation MAY define a domestic namespace to specify attributes that are specific to that Rulebook and are not included in the applicable EU-wide or sectoral namespace. All requirements for namespaces in this Topic SHALL also apply for domestic namespaces.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-014" markdown>
+<div class="eudi-hlr__id">EW-DM-12-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_11
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook an attribute as meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point a) and [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point a) of the [European Digital Identity Regulation]. This attribute SHALL reference the technical specification meant in ARB_25.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-015" markdown>
+<div class="eudi-hlr__id">EW-DM-12-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_12
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include an attribute in the Rulebook indicating that the attestation is an EAA. This attribute SHALL reference the technical specification meant in ARB_25.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-016" markdown>
+<div class="eudi-hlr__id">EW-DM-12-016<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_13
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point b) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-017" markdown>
+<div class="eudi-hlr__id">EW-DM-12-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_14
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an attestation Rulebook describing a type of attestation that is a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point b) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-018" markdown>
+<div class="eudi-hlr__id">EW-DM-12-018<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_15
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point b) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-019" markdown>
+<div class="eudi-hlr__id">EW-DM-12-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_16
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point c) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e46-55-1) point c) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-020" markdown>
+<div class="eudi-hlr__id">EW-DM-12-020<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_17
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point c) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-021" markdown>
+<div class="eudi-hlr__id">EW-DM-12-021<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_18
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point e) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point e) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-022" markdown>
+<div class="eudi-hlr__id">EW-DM-12-022<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_19
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes representing the set of data meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point e) of the [European Digital Identity Regulation].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-023" markdown>
+<div class="eudi-hlr__id">EW-DM-12-023<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_20
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL include in the Rulebook one or more attributes or metadata representing the location meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point h) or [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point h) of the [European Digital Identity Regulation]. This location SHALL indicate at least the URL at which a machine-readable version of the trust anchor to be used for verifying the QEAA or PuB-EAA can be found or looked up.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-024" markdown>
+<div class="eudi-hlr__id">EW-DM-12-024<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_21
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD include in the Rulebook one or more attributes or metadata representing the location at which a machine-readable version of the trust anchor to be used for verifying the EAA can be found or looked up.
+
+*Note: What this location indicates precisely is dependent on the nature of the mechanism used for distributing trust anchors - see requirement ARB_26.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-025" markdown>
+<div class="eudi-hlr__id">EW-DM-12-025<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_22
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook SHALL specify all technical details necessary to ensure interoperability, security, and privacy of that attestation.
+
+*Note: An Attestation Rulebook may also specify requirements regarding how the Wallet Unit must display the attestation and the attributes in it to the User.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-026" markdown>
+<div class="eudi-hlr__id">EW-DM-12-026<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_23
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA or a PuB-EAA SHALL specify which of the revocation mechanisms specified in [Topic 7](./annex-2.02-high-level-requirements-by-topic.md#a235-topic-7-attestation-revocation-and-revocation-checking) SHALL be supported by that attestation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-027" markdown>
+<div class="eudi-hlr__id">EW-DM-12-027<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_24
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHALL specify whether that type of EAA must be revocable. If an EAA type must be revocable, the relevant Rulebook SHALL determine which of the revocation mechanisms specified in [Topic 7](./annex-2.02-high-level-requirements-by-topic.md#a235-topic-7-attestation-revocation-and-revocation-checking) SHALL be supported by that attestation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-028" markdown>
+<div class="eudi-hlr__id">EW-DM-12-028<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_25
+{: .eudi-hlr__meta }
+
+An Attribute Schema Provider SHALL include in its Attestation Rulebook the attribute ``attestation_legal_category``, specified in the [Attestation Rulebook Template](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/template/attestation-rulebook-template.md), with the appropriate value as specified in the Template.
+
+*Note: This attribute contains the indication meant in [Annex V](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-54-1) point a) and [Annex VII](https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:32024R1183#d1e40-56-1) point a).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-029" markdown>
+<div class="eudi-hlr__id">EW-DM-12-029<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_26
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a non-qualified EAA SHOULD define in the Rulebook the mechanism(s) allowing a Relying Party to obtain, in a trustworthy manner, the trust anchor(s) of the EAA Providers issuing this type of EAA.
+
+*Note: [Technical Specification 11](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts11-interfaces-and-formats-for-catalogue-of-attributes-and-catalogue-of-schemes.md), section 4.3.1, recommends the use of the List of trusted entities (LoTE) data model as defined in [ETSI TS 119 602](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/issues/278) for non-qualified EAAs.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-030" markdown>
+<div class="eudi-hlr__id">EW-DM-12-030</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_27
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-031" markdown>
+<div class="eudi-hlr__id">EW-DM-12-031<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_28
+{: .eudi-hlr__meta }
+
+An Attribute Scheme Provider MAY specify an attribute in an Attestation Rulebook that indicates whether the Attestation Provider during attestation issuance requested a cryptographic binding (as specified in [Topic 18](./annex-2.02-high-level-requirements-by-topic.md#a2311-topic-18-combined-presentations-of-attributes)) between the new attestation and an existing PID or attestation. If present in a Rulebook, the identifier for this attribute SHALL be ``cryptographically_bound_to``, and its contents SHALL be an attestation type or vct (see ARB_05).
+
+*Note: The meaning of this attribute, if present, is that this attestation is cryptographically bound to one or more attestations of the given attestation type or vct on this Wallet Unit. If a Relying Party receives this attribute from a Wallet Unit, it can subsequently request the Wallet Unit to send a proof of cryptographic binding between the attestation and an attestation indicated in the ``cryptographically_bound_to`` attribute.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-032" markdown>
+<div class="eudi-hlr__id">EW-DM-12-032<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_29
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook describing a type of attestation that is a QEAA, PuB-EAA, or non-qualified EAA SHOULD ensure that the structure and contents of the Attestation Rulebook follow the descriptions in the [Attestation Rulebook template](https://github.com/eu-digital-identity-wallet/eudi-doc-attestation-rulebooks-catalog/blob/main/template/attestation-rulebook-template.md).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-033" markdown>
+<div class="eudi-hlr__id">EW-DM-12-033<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_30
+{: .eudi-hlr__meta }
+
+If an Attestation Rulebook specifies a [SD-JWT VC]-compliant attestation, the Scheme Provider for that Attestation Rulebook SHALL specify for all claims (i.e., all top-level properties, all nested properties, and all array entries) whether an Attestation Provider MUST, MAY, or MUST NOT make that claim selectively disclosable.
+
+*Note: a) This requirement does not apply to claims defined as non-selectively disclosable in [SD-JWT VC]. b) There will be use cases where a specific claim must not be disclosed without simultaneously disclosing one or more other claims. Such cases should be solved by making all of these claims members of the same JSON object (or elements of the same JSON array). That JSON object (or array) is then the claim that must be selectively disclosable, while the nested properties (or individual array elements) must not be selectively disclosable. c) This requirement does not apply to [ISO/IEC 18013-5]-compliant attestations, since in such attestations, by definition all data elements are selectively disclosable, while none of the key-value pairs or array elements inside a data element (if any) are selectively disclosable.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-034" markdown>
+<div class="eudi-hlr__id">EW-DM-12-034<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_31
+{: .eudi-hlr__meta }
+
+If an Attestation Rulebook specifies a [SD-JWT VC]-compliant attestation, the Scheme Provider for that Attestation Rulebook SHOULD consider defining a Type Metadata Document for it, as defined in Chapter 6 of [SD-JWT VC]. If the Scheme Provider defines such a document, it SHOULD contain the Claim Selective Disclosure Metadata (defined in Section 9.3 of [SD-JWT VC]) for each of the claims, in order to specify if that claim is selectively disclosable (see requirement ARB_30).
+
+*Note: Although a Type Metadata Document is a highly technical document, defining it has a number of advantages for developers, Attestation Providers, Relying Parties, and Wallet Units, as spelled out in Chapter 6 of [SD-JWT VC].*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-035" markdown>
+<div class="eudi-hlr__id">EW-DM-12-035</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_32
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-036" markdown>
+<div class="eudi-hlr__id">EW-DM-12-036<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_33
+{: .eudi-hlr__meta }
+
+If a Scheme Provider for an Attestation Rulebook registers an attestation scheme in the catalogue of attestation schemes meant in [Commission Implementing Regulation 2025/1569](http://data.europa.eu/eli/reg_impl/2025/1569/oj), Article 8, the registration SHALL include a reference to the corresponding Attestation Rulebook.
+
+*Note: By definition, an attestation scheme is machine-readable, whereas an Attestation Rulebook is human-readable.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-12-037" markdown>
+<div class="eudi-hlr__id">EW-DM-12-037<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ARB_34
+{: .eudi-hlr__meta }
+
+The Scheme Provider for an Attestation Rulebook SHALL specify whether that attestation is device-bound or not.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-28-001" markdown>
+<div class="eudi-hlr__id">EW-DM-28-001</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: LP_03
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-31-001" markdown>
+<div class="eudi-hlr__id">EW-DM-31-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPACANot_06
+{: .eudi-hlr__meta }
+
+If an Access Certificate Authority is suspended or cancelled (see requirement GenNot_05 above), that Access Certificate Authority SHALL immediately revoke all of its temporally valid access certificates.
+
+*Note: This implies that if an intermediary obtained its access certificates from an Access Certificate Authority that is suspended or cancelled, any intermediated Relying Party depending on that intermediary will not be able to request attributes from Wallet Units, even though its registration is still valid. Such an intermediated Relying Party will either have to transit to another intermediary (which has access certificates issued by an active Access Certification Authority) or wait until the original intermediary obtains new access certificates either from another Access CA or from the original one, once that CA can continue its operations.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-31-002" markdown>
+<div class="eudi-hlr__id">EW-DM-31-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: TLPub_03
+{: .eudi-hlr__meta }
+
+The publication of the information referred to in TLPub_01 SHALL take place over a secure channel protecting the authenticity and integrity of the published information.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-31-003" markdown>
+<div class="eudi-hlr__id">EW-DM-31-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: TLPub_04
+{: .eudi-hlr__meta }
+
+The technical system mentioned in TLPub_01 SHALL NOT require authentication or prior registration and authorisation of any entity wishing to retrieve the published information.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-31-004" markdown>
+<div class="eudi-hlr__id">EW-DM-31-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: TLPub_05
+{: .eudi-hlr__meta }
+
+The information referred to in TLPub_01 SHALL be published in an electronically signed or sealed form that is suitable for automated processing, and in a human-readable format, e.g., through introspection and display facilities, over an authenticated channel.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-001" markdown>
+<div class="eudi-hlr__id">EW-DM-38-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_03
+{: .eudi-hlr__meta }
+
+A Wallet Provider SHALL have a policy governing all aspects of WIA and KA issuance and management. The policy SHALL distinguish between WIAs, KAs for WSCA/WSCDs, and KAs for keystores. For KAs describing a WSCA/WSCD, the policy SHALL comply with at least the extended normalised certificate policy ('NCP+') requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of KAs rather than public key certificates. For KAs describing a keystore, the policy SHALL comply with at least the normalised certificate policy ('NCP') requirements as specified in [ETSI EN 319 411-1], insofar applicable for the issuance of KAs rather than public key certificates.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-002" markdown>
+<div class="eudi-hlr__id">EW-DM-38-002</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_04
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-003" markdown>
+<div class="eudi-hlr__id">EW-DM-38-003</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_05
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-004" markdown>
+<div class="eudi-hlr__id">EW-DM-38-004</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_06
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-018" markdown>
+<div class="eudi-hlr__id">EW-DM-38-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_07a
+{: .eudi-hlr__meta }
+
+To revoke a WSCD or keystore of a Wallet Unit, the Wallet Provider SHALL, in the status list(s) for WSCDs and keystores, set the `revoked` status at all index positions mentioned in the KAs describing that WSCD or keystore.
+
+*Note: For this requirement, it does not matter whether each index in the status list(s) for WSCDs and keystores refers to a type of WSCD or keystore or to an individual WSCD or keystore.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-006" markdown>
+<div class="eudi-hlr__id">EW-DM-38-006</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_08
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-016" markdown>
+<div class="eudi-hlr__id">EW-DM-38-016</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_15
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-018" markdown>
+<div class="eudi-hlr__id">EW-DM-38-018</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_17
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-019" markdown>
+<div class="eudi-hlr__id">EW-DM-38-019</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_19a
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-020" markdown>
+<div class="eudi-hlr__id">EW-DM-38-020</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_19b
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-021" markdown>
+<div class="eudi-hlr__id">EW-DM-38-021</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_20
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-38-022" markdown>
+<div class="eudi-hlr__id">EW-DM-38-022</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: WURevocation_21
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-43-001" markdown>
+<div class="eudi-hlr__id">EW-DM-43-001</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: EDP_04
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-001" markdown>
+<div class="eudi-hlr__id">EW-DM-44-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_01
+{: .eudi-hlr__meta }
+
+Providers of registration certificates SHALL comply with all relevant requirements in [ETSI TS 119 475].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-002" markdown>
+<div class="eudi-hlr__id">EW-DM-44-002</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_02
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-003" markdown>
+<div class="eudi-hlr__id">EW-DM-44-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_03
+{: .eudi-hlr__meta }
+
+The contents of a registration certificate SHALL include at least the information required in Annex V of the [CIR 2025/848](https://data.europa.eu/eli/reg_impl/2025/848/oj) regarding registration of wallet-relying parties.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-004" markdown>
+<div class="eudi-hlr__id">EW-DM-44-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_04
+{: .eudi-hlr__meta }
+
+If the subject of the registration certificate uses the services of an intermediary (see [Topic 52](./annex-2.02-high-level-requirements-by-topic.md#a2330-topic-52-relying-party-intermediaries)), the 'association to the intermediary' mentioned in Annex I (15) of [CIR 2025/848] SHALL consist of the user-friendly name and unique identifier of this intermediary, as meant in requirements Reg_31 and Reg_32.
+
+*Note: This name and identifier are identical to those in the access certificate of the intermediary.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-005" markdown>
+<div class="eudi-hlr__id">EW-DM-44-005</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_04a
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-006" markdown>
+<div class="eudi-hlr__id">EW-DM-44-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_05
+{: .eudi-hlr__meta }
+
+If the subject of the registration certificate is not a Relying Party (i.e. in the terms of CIR 2025/848, a Service Provider), the certificate SHALL NOT contain the intended use as meant in Annex I (9) and (10) of CIR 2025/848.
+
+*Note: A PID Provider or Attestation Provider may request attributes from the Wallet Unit during issuance. If so, it registers as both a Service Provider and an Attestation Provider, and consequently its registration certificate contains its intended use.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-007" markdown>
+<div class="eudi-hlr__id">EW-DM-44-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_06
+{: .eudi-hlr__meta }
+
+The contents of a registration certificate SHALL include a name for the subject of the certificate, in a format suitable for presenting to a User.
+
+*Note: a) A Wallet Unit needs the name of a Relying Party at least when requesting User approval according to [[Topic 6](./annex-2.02-high-level-requirements-by-topic.md#a234-topic-6-relying-party-authentication-and-user-approval)] b) This name is identical to the name in the access certificate(s) of the entity, see Reg_31.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-008" markdown>
+<div class="eudi-hlr__id">EW-DM-44-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_07
+{: .eudi-hlr__meta }
+
+The contents of a registration certificate SHALL include an EU-wide unique identifier for the subject of the certificate.
+
+*Note: a) A Wallet Unit needs an identifier for a Relying Party at least to allow the User to send a report of suspicious Relying Party presentation requests to a data protection authority according to [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data). b) The EU-wide unique identifier could, for example, be a concatenated list of one or more registered official Relying Party identifiers listed in Annex I(3) of the [CIR 2025/848](https://data.europa.eu/eli/reg_impl/2025/848/oj) regarding registration of Wallet Relying Parties, expressed in the semantic form defined in [ETSI EN 319 412-1] sections 5.1.4 or 5.1.5. c) This identifier is identical to the identifier in the access certificate(s) of the entity, see Reg_32.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-009" markdown>
+<div class="eudi-hlr__id">EW-DM-44-009<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_08
+{: .eudi-hlr__meta }
+
+The EU-wide unique identifier meant in RPRC_07 SHALL be identical in all registration certificates issued for a given entity.
+
+*Note: In case the registration certificates issued to an intermediated Relying Party are held and presented by an intermediary, the entity meant in this requirement is the intermediated Relying Party. An intermediary may obtain and hold registration certificates with a different unique identifier for other intermediated Relying Parties.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-010" markdown>
+<div class="eudi-hlr__id">EW-DM-44-010<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_09
+{: .eudi-hlr__meta }
+
+A Member State Registrar MAY decide that, during the registration process for Relying Parties, as specified in [Topic 27](./annex-2.02-high-level-requirements-by-topic.md#a2316-topic-27-registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties), a Provider of registration certificates associated to the Registrar must create and sign or seal one or more registration certificates. If the Registrar decides to do so, the Provider of registration certificates SHALL create and sign or seal a separate registration certificate for each intended use registered by each Relying Party, and issue it to the Relying Party. Each registration certificate SHALL comply with the requirements in the technical specification mentioned in RPRC_02.
+
+*Note: See also [Topic 52](./annex-2.02-high-level-requirements-by-topic.md#a2330-topic-52-relying-party-intermediaries).*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-011" markdown>
+<div class="eudi-hlr__id">EW-DM-44-011<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_10
+{: .eudi-hlr__meta }
+
+If, during registration, a Relying Party received one or more registration certificates, it SHALL distribute these to all its Relying Party Instances.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-012" markdown>
+<div class="eudi-hlr__id">EW-DM-44-012<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_11
+{: .eudi-hlr__meta }
+
+The contents of a registration certificate issued to a Relying Party SHALL at least one of the following: a) the URL of a web form provided by the Relying Party, which Users can use to send data deletion requests, b) an e-mail address of the Relying Party, on which the Relying Party is prepared to receive data deletion requests from Users, c) a telephone number of the Relying Party, on which the Relying Party is prepared to receive data deletion requests from Users.
+
+*Note: See [Topic 48](./annex-2.02-high-level-requirements-by-topic.md#a2327-topic-48-blueprint-for-requesting-data-deletion-to-relying-parties) for more information about data deletion requests.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-013" markdown>
+<div class="eudi-hlr__id">EW-DM-44-013<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_12
+{: .eudi-hlr__meta }
+
+The contents of a registration certificate issued to a Relying Party SHALL contain the name and country of the Data Protection Authority supervising the Relying Party. In addition, the registration certificate SHALL contain at least one of the following: a) the URL of a web form provided by the DPA, which Users can use to report suspicious attribute presentation requests. b) an e-mail address of the DPA, on which the DPA is prepared to receive reports about suspicious attribute presentation requests from Users, c) a telephone number of the DPA, on which the DPA is prepared to receive reports about suspicious attribute presentation requests from Users.
+
+*Note: See [Topic 50](./annex-2.02-high-level-requirements-by-topic.md#a2328-topic-50-blueprint-to-report-unlawful-or-suspicious-request-of-data) for more information about reporting suspicious attribute presentation requests.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-014" markdown>
+<div class="eudi-hlr__id">EW-DM-44-014<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_16
+{: .eudi-hlr__meta }
+
+A Wallet Unit SHALL offer the User the possibility to indicate whether the User wants the Wallet Unit to go online to the competent Registrar if that is needed to verify the information registered about the Relying Party. The Wallet Unit SHALL inform the User that this implies that the Registrar learns about the User's interaction with the Relying Party. The Wallet Unit SHALL also inform the User that not requesting this information from the Registrar means that the Wallet Unit has no way to verify the information included by the Relying Party in the presentation request.
+
+*Note: a) The Wallet Unit can offer this choice to the User either during a presentation transaction in case no registration certificate was received, or as a general User setting. b) If the User indicates they don't want this, the Wallet Unit will not verify the registered information in case there is no registration certificate, see RPRC_18a. However, if there is a registration certificate, the Wallet Unit will always verify the information in the certificate, per RPRC_17.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-015" markdown>
+<div class="eudi-hlr__id">EW-DM-44-015<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_17
+{: .eudi-hlr__meta }
+
+If the Relying Party sends a registration certificate to the Wallet Unit in a presentation request, the Wallet Unit SHALL verify the authenticity and validity of the registration certificate according to the technical specification meant in RPRC_02. If the certificate is inauthentic or expired, the Wallet Unit SHALL, when asking for User approval according to RPA_07, notify the User that it could not obtain the information registered about the entity.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-016" markdown>
+<div class="eudi-hlr__id">EW-DM-44-016<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_18
+{: .eudi-hlr__meta }
+
+If the User indicated that they want the Wallet Unit to go online to the competent Registrar if needed to verify the information registered about the Relying Party (see RPRC_16), and the Relying Party did not send a registration certificate to the Wallet Unit, the Wallet Unit SHALL connect to the URL of the online service of the Registrar to obtain this information. If the Wallet Unit cannot connect to this URL or if it cannot verify the authenticity and validity of the registered information, it SHALL, when asking for User approval according to RPA_07, notify the User that it could not obtain the information registered about the Relying Party.
+
+*Note: The URL of the Registrar is included in the extension of the presentation request, see RPRC_19a.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-017" markdown>
+<div class="eudi-hlr__id">EW-DM-44-017<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_18a
+{: .eudi-hlr__meta }
+
+If the User indicated that they do not want the Wallet Unit to go online to the competent Registrar, the Wallet Unit SHALL NOT do so, even in case the Relying Party did not send a registration certificate to the Wallet Unit in the presentation request.
+
+*Note: This requirement is not applicable in case the Wallet Unit is interacting with a PID Provider or an Attestation Provider. If a PID Provider or an Attestation Provider does not provide a registration certificate, the Wallet Unit must verify their entitlements at the competent Registrar, see ISSU_24a and ISSU_34a.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-018" markdown>
+<div class="eudi-hlr__id">EW-DM-44-018<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_19
+{: .eudi-hlr__meta }
+
+If a Relying Party Instance received one or more registration certificates (see RPRC_10), it SHALL include a single registration certificate applicable for its current intended use in each presentation request to a Wallet Unit, according to the applicable standard's extension mentioned in RPRC_20. The registration certificate SHALL be included in the request by value, not by reference. The Relying Party Instance SHALL do so both in proximity and remote presentation flows.
+
+*Note:  This ensures that no external requests are necessary to validate the Relying Party.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-019" markdown>
+<div class="eudi-hlr__id">EW-DM-44-019<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_19a
+{: .eudi-hlr__meta }
+
+A Relying Party Instance SHALL include in each presentation request the following information, according to the applicable standard's extension mentioned in RPRC_20a: a) the user-friendly name of the Relying Party, b) the unique identifier of the Relying Party, c) a User-friendly description of the intended use of the Relying Party, d) the URL of the Registrar of the Relying Party, and e) the identifier of the intended use of the Relying Party.
+
+*Note: Including items a) and b) enables the Wallet Unit to show to the User the name of the Relying Party. Including c) enables the Wallet Unit to inform the User about the intended use. Including c) and d) enables the Wallet Unit, if desired by the User, to request from the Registrar the attributes registered by the Relying Party for this intended use, as well as the corresponding privacy policy and other registered information. See [Technical Specification 5](../../technical-specifications/ts5-common-formats-and-api-for-rp-registration-information.md) for the definition of this information. Note that in case the Relying Party Instance is operated by an intermediary, items a) - e) pertain to the intermediated Relying Party, see also RPI_06.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-020" markdown>
+<div class="eudi-hlr__id">EW-DM-44-020<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_20
+{: .eudi-hlr__meta }
+
+Relying Party Instances and Wallet Units SHALL support the extension for [ISO/IEC 18013-5] or the extension for [OpenID4VP], as specified in [ETSI TS 119 472-2] and amended by a CIR in preparation, as applicable, for transferring a single Relying Party registration certificate from a Relying Party Instance to a Wallet Unit.
+
+*Note: The correct CIR will be referenced here when it is published.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-021" markdown>
+<div class="eudi-hlr__id">EW-DM-44-021<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_20a
+{: .eudi-hlr__meta }
+
+Relying Party Instances and Wallet Units SHALL support the extension for [ISO/IEC 18013-5] or the extension for [OpenID4VP], as specified in [ETSI TS 119 472-2] and amended by a CIR in preparation, as applicable, for transferring the information listed in RPRC_19a from a Relying Party Instance to a Wallet Unit.
+
+*Note: The correct CIR will be referenced here when it is published.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-44-022" markdown>
+<div class="eudi-hlr__id">EW-DM-44-022<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPRC_21
+{: .eudi-hlr__meta }
+
+If the User indicated that they want to verify the information registered about a Relying Party and the Wallet Unit retrieved this information either from the registration certificate or from the online service of the Registrar (see RPRC_16 - RPRC_18), it SHALL verify that all attributes requested in the presentation request are included in the list of attributes registered by the Registrar. If the outcome of the verification is negative, the Wallet Unit SHALL, when asking for User approval according to RPA_07, notify the User about the requested attributes that the Relying Party did not register.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-50-001" markdown>
+<div class="eudi-hlr__id">EW-DM-50-001</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPT_DPA_03
+{: .eudi-hlr__meta }
+
+Empty
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-50-002" markdown>
+<div class="eudi-hlr__id">EW-DM-50-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: RPT_DPA_05a
+{: .eudi-hlr__meta }
+
+For a report sent to a DPA, the log SHALL contain at least: a) the date and time when the report was sent, b) the name and country of the DPA, and c) the channel and contact information used for initiating sending the report, i.e., the URL, e-mail address, or phone number of the DPA.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-51-001" markdown>
+<div class="eudi-hlr__id">EW-DM-51-001<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ZKP_01
+{: .eudi-hlr__meta }
+
+A ZKP scheme SHALL provide support for the following generic functions, while hiding all attributes of PIDs or attestations: (i) generation of a proof that an (some) attribute(s) having a specific value is (are) included in a PID or attestation, (ii) generation of a proof that a PID or attestation is within its validity period, (iii) generation of a proof that a PID or attestation has not been revoked, and (iv) generation of a proof that a PID or device-bound attestation is bound to a key stored in the WSCA/WSCD or in a keystore of the Wallet Unit. Additionally, a ZKP scheme SHOULD provide support for the following function, which SHOULD be used only when hiding the PID Provider or Attestation Provider is necessary: (v) generation of a proof that a PID or attestation has been issued by a trusted PID Provider or Attestation Provider, without revealing the PID Provider or Attestation Provider.
+
+*Note: See section 4.1.1 of the Discussion Paper for Topic G.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-51-002" markdown>
+<div class="eudi-hlr__id">EW-DM-51-002<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ZKP_02
+{: .eudi-hlr__meta }
+
+A ZKP scheme SHALL support proving possession of attestation of a given type.
+
+*Note: See section 4.1.2 and 4.1.3 of the Discussion Paper for Topic G.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-51-003" markdown>
+<div class="eudi-hlr__id">EW-DM-51-003<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ZKP_03
+{: .eudi-hlr__meta }
+
+A ZKP scheme SHOULD support the privacy-preserving binding of an attestation to a PID. In addition to the generic functions defined in ZKP_01, for this use case, a ZKP scheme SHALL provide support for the following functions: (i) generation of a proof that the Wallet Unit stores an attestation and a PID and that the attestation includes a specific attribute, having a specific value, which is also present in the PID.
+
+*Note: See section 4.1.4 of the Discussion Paper for Topic G.*
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-51-004" markdown>
+<div class="eudi-hlr__id">EW-DM-51-004<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ZKP_05
+{: .eudi-hlr__meta }
+
+A ZKP scheme SHALL be usable in both remote and proximity presentation flows. While the inclusion of ZKP will introduce computational and verification delays, these delays SHALL NOT critically undermine or defeat the purpose of the Relying Party service (e.g. because of a critical impact on the User experience of the Wallet Unit).
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-51-005" markdown>
+<div class="eudi-hlr__id">EW-DM-51-005<span class="kw-should">SHOULD</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ZKP_06
+{: .eudi-hlr__meta }
+
+A ZKP scheme SHOULD be able to generate proofs for already issued PIDs and attestations in the formats specified in [ISO/IEC 18013-5] or [SD-JWT VC].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-51-006" markdown>
+<div class="eudi-hlr__id">EW-DM-51-006<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ZKP_07
+{: .eudi-hlr__meta }
+
+A ZKP scheme SHALL NOT introduce any additional communication or information that could be used to track or link User activity during, before, or after proof generation.
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-51-007" markdown>
+<div class="eudi-hlr__id">EW-DM-51-007<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ZKP_08
+{: .eudi-hlr__meta }
+
+A ZKP scheme SHALL rely solely on algorithms included in the [ECCG Agreed Cryptographic Mechanisms v2.0].
+
+</div>
+</div>
+
+
+<div class="eudi-hlr" id="EW-DM-51-008" markdown>
+<div class="eudi-hlr__id">EW-DM-51-008<span class="kw-shall">SHALL</span></div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: ZKP_09
+{: .eudi-hlr__meta }
+
+Use of a ZKP scheme SHALL NOT prevent the Wallet Unit's ability to provide User authentication with Level of Assurance High.
+
+</div>
+</div>
+
 
 ---
 

--- a/docs/media/extra.css
+++ b/docs/media/extra.css
@@ -169,3 +169,9 @@
 .md-typeset .eudi-hlr__body { padding: .7rem 0; }
 .md-typeset .eudi-hlr__body > :first-child { margin-top: 0; }
 .md-typeset .eudi-hlr__body > :last-child  { margin-bottom: 0; }
+
+/* Legacy-ID meta line above a requirement (by-category view) */
+.md-typeset .eudi-hlr__meta {
+  font-size: .68rem; color: var(--md-default-fg-color--light);
+  text-transform: uppercase; letter-spacing: .04em; margin: 0 0 .2rem;
+}

--- a/hltr/scripts/annex-2.02-high-level-requirements-by-topic.jinja2
+++ b/hltr/scripts/annex-2.02-high-level-requirements-by-topic.jinja2
@@ -36,7 +36,8 @@ a Topic number.
 Each Topic includes a short description, followed by the High-Level
 Requirements (HLRs), identified by a unique identifier. The identifier
 includes a prefix which signifies the context of the HLRs (e.g. ISSU
-for issuance), an underscore and a numerator, e.g. ISSU_10.
+for issuance), an underscore and a numerator, e.g. ISSU_10. Each requirement
+is anchorable: link directly to it with `#<identifier>`, e.g. `#ISSU_10`.
 
 ### A.2.3 High-Level Requirements
 {% for topic in requirements %}
@@ -49,13 +50,26 @@ for issuance), an underscore and a numerator, e.g. ISSU_10.
 ##### {{ subsection }} <!-- omit from toc -->
 {% endif %}
 
-| **Index** | **Requirement specification** |
-|:-------|:-----------------------------------|
-{% for req in requirements[topic][subsection]%}
-| {{ req.Index }} | {{ req.Requirement_specification }}{% if req.Notes %} *Note: {{ req.Notes }}*{% endif %} |
+{% for req in requirements[topic][subsection] %}
+{% set spec = req.Requirement_specification %}
+{% if 'SHALL' in spec %}{% set kw = 'SHALL' %}{% set kwclass = 'kw-shall' %}
+{% elif 'SHOULD' in spec %}{% set kw = 'SHOULD' %}{% set kwclass = 'kw-should' %}
+{% elif 'MAY' in spec %}{% set kw = 'MAY' %}{% set kwclass = 'kw-may' %}
+{% else %}{% set kw = '' %}{% set kwclass = '' %}{% endif %}
+<div class="eudi-hlr" id="{{ req.Index }}" markdown>
+<div class="eudi-hlr__id">{{ req.Index }}{% if kw %}<span class="{{ kwclass }}">{{ kw }}</span>{% endif %}</div>
+<div class="eudi-hlr__body" markdown>
+
+{{ spec }}
+{% if req.Notes %}
+
+*Note: {{ req.Notes }}*
+{% endif %}
+
+</div>
+</div>
+
 {% endfor %}
 {% endif %}
 {% endfor %}
 {% endfor %}
-
-

--- a/hltr/scripts/annex-2.03-high-level-requirements-by-category.jinja2
+++ b/hltr/scripts/annex-2.03-high-level-requirements-by-category.jinja2
@@ -3,6 +3,29 @@ title: "European Digital Identity Wallet"
 subtitle: "Architecture and Reference Framework"
 ...
 
+{% macro hlr_block(req) %}
+{% set spec = req.Requirement_specification %}
+{% if 'SHALL' in spec %}{% set kw = 'SHALL' %}{% set kwclass = 'kw-shall' %}
+{% elif 'SHOULD' in spec %}{% set kw = 'SHOULD' %}{% set kwclass = 'kw-should' %}
+{% elif 'MAY' in spec %}{% set kw = 'MAY' %}{% set kwclass = 'kw-may' %}
+{% else %}{% set kw = '' %}{% set kwclass = '' %}{% endif %}
+<div class="eudi-hlr" id="{{ req.Harmonized_ID }}" markdown>
+<div class="eudi-hlr__id">{{ req.Harmonized_ID }}{% if kw %}<span class="{{ kwclass }}">{{ kw }}</span>{% endif %}</div>
+<div class="eudi-hlr__body" markdown>
+
+Legacy ID: {{ req.Index }}
+{: .eudi-hlr__meta }
+
+{{ spec }}
+{% if req.Notes %}
+
+*Note: {{ req.Notes }}*
+{% endif %}
+
+</div>
+</div>
+
+{% endmacro %}
 # ANNEX 2.03 - High-Level Requirements by category<!-- omit from toc -->
 
 ## A.2 High-level requirements by category
@@ -23,7 +46,8 @@ In addition, 'must' (non-capitalised) is used to indicate an external
 constraint, i.e., a requirement that is not mandated by this document, but, for
 instance, by an external standard or specification. The word 'can' indicates a
 capability, whereas other words, such as 'will', and 'is' or 'are', are intended
-as statements of fact.
+as statements of fact. Each requirement is anchorable via its identifier, e.g.
+`#WP_01`.
 
 ---
 
@@ -35,13 +59,9 @@ as statements of fact.
 *the EUDI Wallet solutions. They cover the core functionalities, security, user*
 *interface elements, and lifecycle management of the wallet.*
 
-
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
 {% for req in requirements['Wallet Providers'] %}
-|{{ req.Harmonized_ID }} | {{ req.Index }} | {{ req.Requirement_specification }}| {{ req.Notes }} |
+{{ hlr_block(req) }}
 {% endfor %}
-
 ---
 
 ### 2. Member States & Registrars
@@ -50,12 +70,9 @@ as statements of fact.
 *infrastructure. They focus on establishing registries, notifying the*
 *Commission, and defining national policies.*
 
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
 {% for req in requirements['Member States & Registrars'] %}
-|{{ req.Harmonized_ID }} | {{ req.Index }} | {{ req.Requirement_specification }}| {{ req.Notes }} |
+{{ hlr_block(req) }}
 {% endfor %}
-
 ---
 
 ### 3. Attestation & PID Providers
@@ -64,12 +81,9 @@ as statements of fact.
 *the wallet. This includes requirements for identity verification, issuance*
 *protocols, data formats, and revocation policies.*
 
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
 {% for req in requirements['Attestation & PID Providers'] %}
-|{{ req.Harmonized_ID }} | {{ req.Index }} | {{ req.Requirement_specification }}| {{ req.Notes }} |
+{{ hlr_block(req) }}
 {% endfor %}
-
 ---
 
 ### 4. Relying Parties
@@ -78,12 +92,9 @@ as statements of fact.
 *EUDI Wallet. They cover how they must register, authenticate themselves to the*
 *wallet, request user attributes, and handle user data.*
 
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
 {% for req in requirements['Relying Parties'] %}
-|{{ req.Harmonized_ID }} | {{ req.Index }} | {{ req.Requirement_specification }}| {{ req.Notes }} |
+{{ hlr_block(req) }}
 {% endfor %}
-
 ---
 
 ## Part 2: Ecosystem-Wide Rules
@@ -94,12 +105,9 @@ as statements of fact.
 *ensure the entire system works together seamlessly across borders. This covers*
 *how different components talk to each other.*
 
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
 {% for req in requirements['Protocols & Interoperability'] %}
-|{{ req.Harmonized_ID }} | {{ req.Index }} | {{ req.Requirement_specification }}| {{ req.Notes }} |
+{{ hlr_block(req) }}
 {% endfor %}
-
 ---
 
 ### 6. Data Models & Attestation Rules
@@ -109,12 +117,9 @@ as statements of fact.
 *ensuring that the information exchanged is consistent and understandable across*
 *the entire ecosystem.*
 
-| **Identifier** | **Legacy Identifier** | **Description** | **Notes** |
-|:-------|:------|:-------------------------|:-------------|
 {% for req in requirements['Data Models & Attestation Rules'] %}
-|{{ req.Harmonized_ID }} | {{ req.Index }} | {{ req.Requirement_specification }}| {{ req.Notes }} |
+{{ hlr_block(req) }}
 {% endfor %}
-
 ---
 
 ## A.2.2 Backward Reference: Original Topics


### PR DESCRIPTION
## Summary

Replace the Annex 2 high-level-requirement **tables** with the `eudi-hlr` **card component**: each requirement becomes an anchorable card with a colour-coded RFC 2119 badge. The Annex 2 pages are generated, so this changes the two Jinja2 templates and the regenerated markdown together.

> **Stacked on #734** (the EU brand theme). Base is `feat/eudi-theme-restyle` so the diff shows only the HLR changes; GitHub will retarget this PR to `main` once #734 merges.

## Changes

- **`hltr/scripts/annex-2.02-...-by-topic.jinja2`** / **`...-by-category.jinja2`** — render each HLR as a card instead of a table row:
  - Anchorable `id="<identifier>"` — the `Index` (by-topic) or `Harmonized_ID` (by-category). Link directly with `#<identifier>` (e.g. `#ISSU_10`, `#WP_01`).
  - RFC 2119 badge derived from the requirement text (there is no keyword column): **SHALL → yellow, SHOULD → white, MAY → outline**; `SHALL NOT` falls under SHALL. Requirements with no keyword render without a badge.
  - The by-category view keeps the legacy `Index` as a styled meta line above each requirement.
- **`docs/annexes/annex-2/*.md`** — regenerated from `hltr/high-level-requirements.csv` via `make hltr`. Committed together with the templates so the "markdown out of sync with CSV" CI gate stays green.
- **`docs/media/extra.css`** — add the `.eudi-hlr__meta` rule (the legacy-ID meta line) that the brand theme had not yet shipped.

## Numbers

- 684 cards in each view (same HLR set, different organisation); 684 legacy-ID meta lines in the by-category view; **0 tables remaining**.
- Badge distribution (by-topic): 562 SHALL, 20 SHOULD, 5 MAY; ~97 requirements have no RFC 2119 keyword and render badge-less.

## Verification (local)

- `make build-strict` → exit 0
- `make check-links` → 0 broken links/anchors (the `id=""` card anchors are recognised)
- `codespell` clean; markdownlint already ignores the two generated files.

Reminder: never edit the generated `.md` by hand — change `hltr/high-level-requirements.csv` or the templates and run `make hltr`.
