### PR TITLE
feat(home): slim release strip back at top (no PDF link)

### DIFF
--- a/overrides/home.html
+++ b/overrides/home.html
@@ -20,6 +20,13 @@
 {% block content %}
 <div class="md-content__inner md-typeset">
 
+  <div class="eudi-verstrip">
+    <span><span class="dot"></span>Latest release <strong>v2.9.0</strong> · 21 May 2026</span>
+    <span class="sp"></span>
+    <a href="https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/CHANGELOG.md">Changelog</a>
+    <a href="https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/releases">All releases</a>
+  </div>
+
   <h2>Explore the documentation</h2>
   <div class="grid cards eudi-home-cards">
     <ul>
@@ -47,14 +54,6 @@
   </div>
 
   {{ page.content }}
-
-  <div class="eudi-verstrip">
-    <span><span class="dot"></span>Latest release <strong>v2.9.0</strong> · 21 May 2026</span>
-    <span class="sp"></span>
-    <a href="https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/CHANGELOG.md">Changelog</a>
-    {% if config.extra.pdf_url %}<a href="{{ config.extra.pdf_url }}">Download PDF</a>{% endif %}
-    <a href="https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/releases">All releases</a>
-  </div>
 
   <h2>Key resources</h2>
   <div class="grid cards">


### PR DESCRIPTION
## What

Follow-up tweak to the homepage release strip (builds on the merged #742). **Single file, `overrides/home.html`.**

- **Moves the "Latest release" strip back to the top**, directly under the hero and before "Explore the documentation" (reversing #742's move into the About section).
- **Removes the strip's "Download PDF" link** — redundant with the hero's Download PDF button. The strip now carries just Changelog + All releases.

Everything else (hero pill → EUR-Lex CELEX, 6 key-resource cards incl. Official site + FAQ, regulation card) is unchanged.

## Verification

- `python3 tools/gen_references.py` — no diff to tracked files
- `make check-links` — 0 broken internal links / nav / anchors
- `mkdocs build --strict` — clean build
- Rendered `index.html` confirmed: release strip at the top (before Explore/About/Key resources) with only Changelog + All releases; "Download PDF" appears once on the page (the hero button); 6 key-resource cards incl. Official site + FAQ.

## Note

Independent of #743 (hero logo watermark) — different files (`home.html` vs `extra.css`), no conflict if both land.
