### PR TITLE
New nav layout proposal

### DIFF
--- a/docs/media/extra.css
+++ b/docs/media/extra.css
@@ -37,22 +37,15 @@
 .md-header__button.md-logo svg { height: 2.7rem; }
 
 /* ============================================================
-   Tabs — yellow EU accent on the active/hovered tab
+   Tabs
    ============================================================ */
 .md-tabs { border-bottom: 3px solid var(--eudi-yellow); }
-.md-tabs__link {
-  border-bottom: 3px solid transparent;
-  margin-bottom: -3px;
-  padding-bottom: .4rem;
-  opacity: .85;
-  transition: border-color .15s, opacity .15s;
-}
-.md-tabs__item--active .md-tabs__link,
-.md-tabs__link:hover {
-  opacity: 1;
-  border-bottom-color: var(--eudi-yellow);
-}
-.md-tabs__item--active .md-tabs__link { font-weight: 700; }
+.md-tabs__link { opacity: .85; transition: opacity .15s; }
+.md-tabs__link:hover,
+.md-tabs__item--active .md-tabs__link { opacity: 1; }
+.md-tabs__item--active { background: var(--eudi-yellow); }
+.md-tabs__item--active .md-tabs__link { color: var(--eudi-blue) !important; font-weight: 700; }
+.md-tabs__item:not(.md-tabs__item--active):hover { background: rgba(255,255,255,.1); }
 
 /* ============================================================
    Tables — branded header, zebra rows, soft corners


### PR DESCRIPTION
Hi,

the current navigation looks a bit weird with the double line layout:
<img width="600" height="154" alt="Screenshot 2026-06-25 alle 16 47 20" src="https://github.com/user-attachments/assets/05004ae8-8b52-4285-ab41-54c425049715" />

in this PR I am proposing a new look with higher contrast  (yellow for the active page on the blue background):

<img width="586" height="118" alt="Screenshot 2026-06-25 alle 16 47 14" src="https://github.com/user-attachments/assets/5f1af8a6-c87f-4a86-a004-722ef19395f6" />

WDYT @paolo-de-rosa?
Thanks