### PR TITLE
feat(nav): right-hand TOC (toc.follow + toc_depth 3) for long pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,6 @@ theme:
     - navigation.top
     - navigation.footer
     - navigation.tracking
-    - toc.integrate
     - toc.follow
     - search.suggest
     - search.highlight
@@ -82,6 +81,7 @@ markdown_extensions:
   - toc:
       permalink: true
       permalink_title: Link to this section
+      toc_depth: 3
   # --- ARF-specific: shared snippet of references appended to every page ---
   - pymdownx.snippets:
       auto_append:


### PR DESCRIPTION
## Summary

Fix in-page navigation on long single pages (notably the Main Document). With `toc.integrate`, the page's entire heading tree was folded into the **left** sidebar and the right-hand "Table of contents" was removed — on a huge page this made the left nav an unusable wall of headings.

Config-only change: move in-page navigation back to a right-hand TOC that follows the scroll, and cap its depth so it stays scannable. The left sidebar then shows only the document tree.

## Changes (`mkdocs.yml`)

- **`theme.features`** — remove `toc.integrate` (keep `toc.follow`).
- **`markdown_extensions.toc`** — add `toc_depth: 3` so the right-hand TOC only goes down to level 3.

```diff
   - navigation.tracking
-  - toc.integrate
   - toc.follow
```
```diff
   - toc:
       permalink: true
       permalink_title: Link to this section
+      toc_depth: 3
```

Nothing else changes. The homepage is unaffected (it already uses `hide: [navigation, toc]`).

## Verification

- `mkdocs build --strict` → exit 0.

## Notes

- The same one-line change is intended for the sibling sites (`eudi-docs-site`, `eudi-doc-functional-conformance-assessment`) for a consistent experience — tracked separately (the conformance repo has no `toc:` block yet, so it needs a small adaptation).
- Optional, separate follow-up: the Main Document is one very large `.md`; splitting it into per-chapter pages would make the left sidebar a real chapter navigator, but it affects the pandoc PDF/DOCX/EPUB build that concatenates the single file.
