### PR TITLE
feat(home): FAQ + official-site cards, move release strip into About, cite Regulation 910/2014 (consolidated)

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -3,12 +3,11 @@
 ## The EU Digital Identity Wallet
 
 The **European Digital Identity Regulation** (EUDI Regulation,
-[Regulation (EU) 2024/1183](https://eur-lex.europa.eu/eli/reg/2014/910/2024-10-18))
-gives every EU citizen, resident and business the right to a **European Digital
-Identity Wallet**: a secure app, under the user's control, to identify themselves
-and share verified attributes across the Union. It strengthens the EU's earlier
-electronic identification framework (Regulation (EU) No 910/2014), making
-cross-border recognition effective and opening it to the private sector.
+[Regulation (EU) No 910/2014](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:02014R0910-20241018),
+consolidated as amended in 2024) gives every EU citizen, resident and business the
+right to a **European Digital Identity Wallet**: a secure app, under the user's
+control, to identify themselves and share verified attributes across the Union. It
+makes cross-border recognition effective and opens it to the private sector.
 
 A Wallet can be provided directly by a Member State or by a private company it
 officially recognises. By design, the EU Digital Identity Wallet is:
@@ -36,9 +35,9 @@ Implementing Regulations listed below.
 
 ## Commission Implementing Regulations
 
-The ARF builds on the
-[adopted legal text](https://eur-lex.europa.eu/eli/reg/2014/910/2024-10-18) and
-the following Commission Implementing Regulations (CIRs):
+The ARF builds on
+[Regulation (EU) No 910/2014](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:02014R0910-20241018)
+and the following Commission Implementing Regulations (CIRs):
 
 | Reference | Subject |
 | --- | --- |

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,12 @@ hide:
 
 ## About the ARF
 
-The **European Digital Identity Regulation** (Regulation (EU) 2024/1183) requires
-every Member State to offer a Wallet that lets people identify, authenticate, and
-share attributes securely, fully under the user's control. The Architecture and
-Reference Framework (ARF) is the common technical baseline behind it, built on the
-adopted legal text and its Commission Implementing Regulations.
+The **European Digital Identity Regulation**
+([Regulation (EU) No 910/2014](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:02014R0910-20241018),
+consolidated) requires every Member State to offer a Wallet that lets people
+identify, authenticate, and share attributes securely, fully under the user's
+control. The Architecture and Reference Framework (ARF) is the common technical
+baseline behind it, built on that legal text and its Commission Implementing
+Regulations.
 
 [About the EUDI Wallet and the ARF →](about.md)

--- a/docs/media/extra.css
+++ b/docs/media/extra.css
@@ -102,6 +102,8 @@
   background: rgba(255, 255, 255, .12); border: 1px solid rgba(255, 255, 255, .25);
   border-radius: 999px; padding: .25rem .85rem; font-size: .72rem; font-weight: 600; margin-bottom: 1rem;
 }
+a.eudi-hero__eyebrow { color: #fff; text-decoration: none; transition: background .15s, border-color .15s; }
+a.eudi-hero__eyebrow:hover { background: rgba(255, 255, 255, .2); border-color: rgba(255, 255, 255, .55); }
 .eudi-hero h1 { color: #fff; font-weight: 800; font-size: 2.3rem; line-height: 1.12; margin: 0 0 .7rem; max-width: 20ch; }
 .eudi-hero p  { color: rgba(255, 255, 255, .85); font-size: 1rem; max-width: 60ch; margin: 0 0 1.4rem; }
 .eudi-hero .md-button { margin: .2rem .6rem .2rem 0; }

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -4,7 +4,7 @@
   {{ super() }}
   <section class="eudi-hero">
     <div class="eudi-hero__inner">
-      <span class="eudi-hero__eyebrow">★ EUDI Regulation (EU) 2024/1183</span>
+      <a class="eudi-hero__eyebrow" href="https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:02014R0910-20241018">★ Regulation (EU) No 910/2014</a>
       <h1>Architecture and Reference Framework for the EU Digital Identity Wallet</h1>
       <p>The single source of truth: main narrative, normative high-level
          requirements, technical specifications and open discussion topics.</p>
@@ -19,14 +19,6 @@
 
 {% block content %}
 <div class="md-content__inner md-typeset">
-
-  <div class="eudi-verstrip">
-    <span><span class="dot"></span>Latest release <strong>v2.9.0</strong> · 21 May 2026</span>
-    <span class="sp"></span>
-    <a href="https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/CHANGELOG.md">Changelog</a>
-    {% if config.extra.pdf_url %}<a href="{{ config.extra.pdf_url }}">Download PDF</a>{% endif %}
-    <a href="https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/releases">All releases</a>
-  </div>
 
   <h2>Explore the documentation</h2>
   <div class="grid cards eudi-home-cards">
@@ -56,17 +48,35 @@
 
   {{ page.content }}
 
+  <div class="eudi-verstrip">
+    <span><span class="dot"></span>Latest release <strong>v2.9.0</strong> · 21 May 2026</span>
+    <span class="sp"></span>
+    <a href="https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/CHANGELOG.md">Changelog</a>
+    {% if config.extra.pdf_url %}<a href="{{ config.extra.pdf_url }}">Download PDF</a>{% endif %}
+    <a href="https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/releases">All releases</a>
+  </div>
+
   <h2>Key resources</h2>
   <div class="grid cards">
     <ul>
       <li>
+        <p><strong>Official EUDI Wallet site</strong></p>
+        <p>The European Commission's EUDI Wallet space.</p>
+        <p><a href="https://ec.europa.eu/digital-building-blocks/sites/spaces/EUDIGITALIDENTITYWALLET/pages/694487738/EU+Digital+Identity+Wallet+Home">Open →</a></p>
+      </li>
+      <li>
+        <p><strong>FAQ</strong></p>
+        <p>Frequently asked questions about the EUDI Wallet.</p>
+        <p><a href="https://ec.europa.eu/digital-building-blocks/sites/spaces/EUDIGITALIDENTITYWALLET/pages/713526976/FAQ">Open →</a></p>
+      </li>
+      <li>
         <p><strong>EU Digital Identity Regulation</strong></p>
-        <p>Regulation (EU) 2024/1183.</p>
-        <p><a href="https://eur-lex.europa.eu/eli/reg/2014/910/2024-10-18">Open →</a></p>
+        <p>Regulation (EU) No 910/2014 (consolidated).</p>
+        <p><a href="https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:02014R0910-20241018">Open →</a></p>
       </li>
       <li>
         <p><strong>European Commission</strong></p>
-        <p>EUDI Wallet policy page.</p>
+        <p>EUDI Wallet policy and toolbox.</p>
         <p><a href="https://digital-strategy.ec.europa.eu/en/policies/eudi-wallet-toolbox">Open →</a></p>
       </li>
       <li>


### PR DESCRIPTION
## What

Homepage tweaks building on the deployed home redesign and About page.

- **Key resources** — added two cards: **Official EUDI Wallet site** (the Commission's EUDI Wallet space) and **FAQ**.
- **Latest release strip** — moved down into the About section (after the About text, before Key resources).
- **Regulation reference** — repointed from the amending Regulation (EU) 2024/1183 to the consolidated base **Regulation (EU) No 910/2014**, linked to the EUR-Lex CELEX consolidated text (`CELEX:02014R0910-20241018`), in the hero, on the homepage and on the About page.

## Files

| File | Change |
| --- | --- |
| `overrides/home.html` | Hero eyebrow is now a link to the consolidated text reading "Regulation (EU) No 910/2014"; release strip moved into the About section; Official-site + FAQ cards added; regulation card repointed to CELEX (now 6 cards). |
| `docs/media/extra.css` | Two `a.eudi-hero__eyebrow` rules (keep eyebrow white on the blue hero + hover state). |
| `docs/index.md` | About paragraph cites Regulation (EU) No 910/2014 (consolidated), linked to CELEX. |
| `docs/about.md` | Intro paragraph and CIR-section intro repointed to 910/2014 at the CELEX consolidated URL. |

## Verification

- `python3 tools/gen_references.py` — no diff to tracked files
- `make check-links` — 0 broken internal links / nav / anchors
- `mkdocs build --strict` — builds clean
- Rendered `index.html` confirmed: hero pill → CELEX URL; 6 key-resource cards incl. Official site + FAQ; DOM order is About heading → release strip → Key resources.

## Scope note

The repoint sweep was limited to the redesign-owned files (home/index/about/css). Reference-table citations of Regulation (EU) 2024/1183 in the main document and discussion topics were left untouched — they accurately cite the amending act by its full title ("…amending Regulation (EU) No 910/2014…"), not headline mis-citations.
