### PR TITLE
style(hero): faint full-bleed wallet logo watermark

### DIFF
--- a/docs/media/extra.css
+++ b/docs/media/extra.css
@@ -94,9 +94,15 @@
    HERO  (homepage) — "Hero A": solid blue, left aligned
    Rendered by overrides/home.html (index page only)
    ============================================================ */
-.eudi-hero { background: var(--eudi-blue); color: #fff; padding: 3.4rem 1.2rem 3.8rem; }
+.eudi-hero { position: relative; overflow: hidden; background: var(--eudi-blue); color: #fff; padding: 3.4rem 1.2rem 3.8rem; }
 [data-md-color-scheme="slate"] .eudi-hero { background: var(--eudi-blue-dark); }
-.eudi-hero__inner { max-width: 61rem; margin: 0 auto; padding: 0 .8rem; }
+/* Faint full-bleed wallet logo watermark behind the hero text */
+.eudi-hero::after {
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  background: url("logo_eudi_white.svg") no-repeat center / 120% auto;
+  opacity: .06;
+}
+.eudi-hero__inner { position: relative; z-index: 1; max-width: 61rem; margin: 0 auto; padding: 0 .8rem; }
 .eudi-hero__eyebrow {
   display: inline-flex; gap: .4rem; align-items: center;
   background: rgba(255, 255, 255, .12); border: 1px solid rgba(255, 255, 255, .25);


### PR DESCRIPTION
## What

Adds a faint, full-bleed white wallet-logo watermark behind the homepage hero text. **CSS-only — no HTML changes.**

## Change

Single file, `docs/media/extra.css`, hero block:

- `.eudi-hero` → `position: relative; overflow: hidden;` (containment + clipping for the oversized watermark)
- New `.eudi-hero::after` → `logo_eudi_white.svg`, `no-repeat center / 120% auto`, `opacity: .06`, `pointer-events: none`
- `.eudi-hero__inner` → `position: relative; z-index: 1;` so the hero text/buttons stay above the watermark

## Notes

- `logo_eudi_white.svg` resolves relative to `extra.css` (both in `docs/media/`), so the URL needs no change.
- The watermark only renders on the ARF hero (`.eudi-hero`); the shared `extra.css` is harmless on the sibling sites, which have no hero.
- Applies in both light and dark schemes (dark keeps `--eudi-blue-dark` behind the same white logo).
- Visibility is easy to tune later via `opacity` (0.05–0.10).

## Verification

- `mkdocs build --strict` — clean build
- Built `site/media/extra.css` contains the `.eudi-hero::after` rule with the logo URL + opacity; `logo_eudi_white.svg` ships to `site/media/`.
